### PR TITLE
Handle exit message generically in LSP server

### DIFF
--- a/lsp/lsp.go
+++ b/lsp/lsp.go
@@ -29,8 +29,6 @@ type LanguageServerHandlers struct {
 	Completion func(ctx context.Context, params *protocol.CompletionParams) (*protocol.CompletionList, error)
 	// Shutdown handles the shutdown request - server should shut down but not exit
 	Shutdown func(ctx context.Context) error
-	// Exit handles the exit notification - server should exit its process
-	Exit func(ctx context.Context) error
 }
 
 // stdioDialer implements jsonrpc2.Dialer for stdio communication
@@ -57,6 +55,7 @@ func (rw *stdioReadWriteCloser) Close() error {
 // languageServer implements the protocol.Server interface
 type languageServer struct {
 	handlers *LanguageServerHandlers
+	conn     *jsonrpc2.Connection
 }
 
 func (s *languageServer) Initialize(ctx context.Context, params *protocol.ParamInitialize) (*protocol.InitializeResult, error) {
@@ -123,8 +122,9 @@ func (s *languageServer) ResolveCodeLens(ctx context.Context, params *protocol.C
 func (s *languageServer) ResolveCompletionItem(ctx context.Context, params *protocol.CompletionItem) (*protocol.CompletionItem, error) { return nil, nil }
 func (s *languageServer) ResolveDocumentLink(ctx context.Context, params *protocol.DocumentLink) (*protocol.DocumentLink, error) { return nil, nil }
 func (s *languageServer) Exit(ctx context.Context) error {
-	if s.handlers != nil && s.handlers.Exit != nil {
-		return s.handlers.Exit(ctx)
+	// Close the connection to allow the server to exit
+	if s.conn != nil {
+		return s.conn.Close()
 	}
 	return nil
 }
@@ -195,10 +195,12 @@ func (s *languageServer) WorkDoneProgressCancel(ctx context.Context, params *pro
 
 // simpleBinder implements jsonrpc2.Binder
 type simpleBinder struct {
-	server protocol.Server
+	server *languageServer
 }
 
 func (b *simpleBinder) Bind(ctx context.Context, conn *jsonrpc2.Connection) (jsonrpc2.ConnectionOptions, error) {
+	// Store the connection reference in the server so it can be closed on exit
+	b.server.conn = conn
 	return jsonrpc2.ConnectionOptions{
 		Handler: protocol.ServerHandler(b.server),
 	}, nil

--- a/lsp/lsp_test.go
+++ b/lsp/lsp_test.go
@@ -60,10 +60,6 @@ func TestLanguageServerHandlers(t *testing.T) {
 			handlersCalled = append(handlersCalled, "shutdown")
 			return nil
 		},
-		Exit: func(ctx context.Context) error {
-			handlersCalled = append(handlersCalled, "exit")
-			return nil
-		},
 	}
 	
 	// Create language server instance
@@ -136,7 +132,7 @@ func TestLanguageServerHandlers(t *testing.T) {
 	}
 	
 	// Verify all handlers were called in the expected order
-	expectedCalls := []string{"initialize", "initialized", "didOpen", "didChange", "didClose", "completion", "shutdown", "exit"}
+	expectedCalls := []string{"initialize", "initialized", "didOpen", "didChange", "didClose", "completion", "shutdown"}
 	if len(handlersCalled) != len(expectedCalls) {
 		t.Errorf("Expected %d handler calls, got %d", len(expectedCalls), len(handlersCalled))
 	}


### PR DESCRIPTION
- Remove Exit handler from LanguageServerHandlers API
- Exit method now automatically closes connection for clean shutdown
- Language implementers no longer need to provide exit handling
- Updated tests to reflect API changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `Exit` from `LanguageServerHandlers` and makes `languageServer.Exit` close the JSON-RPC connection; updates binder and tests accordingly.
> 
> - **LSP Server**:
>   - Remove `Exit` from `LanguageServerHandlers` API.
>   - Add `conn` to `languageServer` and make `Exit` close `s.conn`.
>   - Change `simpleBinder` to hold `*languageServer` and set `server.conn` in `Bind`.
> - **Tests**:
>   - Drop `Exit` handler usage and expected call from `lsp/lsp_test.go`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ece3fc01dcfa4ff42db5472aef9c314a4bdb2d18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->