### PR TITLE
Support comment tokens

### DIFF
--- a/document.go
+++ b/document.go
@@ -23,6 +23,7 @@ type Document struct {
 	State                 DocumentState
 	Root                  AstNode
 	Tokens                TokenSlice
+	Comments              TokenSlice
 	LocalSymbols          LocalSymbols
 	ExportedSymbols       []*AstNodeDescription
 	ImportedSymbols       SymbolList

--- a/internal/generator/lexer_generator.go
+++ b/internal/generator/lexer_generator.go
@@ -134,7 +134,9 @@ func generateTokenType(token grammar.Token, id int) GenerateLexerResult {
 		n.AppendLine("\"", token.Name(), "\",")
 		n.AppendLine("\"", token.Name(), "\",")
 		if token.Type() == "hidden" {
-			n.AppendLine("-1,")
+			n.AppendLine("core.SkippedGroup,")
+		} else if token.Type() == "comment" {
+			n.AppendLine("core.CommentGroup,")
 		} else {
 			n.AppendLine("0,")
 		}

--- a/internal/grammar/grammar.fb
+++ b/internal/grammar/grammar.fb
@@ -74,7 +74,7 @@ interface Token extends AbstractRule {
     Regexp string
 }
 
-Token returns Token: Type="hidden"? "token" Name=ID ":" Regexp=RegexLiteral ";";
+Token returns Token: (Type?="hidden" | Type?="comment")? "token" Name=ID ":" Regexp=RegexLiteral ";";
 
 interface Element {
     Cardinality string
@@ -136,6 +136,10 @@ interface Action extends Element {
 }
 
 Action returns Action: "{" Type=[Interface:ID] ("." Property=[Field:ID] Operator=("+=" | "=") "current")? "}";
+
+// Move comments in front of RegexLiteral
+comment token SL_COMMENT: /\/\/[^\r\n]*/;
+comment token ML_COMMENT: /\/\*[^*]*\*\//;
 
 token String: /"[^"]+"/;
 token ID: /[a-zA-Z_][a-zA-Z0-9_]*/;

--- a/internal/grammar/lexer_gen.go
+++ b/internal/grammar/lexer_gen.go
@@ -281,7 +281,25 @@ var Keyword_bool = core.NewTokenType(
 	[]rune{'b'},
 )
 
-const Keyword_current_Idx = 16
+const Keyword_comment_Idx = 16
+
+var Keyword_comment = core.NewTokenType(
+	Keyword_comment_Idx,
+	"comment",
+	"comment",
+	0,
+	0,
+	false,
+	func(text string, offset int) int {
+		if strings.HasPrefix(text[offset:], "comment") {
+			return 7
+		}
+		return 0
+	},
+	[]rune{'c'},
+)
+
+const Keyword_current_Idx = 17
 
 var Keyword_current = core.NewTokenType(
 	Keyword_current_Idx,
@@ -299,7 +317,7 @@ var Keyword_current = core.NewTokenType(
 	[]rune{'c'},
 )
 
-const Keyword_extends_Idx = 17
+const Keyword_extends_Idx = 18
 
 var Keyword_extends = core.NewTokenType(
 	Keyword_extends_Idx,
@@ -317,7 +335,7 @@ var Keyword_extends = core.NewTokenType(
 	[]rune{'e'},
 )
 
-const Keyword_grammar_Idx = 18
+const Keyword_grammar_Idx = 19
 
 var Keyword_grammar = core.NewTokenType(
 	Keyword_grammar_Idx,
@@ -335,7 +353,7 @@ var Keyword_grammar = core.NewTokenType(
 	[]rune{'g'},
 )
 
-const Keyword_hidden_Idx = 19
+const Keyword_hidden_Idx = 20
 
 var Keyword_hidden = core.NewTokenType(
 	Keyword_hidden_Idx,
@@ -353,7 +371,7 @@ var Keyword_hidden = core.NewTokenType(
 	[]rune{'h'},
 )
 
-const Keyword_interface_Idx = 20
+const Keyword_interface_Idx = 21
 
 var Keyword_interface = core.NewTokenType(
 	Keyword_interface_Idx,
@@ -371,7 +389,7 @@ var Keyword_interface = core.NewTokenType(
 	[]rune{'i'},
 )
 
-const Keyword_returns_Idx = 21
+const Keyword_returns_Idx = 22
 
 var Keyword_returns = core.NewTokenType(
 	Keyword_returns_Idx,
@@ -389,7 +407,7 @@ var Keyword_returns = core.NewTokenType(
 	[]rune{'r'},
 )
 
-const Keyword_string_Idx = 22
+const Keyword_string_Idx = 23
 
 var Keyword_string = core.NewTokenType(
 	Keyword_string_Idx,
@@ -407,7 +425,7 @@ var Keyword_string = core.NewTokenType(
 	[]rune{'s'},
 )
 
-const Keyword_token_Idx = 23
+const Keyword_token_Idx = 24
 
 var Keyword_token = core.NewTokenType(
 	Keyword_token_Idx,
@@ -425,7 +443,7 @@ var Keyword_token = core.NewTokenType(
 	[]rune{'t'},
 )
 
-const Keyword_LeftBrace_Idx = 24
+const Keyword_LeftBrace_Idx = 25
 
 var Keyword_LeftBrace = core.NewTokenType(
 	Keyword_LeftBrace_Idx,
@@ -443,7 +461,7 @@ var Keyword_LeftBrace = core.NewTokenType(
 	[]rune{'{'},
 )
 
-const Keyword_Pipe_Idx = 25
+const Keyword_Pipe_Idx = 26
 
 var Keyword_Pipe = core.NewTokenType(
 	Keyword_Pipe_Idx,
@@ -461,7 +479,7 @@ var Keyword_Pipe = core.NewTokenType(
 	[]rune{'|'},
 )
 
-const Keyword_RightBrace_Idx = 26
+const Keyword_RightBrace_Idx = 27
 
 var Keyword_RightBrace = core.NewTokenType(
 	Keyword_RightBrace_Idx,
@@ -479,7 +497,233 @@ var Keyword_RightBrace = core.NewTokenType(
 	[]rune{'}'},
 )
 
-const Token_String_Idx = 27
+const Token_SL_COMMENT_Idx = 28
+
+var Token_SL_COMMENT = core.NewTokenType(
+	Token_SL_COMMENT_Idx,
+	"SL_COMMENT",
+	"SL_COMMENT",
+	core.CommentGroup,
+	0,
+	false,
+	func(s string, offset int) int {
+		input := s[offset:]
+		length := len(input)
+		accepted := map[int]bool{2: true}
+		state := 0
+		acceptedIndex := 0
+		index := 0
+	loop:
+		for index < length {
+			r, runeSize := utf8.DecodeRuneInString(input[index:])
+			switch state {
+			case 0:
+				nextState := -1
+				next := Token_SL_COMMENT_Next[0]
+				lookup := Token_SL_COMMENT_Lookup[0]
+				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
+					lo := rune(lowHigh & 0xFFFFFFFF)
+					hi := rune(lowHigh >> 32)
+					return lo <= r && r <= hi
+				})
+				if searchIndex > -1 {
+					nextState = next[searchIndex]
+				}
+				if nextState > -1 {
+					state = nextState
+				} else {
+					break loop
+				}
+			case 1:
+				nextState := -1
+				next := Token_SL_COMMENT_Next[1]
+				lookup := Token_SL_COMMENT_Lookup[1]
+				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
+					lo := rune(lowHigh & 0xFFFFFFFF)
+					hi := rune(lowHigh >> 32)
+					return lo <= r && r <= hi
+				})
+				if searchIndex > -1 {
+					nextState = next[searchIndex]
+				}
+				if nextState > -1 {
+					state = nextState
+				} else {
+					break loop
+				}
+			case 2:
+				nextState := -1
+				next := Token_SL_COMMENT_Next[2]
+				lookup := Token_SL_COMMENT_Lookup[2]
+				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
+					lo := rune(lowHigh & 0xFFFFFFFF)
+					hi := rune(lowHigh >> 32)
+					return lo <= r && r <= hi
+				})
+				if searchIndex > -1 {
+					nextState = next[searchIndex]
+				}
+				if nextState > -1 {
+					state = nextState
+				} else {
+					break loop
+				}
+			default:
+				break loop
+			}
+			index += runeSize
+			if accepted[state] {
+				acceptedIndex = index
+			}
+		}
+		return acceptedIndex
+	},
+	[]rune{'/'},
+)
+var Token_SL_COMMENT_Lookup = [][]int64{
+	{0x0000002F0000002F},
+	{0x0000002F0000002F},
+	{0x0000000900000000, 0x0000000C0000000B, 0x0010FFFF0000000E},
+}
+var Token_SL_COMMENT_Next = [][]int{
+	{1},
+	{2},
+	{2, 2, 2},
+}
+
+const Token_ML_COMMENT_Idx = 29
+
+var Token_ML_COMMENT = core.NewTokenType(
+	Token_ML_COMMENT_Idx,
+	"ML_COMMENT",
+	"ML_COMMENT",
+	core.CommentGroup,
+	0,
+	false,
+	func(s string, offset int) int {
+		input := s[offset:]
+		length := len(input)
+		accepted := map[int]bool{4: true}
+		state := 0
+		acceptedIndex := 0
+		index := 0
+	loop:
+		for index < length {
+			r, runeSize := utf8.DecodeRuneInString(input[index:])
+			switch state {
+			case 0:
+				nextState := -1
+				next := Token_ML_COMMENT_Next[0]
+				lookup := Token_ML_COMMENT_Lookup[0]
+				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
+					lo := rune(lowHigh & 0xFFFFFFFF)
+					hi := rune(lowHigh >> 32)
+					return lo <= r && r <= hi
+				})
+				if searchIndex > -1 {
+					nextState = next[searchIndex]
+				}
+				if nextState > -1 {
+					state = nextState
+				} else {
+					break loop
+				}
+			case 1:
+				nextState := -1
+				next := Token_ML_COMMENT_Next[1]
+				lookup := Token_ML_COMMENT_Lookup[1]
+				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
+					lo := rune(lowHigh & 0xFFFFFFFF)
+					hi := rune(lowHigh >> 32)
+					return lo <= r && r <= hi
+				})
+				if searchIndex > -1 {
+					nextState = next[searchIndex]
+				}
+				if nextState > -1 {
+					state = nextState
+				} else {
+					break loop
+				}
+			case 2:
+				nextState := -1
+				next := Token_ML_COMMENT_Next[2]
+				lookup := Token_ML_COMMENT_Lookup[2]
+				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
+					lo := rune(lowHigh & 0xFFFFFFFF)
+					hi := rune(lowHigh >> 32)
+					return lo <= r && r <= hi
+				})
+				if searchIndex > -1 {
+					nextState = next[searchIndex]
+				}
+				if nextState > -1 {
+					state = nextState
+				} else {
+					break loop
+				}
+			case 3:
+				nextState := -1
+				next := Token_ML_COMMENT_Next[3]
+				lookup := Token_ML_COMMENT_Lookup[3]
+				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
+					lo := rune(lowHigh & 0xFFFFFFFF)
+					hi := rune(lowHigh >> 32)
+					return lo <= r && r <= hi
+				})
+				if searchIndex > -1 {
+					nextState = next[searchIndex]
+				}
+				if nextState > -1 {
+					state = nextState
+				} else {
+					break loop
+				}
+			case 4:
+				nextState := -1
+				next := Token_ML_COMMENT_Next[4]
+				lookup := Token_ML_COMMENT_Lookup[4]
+				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
+					lo := rune(lowHigh & 0xFFFFFFFF)
+					hi := rune(lowHigh >> 32)
+					return lo <= r && r <= hi
+				})
+				if searchIndex > -1 {
+					nextState = next[searchIndex]
+				}
+				if nextState > -1 {
+					state = nextState
+				} else {
+					break loop
+				}
+			default:
+				break loop
+			}
+			index += runeSize
+			if accepted[state] {
+				acceptedIndex = index
+			}
+		}
+		return acceptedIndex
+	},
+	[]rune{'/'},
+)
+var Token_ML_COMMENT_Lookup = [][]int64{
+	{0x0000002F0000002F},
+	{0x0000002A0000002A},
+	{0x0000002900000000, 0x0000002A0000002A, 0x0010FFFF0000002B},
+	{0x0000002F0000002F},
+	{},
+}
+var Token_ML_COMMENT_Next = [][]int{
+	{1},
+	{2},
+	{2, 3, 2},
+	{4},
+	{},
+}
+
+const Token_String_Idx = 30
 
 var Token_String = core.NewTokenType(
 	Token_String_Idx,
@@ -592,7 +836,7 @@ var Token_String_Next = [][]int{
 	{},
 }
 
-const Token_ID_Idx = 28
+const Token_ID_Idx = 31
 
 var Token_ID = core.NewTokenType(
 	Token_ID_Idx,
@@ -667,7 +911,7 @@ var Token_ID_Next = [][]int{
 	{1, 1, 1, 1},
 }
 
-const Token_RegexLiteral_Idx = 29
+const Token_RegexLiteral_Idx = 32
 
 var Token_RegexLiteral = core.NewTokenType(
 	Token_RegexLiteral_Idx,
@@ -837,13 +1081,13 @@ var Token_RegexLiteral_Next = [][]int{
 	{3, 3},
 }
 
-const Token_WS_Idx = 30
+const Token_WS_Idx = 33
 
 var Token_WS = core.NewTokenType(
 	Token_WS_Idx,
 	"WS",
 	"WS",
-	-1,
+	core.SkippedGroup,
 	0,
 	false,
 	func(s string, offset int) int {
@@ -929,6 +1173,7 @@ func NewLexer() lexer.Lexer {
 		Keyword_LeftBracket,
 		Keyword_RightBracket,
 		Keyword_bool,
+		Keyword_comment,
 		Keyword_current,
 		Keyword_extends,
 		Keyword_grammar,
@@ -940,6 +1185,8 @@ func NewLexer() lexer.Lexer {
 		Keyword_LeftBrace,
 		Keyword_Pipe,
 		Keyword_RightBrace,
+		Token_SL_COMMENT,
+		Token_ML_COMMENT,
 		Token_String,
 		Token_ID,
 		Token_RegexLiteral,

--- a/internal/grammar/parser_gen.go
+++ b/internal/grammar/parser_gen.go
@@ -83,6 +83,7 @@ const (
 	TokenNameID_0
 	TokenRegexpRegexLiteral_0
 	TokenSemicolon_0
+	TokenTypecomment_0
 	TokenTypehidden_0
 	Tokentoken_0
 )
@@ -93,7 +94,7 @@ var ActionLookahead13 = parser.LLkLookahead{
 	},
 }
 
-var ActionOperatorLookaheadOr8 = parser.LLkLookahead{
+var ActionOperatorLookaheadOr9 = parser.LLkLookahead{
 	parser.LookaheadOption{
 		parser.LookaheadPath{Keyword_PlusEquals_Idx},
 	},
@@ -126,7 +127,7 @@ var AssignableAlternativesLookahead11 = parser.LLkLookahead{
 	},
 }
 
-var AssignableLookaheadOr6 = parser.LLkLookahead{
+var AssignableLookaheadOr7 = parser.LLkLookahead{
 	parser.LookaheadOption{
 		parser.LookaheadPath{Token_String_Idx},
 	},
@@ -141,7 +142,7 @@ var AssignableLookaheadOr6 = parser.LLkLookahead{
 	},
 }
 
-var AssignableWithoutAltsLookaheadOr7 = parser.LLkLookahead{
+var AssignableWithoutAltsLookaheadOr8 = parser.LLkLookahead{
 	parser.LookaheadOption{
 		parser.LookaheadPath{Token_String_Idx},
 	},
@@ -153,7 +154,7 @@ var AssignableWithoutAltsLookaheadOr7 = parser.LLkLookahead{
 	},
 }
 
-var AssignmentOperatorLookaheadOr5 = parser.LLkLookahead{
+var AssignmentOperatorLookaheadOr6 = parser.LLkLookahead{
 	parser.LookaheadOption{
 		parser.LookaheadPath{Keyword_PlusEquals_Idx},
 	},
@@ -171,7 +172,7 @@ var CrossRefLookahead12 = parser.LLkLookahead{
 	},
 }
 
-var ElementCardinalityLookaheadOr4 = parser.LLkLookahead{
+var ElementCardinalityLookaheadOr5 = parser.LLkLookahead{
 	parser.LookaheadOption{
 		parser.LookaheadPath{Keyword_Asterisk_Idx},
 	},
@@ -191,7 +192,7 @@ var ElementLookahead9 = parser.LLkLookahead{
 	},
 }
 
-var ElementLookaheadOr3 = parser.LLkLookahead{
+var ElementLookaheadOr4 = parser.LLkLookahead{
 	parser.LookaheadOption{
 		parser.LookaheadPath{Token_String_Idx},
 	},
@@ -236,6 +237,7 @@ var GrammarLookahead0 = parser.LLkLookahead{
 		parser.LookaheadPath{Token_ID_Idx},
 		parser.LookaheadPath{Keyword_token_Idx},
 		parser.LookaheadPath{Keyword_hidden_Idx},
+		parser.LookaheadPath{Keyword_comment_Idx},
 		parser.LookaheadPath{Keyword_interface_Idx},
 	},
 }
@@ -247,6 +249,7 @@ var GrammarLookaheadOr0 = parser.LLkLookahead{
 	parser.LookaheadOption{
 		parser.LookaheadPath{Keyword_token_Idx},
 		parser.LookaheadPath{Keyword_hidden_Idx},
+		parser.LookaheadPath{Keyword_comment_Idx},
 	},
 	parser.LookaheadOption{
 		parser.LookaheadPath{Keyword_interface_Idx},
@@ -303,6 +306,16 @@ var PrimitiveTypeTypeLookaheadOr2 = parser.LLkLookahead{
 var TokenLookahead4 = parser.LLkLookahead{
 	parser.LookaheadOption{
 		parser.LookaheadPath{Keyword_hidden_Idx},
+		parser.LookaheadPath{Keyword_comment_Idx},
+	},
+}
+
+var TokenLookaheadOr3 = parser.LLkLookahead{
+	parser.LookaheadOption{
+		parser.LookaheadPath{Keyword_hidden_Idx},
+	},
+	parser.LookaheadOption{
+		parser.LookaheadPath{Keyword_comment_Idx},
 	},
 }
 
@@ -584,12 +597,23 @@ func (p *Parser) ParseParserRule() ParserRule {
 func (p *Parser) ParseToken() Token {
 	current := NewToken()
 	current.SetSegmentStartToken(p.state.LA(1))
-	{
-		if p.state.Lookahead(TokenLookahead4) == 0 {
-			token := p.state.Consume(Keyword_hidden_Idx)
-			core.AssignToken(current, token, TokenTypehidden_0)
-			if token != nil {
-				current.SetType(token)
+	if p.state.Lookahead(TokenLookahead4) == 0 {
+		switch p.state.Lookahead(TokenLookaheadOr3) {
+		case 0:
+			{
+				token := p.state.Consume(Keyword_hidden_Idx)
+				core.AssignToken(current, token, TokenTypehidden_0)
+				if token != nil {
+					current.SetType(token)
+				}
+			}
+		case 1:
+			{
+				token := p.state.Consume(Keyword_comment_Idx)
+				core.AssignToken(current, token, TokenTypecomment_0)
+				if token != nil {
+					current.SetType(token)
+				}
 			}
 		}
 	}
@@ -690,7 +714,7 @@ func (p *Parser) ParseGroup() Element {
 func (p *Parser) ParseElement() Element {
 	current := NewElement()
 	current.SetSegmentStartToken(p.state.LA(1))
-	switch p.state.Lookahead(ElementLookaheadOr3) {
+	switch p.state.Lookahead(ElementLookaheadOr4) {
 	case 0:
 		{
 			result := p.ParseKeyword()
@@ -732,7 +756,7 @@ func (p *Parser) ParseElement() Element {
 	}
 	{
 		if p.state.Lookahead(ElementLookahead9) == 0 {
-			switch p.state.Lookahead(ElementCardinalityLookaheadOr4) {
+			switch p.state.Lookahead(ElementCardinalityLookaheadOr5) {
 			case 0:
 				token := p.state.Consume(Keyword_Asterisk_Idx)
 				core.AssignToken(current, token, ElementCardinalityAsterisk_0)
@@ -783,7 +807,7 @@ func (p *Parser) ParseAssignment() Assignment {
 		}
 	}
 	{
-		switch p.state.Lookahead(AssignmentOperatorLookaheadOr5) {
+		switch p.state.Lookahead(AssignmentOperatorLookaheadOr6) {
 		case 0:
 			token := p.state.Consume(Keyword_PlusEquals_Idx)
 			core.AssignToken(current, token, AssignmentOperatorPlusEquals_0)
@@ -817,7 +841,7 @@ func (p *Parser) ParseAssignment() Assignment {
 func (p *Parser) ParseAssignable() Assignable {
 	current := NewAssignable()
 	current.SetSegmentStartToken(p.state.LA(1))
-	switch p.state.Lookahead(AssignableLookaheadOr6) {
+	switch p.state.Lookahead(AssignableLookaheadOr7) {
 	case 0:
 		{
 			result := p.ParseKeyword()
@@ -858,7 +882,7 @@ func (p *Parser) ParseAssignable() Assignable {
 func (p *Parser) ParseAssignableWithoutAlts() Assignable {
 	current := NewAssignable()
 	current.SetSegmentStartToken(p.state.LA(1))
-	switch p.state.Lookahead(AssignableWithoutAltsLookaheadOr7) {
+	switch p.state.Lookahead(AssignableWithoutAltsLookaheadOr8) {
 	case 0:
 		{
 			result := p.ParseKeyword()
@@ -991,7 +1015,7 @@ func (p *Parser) ParseAction() Action {
 			}
 		}
 		{
-			switch p.state.Lookahead(ActionOperatorLookaheadOr8) {
+			switch p.state.Lookahead(ActionOperatorLookaheadOr9) {
 			case 0:
 				token := p.state.Consume(Keyword_PlusEquals_Idx)
 				core.AssignToken(current, token, ActionOperatorPlusEquals_0)

--- a/internal/vscode-extensions/fastbelt/data/fastbelt.tmLanguage.json
+++ b/internal/vscode-extensions/fastbelt/data/fastbelt.tmLanguage.json
@@ -13,7 +13,7 @@
         },
         {
             "name": "keyword.control.fastbelt",
-            "match": "\\b(left|right|assoc|current|entry|extends|fragment|grammar|hidden|import|infer|infers|infix|interface|returns|terminal|type|with|on)\\b"
+            "match": "\\b(left|right|assoc|current|entry|extends|fragment|grammar|hidden|import|infer|infers|infix|interface|returns|token|comment|type|with|on)\\b"
         },
         {
             "name": "constant.language.fastbelt",

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -12,9 +12,10 @@ import (
 )
 
 type LexerResult struct {
-	Tokens []*core.Token
-	Errors []*core.LexerError
-	Groups map[int][]*core.Token
+	Tokens   []*core.Token
+	Comments []*core.Token
+	Errors   []*core.LexerError
+	Groups   map[int][]*core.Token
 }
 
 type Lexer interface {
@@ -29,6 +30,7 @@ type DefaultLexer struct {
 func (l *DefaultLexer) Lex(input string) *LexerResult {
 	length := len(input)
 	tokens := make([]*core.Token, 0, length/5) // rough estimate
+	comments := make([]*core.Token, 0)
 	errors := make([]*core.LexerError, 0)
 	groups := make(map[int][]*core.Token)
 
@@ -70,7 +72,20 @@ func (l *DefaultLexer) Lex(input string) *LexerResult {
 		}
 
 		if longestType != nil {
-			if !longestType.IsSkipped() {
+			switch longestType.Group {
+			case core.SkippedGroup:
+				// do nothing
+			case core.CommentGroup:
+				comments = append(comments, core.NewToken(
+					longestType,
+					input[offset:end],
+					offset, end,
+					startLine,
+					line,
+					startColumn,
+					column,
+				))
+			case 0:
 				tokens = append(tokens, core.NewToken(
 					longestType,
 					input[offset:end],
@@ -96,9 +111,10 @@ func (l *DefaultLexer) Lex(input string) *LexerResult {
 	}
 
 	return &LexerResult{
-		Tokens: tokens,
-		Errors: errors,
-		Groups: groups,
+		Tokens:   tokens,
+		Comments: comments,
+		Errors:   errors,
+		Groups:   groups,
 	}
 }
 

--- a/token.go
+++ b/token.go
@@ -5,6 +5,7 @@
 package fastbelt
 
 const SkippedGroup = -1
+const CommentGroup = -2
 
 type Matcher func(input string, offset int) int
 
@@ -34,6 +35,10 @@ func NewTokenType(id int, name, label string, group int, pushMode int, popMode b
 
 func (t *TokenType) IsSkipped() bool {
 	return t.Group == SkippedGroup
+}
+
+func (t *TokenType) IsComment() bool {
+	return t.Group == CommentGroup
 }
 
 var EOF = NewTokenType(

--- a/workspace/document_parser.go
+++ b/workspace/document_parser.go
@@ -31,6 +31,7 @@ func (p *DefaultDocumentParser) Parse(doc *core.Document) {
 	lexerRes := p.srv.Generated().Lexer.Lex(text)
 	doc.LexerErrors = lexerRes.Errors
 	doc.Tokens = lexerRes.Tokens
+	doc.Comments = lexerRes.Comments
 	// Run the parser
 	parserRes := p.srv.Generated().Parser.Parse(doc)
 	doc.ParserErrors = parserRes.Errors


### PR DESCRIPTION
Closes https://github.com/TypeFox/fastbelt/issues/20.

Adds support for comment tokens. Note that `comment` tokens are semantically relevant comments. Those that are not semantically relevant should keep their `hidden` state.