### PR TITLE
New ImportedSymbolsProvider service

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -60,9 +60,10 @@ func runCmd() error {
 	file, _ := textdoc.NewFile(lsp.URIFromPath(grammarPath), "fb", 0, string(grammarText))
 
 	document := core.NewDocument(file)
-	srv.Workspace().DocumentParser.Parse(document)
-	srv.Linking().LocalSymbolsProvider.Compute(context.Background(), document)
-	srv.Linking().Linker.Link(context.Background(), document)
+	srv.Workspace().DocumentManager.Set(document)
+	if err := srv.Workspace().Builder.Build(context.Background(), []*core.Document{document}); err != nil {
+		return err
+	}
 
 	grammr, ok := document.Root.(grammar.Grammar)
 	if !ok {

--- a/document.go
+++ b/document.go
@@ -26,6 +26,7 @@ type Document struct {
 	Tokens          TokenSlice
 	LocalSymbols    LocalSymbols
 	ExportedSymbols []*AstNodeDescription
+	ImportedSymbols SymbolList
 	ParserErrors    []*ParserError
 	LexerErrors     []*LexerError
 	References      []UntypedReference
@@ -68,9 +69,10 @@ type DocumentState uint32
 const (
 	DocStateParsed          DocumentState = 1 << iota // 0x0001
 	DocStateExportedSymbols                           // 0x0002
-	DocStateLocalSymbols                              // 0x0004
-	DocStateLinked                                    // 0x0008
-	DocStateValidated                                 // 0x0010
+	DocStateImportedSymbols                           // 0x0004
+	DocStateLocalSymbols                              // 0x0008
+	DocStateLinked                                    // 0x0010
+	DocStateValidated                                 // 0x0020
 )
 
 func (s DocumentState) String() string {
@@ -80,6 +82,9 @@ func (s DocumentState) String() string {
 	}
 	if s.Has(DocStateExportedSymbols) {
 		flags = append(flags, "ExportedSymbols")
+	}
+	if s.Has(DocStateImportedSymbols) {
+		flags = append(flags, "ImportedSymbols")
 	}
 	if s.Has(DocStateLocalSymbols) {
 		flags = append(flags, "LocalSymbols")

--- a/internal/generator/linker_generator.go
+++ b/internal/generator/linker_generator.go
@@ -96,8 +96,7 @@ func generateScopeProvider(context *LinkerGeneratorContext) generator.Node {
 
 	for _, field := range context.fields {
 		node.AppendLine("func (s *Default", context.grammar.Name(), "ScopeProvider) Scope", field.typeName, field.name, "(ctx context.Context, reference *core.Reference[", field.target, "]) core.Scope {")
-		node.AppendLine("	allDocuments := s.srv.Workspace().DocumentManager.All()")
-		node.AppendLine("	return linking.DefaultScopeOfType[", field.target, "](reference.Owner, allDocuments)")
+		node.AppendLine("	return linking.DefaultScopeOfType[", field.target, "](reference.Owner)")
 		node.AppendLine("}").AppendLine()
 	}
 	return node

--- a/internal/grammar/linker_gen.go
+++ b/internal/grammar/linker_gen.go
@@ -30,48 +30,39 @@ func NewDefaultFastbeltScopeProvider(srv FastbeltLinkingSrvCont) *DefaultFastbel
 }
 
 func (s *DefaultFastbeltScopeProvider) ScopeInterfaceExtends(ctx context.Context, reference *core.Reference[Interface]) core.Scope {
-	allDocuments := s.srv.Workspace().DocumentManager.All()
-	return linking.DefaultScopeOfType[Interface](reference.Owner, allDocuments)
+	return linking.DefaultScopeOfType[Interface](reference.Owner)
 }
 
 func (s *DefaultFastbeltScopeProvider) ScopeReferenceTypeType(ctx context.Context, reference *core.Reference[Interface]) core.Scope {
-	allDocuments := s.srv.Workspace().DocumentManager.All()
-	return linking.DefaultScopeOfType[Interface](reference.Owner, allDocuments)
+	return linking.DefaultScopeOfType[Interface](reference.Owner)
 }
 
 func (s *DefaultFastbeltScopeProvider) ScopeSimpleTypeType(ctx context.Context, reference *core.Reference[Interface]) core.Scope {
-	allDocuments := s.srv.Workspace().DocumentManager.All()
-	return linking.DefaultScopeOfType[Interface](reference.Owner, allDocuments)
+	return linking.DefaultScopeOfType[Interface](reference.Owner)
 }
 
 func (s *DefaultFastbeltScopeProvider) ScopeParserRuleReturnType(ctx context.Context, reference *core.Reference[Interface]) core.Scope {
-	allDocuments := s.srv.Workspace().DocumentManager.All()
-	return linking.DefaultScopeOfType[Interface](reference.Owner, allDocuments)
+	return linking.DefaultScopeOfType[Interface](reference.Owner)
 }
 
 func (s *DefaultFastbeltScopeProvider) ScopeAssignmentProperty(ctx context.Context, reference *core.Reference[Field]) core.Scope {
-	allDocuments := s.srv.Workspace().DocumentManager.All()
-	return linking.DefaultScopeOfType[Field](reference.Owner, allDocuments)
+	return linking.DefaultScopeOfType[Field](reference.Owner)
 }
 
 func (s *DefaultFastbeltScopeProvider) ScopeCrossRefType(ctx context.Context, reference *core.Reference[Interface]) core.Scope {
-	allDocuments := s.srv.Workspace().DocumentManager.All()
-	return linking.DefaultScopeOfType[Interface](reference.Owner, allDocuments)
+	return linking.DefaultScopeOfType[Interface](reference.Owner)
 }
 
 func (s *DefaultFastbeltScopeProvider) ScopeRuleCallRule(ctx context.Context, reference *core.Reference[AbstractRule]) core.Scope {
-	allDocuments := s.srv.Workspace().DocumentManager.All()
-	return linking.DefaultScopeOfType[AbstractRule](reference.Owner, allDocuments)
+	return linking.DefaultScopeOfType[AbstractRule](reference.Owner)
 }
 
 func (s *DefaultFastbeltScopeProvider) ScopeActionType(ctx context.Context, reference *core.Reference[Interface]) core.Scope {
-	allDocuments := s.srv.Workspace().DocumentManager.All()
-	return linking.DefaultScopeOfType[Interface](reference.Owner, allDocuments)
+	return linking.DefaultScopeOfType[Interface](reference.Owner)
 }
 
 func (s *DefaultFastbeltScopeProvider) ScopeActionProperty(ctx context.Context, reference *core.Reference[Field]) core.Scope {
-	allDocuments := s.srv.Workspace().DocumentManager.All()
-	return linking.DefaultScopeOfType[Field](reference.Owner, allDocuments)
+	return linking.DefaultScopeOfType[Field](reference.Owner)
 }
 
 type FastbeltReferenceLinker interface {

--- a/linking/exported_symbols.go
+++ b/linking/exported_symbols.go
@@ -10,13 +10,13 @@ import (
 	core "typefox.dev/fastbelt"
 )
 
-// ExportedSymbolsProvider computes the symbols to be exported from a document,
-// potentially making them visible from other documents.
+// ExportedSymbolsProvider computes the symbols to be exported from a document
+// so they can be imported into other documents.
 type ExportedSymbolsProvider interface {
-	// Compute traverses the document's AST and computes the exported symbols.
+	// Provide traverses the document's AST and computes the exported symbols.
 	// The result is stored in the document's ExportedSymbols field.
 	// The caller must hold the document's write lock.
-	Compute(ctx context.Context, document *core.Document)
+	Provide(ctx context.Context, document *core.Document)
 }
 
 // DefaultExportedSymbolsProvider is the default implementation of ExportedSymbolsProvider.
@@ -31,7 +31,7 @@ func NewDefaultExportedSymbolsProvider(srv LinkingSrvCont) ExportedSymbolsProvid
 	}
 }
 
-func (s *DefaultExportedSymbolsProvider) Compute(ctx context.Context, document *core.Document) {
+func (s *DefaultExportedSymbolsProvider) Provide(ctx context.Context, document *core.Document) {
 	root := document.Root
 	describer := s.srv.Linking().ExportedSymbolDescriber
 	var exports []*core.AstNodeDescription

--- a/linking/imported_symbols.go
+++ b/linking/imported_symbols.go
@@ -1,0 +1,44 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+package linking
+
+import (
+	"context"
+	"iter"
+	"slices"
+
+	core "typefox.dev/fastbelt"
+	"typefox.dev/fastbelt/util/extiter"
+)
+
+// ImportedSymbolsProvider computes the symbols imported into a document from
+// other documents, making them available for cross-document reference resolution.
+type ImportedSymbolsProvider interface {
+	// Provide creates a sequence of all symbols that are visible from other documents.
+	// The result is stored in the document's ImportedSymbols field.
+	// The caller must hold the document's write lock.
+	Provide(ctx context.Context, document *core.Document, allDocuments iter.Seq[*core.Document])
+}
+
+// DefaultImportedSymbolsProvider is the default implementation of ImportedSymbolsProvider.
+// It flat-maps the exported symbols of all documents into a single lazy sequence.
+type DefaultImportedSymbolsProvider struct {
+	srv LinkingSrvCont
+}
+
+func NewDefaultImportedSymbolsProvider(srv LinkingSrvCont) ImportedSymbolsProvider {
+	return &DefaultImportedSymbolsProvider{
+		srv: srv,
+	}
+}
+
+func (p *DefaultImportedSymbolsProvider) Provide(ctx context.Context, doc *core.Document, allDocs iter.Seq[*core.Document]) {
+	doc.ImportedSymbols = extiter.FlatMap(allDocs, func(d *core.Document) iter.Seq[*core.AstNodeDescription] {
+		if len(d.ExportedSymbols) == 0 {
+			return core.EmptyAstNodeDescriptions
+		}
+		return slices.Values(d.ExportedSymbols)
+	})
+}

--- a/linking/local_symbols.go
+++ b/linking/local_symbols.go
@@ -14,10 +14,10 @@ import (
 
 // LocalSymbolsProvider computes local symbol information for documents.
 type LocalSymbolsProvider interface {
-	// Compute traverses the document's AST and computes the local symbol table.
+	// Provide traverses the document's AST and computes the local symbol table.
 	// The result is stored in the document's LocalSymbols field.
 	// The caller must hold the document's write lock.
-	Compute(ctx context.Context, document *core.Document)
+	Provide(ctx context.Context, document *core.Document)
 }
 
 // DefaultLocalSymbolsProvider is the default implementation of LocalSymbolsProvider.
@@ -31,7 +31,7 @@ func NewDefaultLocalSymbolsProvider(srv LinkingSrvCont) LocalSymbolsProvider {
 	}
 }
 
-func (s *DefaultLocalSymbolsProvider) Compute(ctx context.Context, document *core.Document) {
+func (s *DefaultLocalSymbolsProvider) Provide(ctx context.Context, document *core.Document) {
 	root := document.Root
 	symbols := collections.NewMultiMap[core.AstNode, *core.AstNodeDescription]()
 

--- a/linking/scoping.go
+++ b/linking/scoping.go
@@ -5,26 +5,21 @@
 package linking
 
 import (
-	"iter"
-	"slices"
-
 	core "typefox.dev/fastbelt"
 	"typefox.dev/fastbelt/util/extiter"
 )
 
-func DefaultScopeOfType[T core.AstNode](node core.AstNode, allDocuments iter.Seq[*core.Document]) core.Scope {
-	globalScope := GlobalScopeOfType[T](node, allDocuments)
+func DefaultScopeOfType[T core.AstNode](node core.AstNode) core.Scope {
+	globalScope := GlobalScopeOfType[T](node)
 	return LocalScopeOfType[T](node, globalScope)
 }
 
-func GlobalScopeOfType[T core.AstNode](node core.AstNode, allDocuments iter.Seq[*core.Document]) core.Scope {
-	symbols := extiter.FlatMap(allDocuments, func(doc *core.Document) iter.Seq[*core.AstNodeDescription] {
-		if len(doc.ExportedSymbols) == 0 {
-			return core.EmptyAstNodeDescriptions
-		}
-		exported := slices.Values(doc.ExportedSymbols)
-		return SymbolsOfType[T](exported)
-	})
+func GlobalScopeOfType[T core.AstNode](node core.AstNode) core.Scope {
+	imported := node.Document().ImportedSymbols
+	if imported == nil {
+		return core.EmptyScope
+	}
+	symbols := SymbolsOfType[T](imported)
 	return core.NewMapScopeFromSeq(symbols, nil)
 }
 

--- a/linking/services.go
+++ b/linking/services.go
@@ -7,6 +7,7 @@ package linking
 type LinkingSrv struct {
 	ExportedSymbolsProvider ExportedSymbolsProvider
 	ExportedSymbolDescriber ExportedSymbolDescriber
+	ImportedSymbolsProvider ImportedSymbolsProvider
 	LocalSymbolsProvider    LocalSymbolsProvider
 	LocalSymbolDescriber    LocalSymbolDescriber
 	Namer                   Namer
@@ -32,6 +33,9 @@ func CreateDefaultServices(srv LinkingSrvCont) {
 	}
 	if linking.ExportedSymbolDescriber == nil {
 		linking.ExportedSymbolDescriber = NewDefaultExportedSymbolDescriber(srv)
+	}
+	if linking.ImportedSymbolsProvider == nil {
+		linking.ImportedSymbolsProvider = NewDefaultImportedSymbolsProvider(srv)
 	}
 	if linking.LocalSymbolsProvider == nil {
 		linking.LocalSymbolsProvider = NewDefaultLocalSymbolsProvider(srv)

--- a/workspace/builder.go
+++ b/workspace/builder.go
@@ -82,7 +82,7 @@ func (b *DefaultBuilder) Build(ctx context.Context, docs []*core.Document) error
 			}
 			// STEP 1.2: Compute the exported symbols for cross-document references.
 			if !doc.State.Has(core.DocStateExportedSymbols) {
-				exportedSymbols.Compute(ctx, doc)
+				exportedSymbols.Provide(ctx, doc)
 				doc.State = doc.State.With(core.DocStateExportedSymbols)
 				b.notifyListeners(ctx, core.DocStateExportedSymbols, doc)
 			}
@@ -97,8 +97,9 @@ func (b *DefaultBuilder) Build(ctx context.Context, docs []*core.Document) error
 		return err
 	}
 
-	// PHASE 2: Compute local symbols and link (parallel per document).
+	// PHASE 2: Compute imported/local symbols and link (parallel per document).
 	// This requires the exported symbols of all documents to be available.
+	importedSymbols := b.srv.Linking().ImportedSymbolsProvider
 	localSymbols := b.srv.Linking().LocalSymbolsProvider
 	linker := b.srv.Linking().Linker
 	var phase2 sync.WaitGroup
@@ -107,16 +108,26 @@ func (b *DefaultBuilder) Build(ctx context.Context, docs []*core.Document) error
 			if ctx.Err() != nil {
 				return
 			}
-			// STEP 2.1: Compute the local symbols for intra-document references.
+			// STEP 2.1: Collect imported symbols from all other documents.
+			if !doc.State.Has(core.DocStateImportedSymbols) {
+				allDocs := b.srv.Workspace().DocumentManager.All()
+				importedSymbols.Provide(ctx, doc, allDocs)
+				doc.State = doc.State.With(core.DocStateImportedSymbols)
+				b.notifyListeners(ctx, core.DocStateImportedSymbols, doc)
+			}
+			if ctx.Err() != nil {
+				return
+			}
+			// STEP 2.2: Compute the local symbols for intra-document references.
 			if !doc.State.Has(core.DocStateLocalSymbols) {
-				localSymbols.Compute(ctx, doc)
+				localSymbols.Provide(ctx, doc)
 				doc.State = doc.State.With(core.DocStateLocalSymbols)
 				b.notifyListeners(ctx, core.DocStateLocalSymbols, doc)
 			}
 			if ctx.Err() != nil {
 				return
 			}
-			// STEP 2.2: Link the document to resolve all references.
+			// STEP 2.3: Link the document to resolve all references.
 			if !doc.State.Has(core.DocStateLinked) {
 				linker.Link(ctx, doc)
 				doc.State = doc.State.With(core.DocStateLinked)
@@ -155,6 +166,9 @@ func (b *DefaultBuilder) Reset(doc *core.Document, state core.DocumentState) {
 	}
 	if !state.Has(core.DocStateExportedSymbols) {
 		doc.ExportedSymbols = nil
+	}
+	if !state.Has(core.DocStateImportedSymbols) {
+		doc.ImportedSymbols = nil
 	}
 	if !state.Has(core.DocStateLocalSymbols) {
 		doc.LocalSymbols = nil


### PR DESCRIPTION
This service is called after all exported symbols have been provided. The default implementation gathers all exported symbols from all documents. In a language with explicit imports or specific visibility rules, you can filter the documents and symbols at this stage so a semantically correct global scope can be formed later.