### PR TITLE
Optimize lexer by using arrays instead of maps

### DIFF
--- a/internal/generator/lexer_generator.go
+++ b/internal/generator/lexer_generator.go
@@ -153,8 +153,7 @@ func generateTokenType(token grammar.Token, id int) GenerateLexerResult {
 		n.AppendLine("},")
 	})
 	code.AppendLine(")")
-	code.AppendNode(result.Lookup)
-	code.AppendNode(result.Next)
+	code.AppendNode(result.Vars)
 	return GenerateLexerResult{
 		Imports: imports,
 		Code:    code,

--- a/internal/grammar/lexer_gen.go
+++ b/internal/grammar/lexer_gen.go
@@ -491,7 +491,6 @@ var Token_String = core.NewTokenType(
 	func(s string, offset int) int {
 		input := s[offset:]
 		length := len(input)
-		accepted := map[int]bool{3: true}
 		state := 0
 		acceptedIndex := 0
 		index := 0
@@ -571,7 +570,7 @@ var Token_String = core.NewTokenType(
 				break loop
 			}
 			index += runeSize
-			if accepted[state] {
+			if Token_String_Accepting[state] {
 				acceptedIndex = index
 			}
 		}
@@ -591,6 +590,9 @@ var Token_String_Next = [][]int{
 	{2, 3, 2},
 	{},
 }
+var Token_String_Accepting = [4]bool{
+	3: true,
+}
 
 const Token_ID_Idx = 28
 
@@ -604,7 +606,6 @@ var Token_ID = core.NewTokenType(
 	func(s string, offset int) int {
 		input := s[offset:]
 		length := len(input)
-		accepted := map[int]bool{1: true}
 		state := 0
 		acceptedIndex := 0
 		index := 0
@@ -650,7 +651,7 @@ var Token_ID = core.NewTokenType(
 				break loop
 			}
 			index += runeSize
-			if accepted[state] {
+			if Token_ID_Accepting[state] {
 				acceptedIndex = index
 			}
 		}
@@ -666,6 +667,9 @@ var Token_ID_Next = [][]int{
 	{1, 1, 1},
 	{1, 1, 1, 1},
 }
+var Token_ID_Accepting = [2]bool{
+	1: true,
+}
 
 const Token_RegexLiteral_Idx = 29
 
@@ -679,7 +683,6 @@ var Token_RegexLiteral = core.NewTokenType(
 	func(s string, offset int) int {
 		input := s[offset:]
 		length := len(input)
-		accepted := map[int]bool{5: true}
 		state := 0
 		acceptedIndex := 0
 		index := 0
@@ -810,7 +813,7 @@ var Token_RegexLiteral = core.NewTokenType(
 				break loop
 			}
 			index += runeSize
-			if accepted[state] {
+			if Token_RegexLiteral_Accepting[state] {
 				acceptedIndex = index
 			}
 		}
@@ -836,6 +839,9 @@ var Token_RegexLiteral_Next = [][]int{
 	{},
 	{3, 3},
 }
+var Token_RegexLiteral_Accepting = [7]bool{
+	5: true,
+}
 
 const Token_WS_Idx = 30
 
@@ -849,7 +855,6 @@ var Token_WS = core.NewTokenType(
 	func(s string, offset int) int {
 		input := s[offset:]
 		length := len(input)
-		accepted := map[int]bool{1: true}
 		state := 0
 		acceptedIndex := 0
 		index := 0
@@ -895,7 +900,7 @@ var Token_WS = core.NewTokenType(
 				break loop
 			}
 			index += runeSize
-			if accepted[state] {
+			if Token_WS_Accepting[state] {
 				acceptedIndex = index
 			}
 		}
@@ -910,6 +915,9 @@ var Token_WS_Lookup = [][]int64{
 var Token_WS_Next = [][]int{
 	{1, 1, 1},
 	{1, 1, 1},
+}
+var Token_WS_Accepting = [2]bool{
+	1: true,
 }
 
 func NewLexer() lexer.Lexer {

--- a/internal/regexp/benchmark/benchmarks_test.go
+++ b/internal/regexp/benchmark/benchmarks_test.go
@@ -12,40 +12,40 @@ const url = "https://www.example.com/path?query=string#fragment"
 const ipv4 = "255.123.2.1"
 
 func BenchmarkEmailCustom(b *testing.B) {
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		generated.Email(email, 0)
 	}
 }
 
 func BenchmarkEmailOriginal(b *testing.B) {
 	regexp := original.MustCompile(EmailPattern())
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		regexp.FindStringIndex(email)
 	}
 }
 
 func BenchmarkURLCustom(b *testing.B) {
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		generated.URL(url, 0)
 	}
 }
 
 func BenchmarkURLOriginal(b *testing.B) {
 	regexp := original.MustCompile(URLPattern())
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		regexp.FindStringIndex(url)
 	}
 }
 
 func BenchmarkIPv4Custom(b *testing.B) {
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		generated.IPv4(ipv4, 0)
 	}
 }
 
 func BenchmarkIPv4Original(b *testing.B) {
 	regexp := original.MustCompile(IPv4Pattern())
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		regexp.FindStringIndex(ipv4)
 	}
 }

--- a/internal/regexp/benchmark/generated/email.go
+++ b/internal/regexp/benchmark/generated/email.go
@@ -21,11 +21,13 @@ var Email_Next = [][]int{
 	{5, 5, 5, 5, 5, 5},
 	{5, 5, 5, 5, 5, 5},
 }
+var Email_Accepting = [6]bool{
+	5: true,
+}
 
 func Email(s string, offset int) int {
 	input := s[offset:]
 	length := len(input)
-	accepted := map[int]bool{5: true}
 	state := 0
 	acceptedIndex := 0
 	index := 0
@@ -139,7 +141,7 @@ loop:
 			break loop
 		}
 		index += runeSize
-		if accepted[state] {
+		if Email_Accepting[state] {
 			acceptedIndex = index
 		}
 	}

--- a/internal/regexp/benchmark/generated/ipv4.go
+++ b/internal/regexp/benchmark/generated/ipv4.go
@@ -57,11 +57,17 @@ var IPv4_Next = [][]int{
 	{23},
 	{},
 }
+var IPv4_Accepting = [24]bool{
+	19: true,
+	20: true,
+	21: true,
+	22: true,
+	23: true,
+}
 
 func IPv4(s string, offset int) int {
 	input := s[offset:]
 	length := len(input)
-	accepted := map[int]bool{19: true, 20: true, 21: true, 22: true, 23: true}
 	state := 0
 	acceptedIndex := 0
 	index := 0
@@ -481,7 +487,7 @@ loop:
 			break loop
 		}
 		index += runeSize
-		if accepted[state] {
+		if IPv4_Accepting[state] {
 			acceptedIndex = index
 		}
 	}

--- a/internal/regexp/benchmark/generated/url.go
+++ b/internal/regexp/benchmark/generated/url.go
@@ -33,11 +33,13 @@ var URL_Next = [][]int{
 	{9, 9, 11, 9, 9, 10, 11, 9, 9, 9, 11, 9, 11, 9},
 	{11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11},
 }
+var URL_Accepting = [12]bool{
+	11: true,
+}
 
 func URL(s string, offset int) int {
 	input := s[offset:]
 	length := len(input)
-	accepted := map[int]bool{11: true}
 	state := 0
 	acceptedIndex := 0
 	index := 0
@@ -253,7 +255,7 @@ loop:
 			break loop
 		}
 		index += runeSize
-		if accepted[state] {
+		if URL_Accepting[state] {
 			acceptedIndex = index
 		}
 	}

--- a/internal/regexp/benchmark/setup_test.go
+++ b/internal/regexp/benchmark/setup_test.go
@@ -23,8 +23,7 @@ func writeRegexpFile(name string, pattern string) {
 	}
 	root.AppendLine(")")
 	root.AppendLine()
-	root.AppendNode(result.Lookup)
-	root.AppendNode(result.Next)
+	root.AppendNode(result.Vars)
 	root.AppendNode(result.Code)
 	err := os.WriteFile("generated/"+strings.ToLower(name)+".go", []byte(format.FormatIfPossible(root.String())), 0644)
 	if err != nil {

--- a/internal/regexp/regexp_generator.go
+++ b/internal/regexp/regexp_generator.go
@@ -86,23 +86,20 @@ func GenerateTransitionsUsingBinarySearch(bySource *automatons.RuneRangeTargetsM
 
 type GenerateRegExpResult struct {
 	Imports map[string]bool
-	Lookup  generator.Node
-	Next    generator.Node
+	Vars    generator.Node
 	Code    generator.Node
 }
 
 func (r *RegexpImpl) GenerateRegExp(funcName string, tokenName string) GenerateRegExpResult {
+	vars := generator.NewNode()
 	lookup := generator.NewNode()
 	lookup.AppendLine(fmt.Sprintf("var %s_Lookup = [][]int64{", tokenName))
 	next := generator.NewNode()
 	next.AppendLine(fmt.Sprintf("var %s_Next = [][]int{", tokenName))
-	imports := map[string]bool{"unicode/utf8": true}
-	root := generator.NewNode()
-	root.AppendLine(fmt.Sprintf("func %s(s string, offset int) int {", funcName))
-	root.Indent(func(n generator.Node) {
-		n.AppendLine("input := s[offset:]")
-		n.AppendLine("length := len(input)")
-		n.Append("accepted := map[int]bool{")
+	accepting := generator.NewNode()
+	acceptingName := fmt.Sprintf("%s_Accepting", tokenName)
+	accepting.AppendLine(fmt.Sprintf("var %s = [%d]bool{", acceptingName, r.dfa.StateCount))
+	accepting.Indent(func(n generator.Node) {
 		acceptingStates := r.dfa.AcceptingStates
 		stateIDs := make([]int, 0, len(acceptingStates))
 		for state, isAccepting := range acceptingStates {
@@ -112,9 +109,17 @@ func (r *RegexpImpl) GenerateRegExp(funcName string, tokenName string) GenerateR
 		}
 		slices.Sort(stateIDs)
 		for _, state := range stateIDs {
-			n.Append(fmt.Sprintf("%d: true, ", state))
+			n.AppendLine(fmt.Sprintf("%d: true,", state))
 		}
-		n.AppendLine("}")
+	})
+	accepting.AppendLine("}")
+
+	imports := map[string]bool{"unicode/utf8": true}
+	root := generator.NewNode()
+	root.AppendLine(fmt.Sprintf("func %s(s string, offset int) int {", funcName))
+	root.Indent(func(n generator.Node) {
+		n.AppendLine("input := s[offset:]")
+		n.AppendLine("length := len(input)")
 		n.AppendLine(fmt.Sprintf("state := %d", r.dfa.StartState))
 		n.AppendLine("acceptedIndex := 0")
 		n.AppendLine("index := 0")
@@ -140,7 +145,7 @@ func (r *RegexpImpl) GenerateRegExp(funcName string, tokenName string) GenerateR
 			})
 			n.AppendLine("}")
 			n.AppendLine("index += runeSize")
-			n.AppendLine("if accepted[state] {")
+			n.AppendLine(fmt.Sprintf("if %s[state] {", acceptingName))
 			n.Indent(func(n generator.Node) {
 				n.AppendLine("acceptedIndex = index")
 			})
@@ -152,10 +157,12 @@ func (r *RegexpImpl) GenerateRegExp(funcName string, tokenName string) GenerateR
 	root.Append("}")
 	lookup.AppendLine("}")
 	next.AppendLine("}")
+	vars.AppendNode(lookup)
+	vars.AppendNode(next)
+	vars.AppendNode(accepting)
 	return GenerateRegExpResult{
 		Imports: imports,
 		Code:    root,
-		Lookup:  lookup,
-		Next:    next,
+		Vars:    vars,
 	}
 }


### PR DESCRIPTION
I noticed that we're still using some map lookups in our generated lexing code. This eliminates those maps in favor of arrays. It speeds up the code by quite a bit, depending on the complexity of the regexp:

|Name|Before|After|
|------|------|-----|
|email|68.58 ns/op|39.20 ns/op|
|ipv4|285.8 ns/op|182.0 ns/op|
|url|95.98 ns/op|20.24 ns/op|