### PR TITLE
Improve lexer performance using struct-array

### DIFF
--- a/document.go
+++ b/document.go
@@ -53,6 +53,7 @@ func NewDocument(textDoc textdoc.Handle) *Document {
 		ExportedSymbols: nil,
 		Data:            sync.Map{},
 		Tokens:          TokenSlice{},
+		Comments:        TokenSlice{},
 		ParserErrors:    []*ParserError{},
 		LexerErrors:     []*LexerError{},
 		References:      []UntypedReference{},

--- a/examples/statemachine/benchmark_test.go
+++ b/examples/statemachine/benchmark_test.go
@@ -21,13 +21,16 @@ const resourceCount = 200
 // BenchmarkWorkspaceCycle benchmarks a full workspace build cycle over
 // resourceCount in-memory statemachine documents: parse, index, link, and validate.
 func BenchmarkWorkspaceCycle(b *testing.B) {
+	length := 0
 	contents := make([]string, resourceCount)
 	for i := range contents {
 		contents[i], _ = generateStatemachineContent(i)
+		length += len(contents[i])
 	}
 	srv := CreateServices()
 
 	var totalNs int64
+	b.SetBytes(int64(length))
 	b.ResetTimer()
 	for range b.N {
 		// Fresh document manager per cycle so each build starts from a clean state.
@@ -107,6 +110,36 @@ func TestAllChildrenEquivalence(t *testing.T) {
 		childCount++
 	}
 	assert.Equal(t, totalCount, childCount, "AllChildren should iterate all child nodes in the document")
+}
+
+// BenchmarkParser benchmarks parsing a single generated statemachine document,
+// reusing the pre-lexed token slice every iteration.
+func BenchmarkParser(b *testing.B) {
+	content, _ := generateStatemachineContent(0)
+	srv := CreateServices()
+	tokens := srv.Generated().Lexer.Lex(content).Tokens
+	doc, err := fastbelt.NewDocumentFromString("file:///workspace/statemachine_0.statemachine", "statemachine", content)
+	if err != nil {
+		b.Fatal(err)
+	}
+	doc.Tokens = tokens
+	b.SetBytes(int64(len(content)))
+	b.ResetTimer()
+	for b.Loop() {
+		result := srv.Generated().Parser.Parse(doc)
+		doc.Root = result.Node
+	}
+}
+
+// BenchmarkLexer benchmarks tokenizing a single generated statemachine document.
+func BenchmarkLexer(b *testing.B) {
+	content, _ := generateStatemachineContent(0)
+	l := NewLexer()
+	b.SetBytes(int64(len(content)))
+	b.ResetTimer()
+	for b.Loop() {
+		_ = l.Lex(content)
+	}
 }
 
 // generateStatemachineContent generates a syntactically valid statemachine

--- a/examples/statemachine/lexer_gen.go
+++ b/examples/statemachine/lexer_gen.go
@@ -3,7 +3,6 @@
 package statemachine
 
 import (
-	"slices"
 	"strings"
 	core "typefox.dev/fastbelt"
 	"typefox.dev/fastbelt/lexer"
@@ -213,13 +212,11 @@ var Token_ID = core.NewTokenType(
 				nextState := -1
 				next := Token_ID_Next[0]
 				lookup := Token_ID_Lookup[0]
-				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-					lo := rune(lowHigh & 0xFFFFFFFF)
-					hi := rune(lowHigh >> 32)
-					return lo <= r && r <= hi
-				})
-				if searchIndex > -1 {
-					nextState = next[searchIndex]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
 				}
 				if nextState > -1 {
 					state = nextState
@@ -230,13 +227,11 @@ var Token_ID = core.NewTokenType(
 				nextState := -1
 				next := Token_ID_Next[1]
 				lookup := Token_ID_Lookup[1]
-				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-					lo := rune(lowHigh & 0xFFFFFFFF)
-					hi := rune(lowHigh >> 32)
-					return lo <= r && r <= hi
-				})
-				if searchIndex > -1 {
-					nextState = next[searchIndex]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
 				}
 				if nextState > -1 {
 					state = nextState
@@ -290,13 +285,11 @@ var Token_WS = core.NewTokenType(
 				nextState := -1
 				next := Token_WS_Next[0]
 				lookup := Token_WS_Lookup[0]
-				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-					lo := rune(lowHigh & 0xFFFFFFFF)
-					hi := rune(lowHigh >> 32)
-					return lo <= r && r <= hi
-				})
-				if searchIndex > -1 {
-					nextState = next[searchIndex]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
 				}
 				if nextState > -1 {
 					state = nextState
@@ -307,13 +300,11 @@ var Token_WS = core.NewTokenType(
 				nextState := -1
 				next := Token_WS_Next[1]
 				lookup := Token_WS_Lookup[1]
-				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-					lo := rune(lowHigh & 0xFFFFFFFF)
-					hi := rune(lowHigh >> 32)
-					return lo <= r && r <= hi
-				})
-				if searchIndex > -1 {
-					nextState = next[searchIndex]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
 				}
 				if nextState > -1 {
 					state = nextState
@@ -367,13 +358,11 @@ var Token_ML_COMMENT = core.NewTokenType(
 				nextState := -1
 				next := Token_ML_COMMENT_Next[0]
 				lookup := Token_ML_COMMENT_Lookup[0]
-				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-					lo := rune(lowHigh & 0xFFFFFFFF)
-					hi := rune(lowHigh >> 32)
-					return lo <= r && r <= hi
-				})
-				if searchIndex > -1 {
-					nextState = next[searchIndex]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
 				}
 				if nextState > -1 {
 					state = nextState
@@ -384,13 +373,11 @@ var Token_ML_COMMENT = core.NewTokenType(
 				nextState := -1
 				next := Token_ML_COMMENT_Next[1]
 				lookup := Token_ML_COMMENT_Lookup[1]
-				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-					lo := rune(lowHigh & 0xFFFFFFFF)
-					hi := rune(lowHigh >> 32)
-					return lo <= r && r <= hi
-				})
-				if searchIndex > -1 {
-					nextState = next[searchIndex]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
 				}
 				if nextState > -1 {
 					state = nextState
@@ -401,13 +388,11 @@ var Token_ML_COMMENT = core.NewTokenType(
 				nextState := -1
 				next := Token_ML_COMMENT_Next[2]
 				lookup := Token_ML_COMMENT_Lookup[2]
-				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-					lo := rune(lowHigh & 0xFFFFFFFF)
-					hi := rune(lowHigh >> 32)
-					return lo <= r && r <= hi
-				})
-				if searchIndex > -1 {
-					nextState = next[searchIndex]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
 				}
 				if nextState > -1 {
 					state = nextState
@@ -418,13 +403,11 @@ var Token_ML_COMMENT = core.NewTokenType(
 				nextState := -1
 				next := Token_ML_COMMENT_Next[3]
 				lookup := Token_ML_COMMENT_Lookup[3]
-				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-					lo := rune(lowHigh & 0xFFFFFFFF)
-					hi := rune(lowHigh >> 32)
-					return lo <= r && r <= hi
-				})
-				if searchIndex > -1 {
-					nextState = next[searchIndex]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
 				}
 				if nextState > -1 {
 					state = nextState
@@ -435,13 +418,11 @@ var Token_ML_COMMENT = core.NewTokenType(
 				nextState := -1
 				next := Token_ML_COMMENT_Next[4]
 				lookup := Token_ML_COMMENT_Lookup[4]
-				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-					lo := rune(lowHigh & 0xFFFFFFFF)
-					hi := rune(lowHigh >> 32)
-					return lo <= r && r <= hi
-				})
-				if searchIndex > -1 {
-					nextState = next[searchIndex]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
 				}
 				if nextState > -1 {
 					state = nextState
@@ -501,13 +482,11 @@ var Token_SL_COMMENT = core.NewTokenType(
 				nextState := -1
 				next := Token_SL_COMMENT_Next[0]
 				lookup := Token_SL_COMMENT_Lookup[0]
-				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-					lo := rune(lowHigh & 0xFFFFFFFF)
-					hi := rune(lowHigh >> 32)
-					return lo <= r && r <= hi
-				})
-				if searchIndex > -1 {
-					nextState = next[searchIndex]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
 				}
 				if nextState > -1 {
 					state = nextState
@@ -518,13 +497,11 @@ var Token_SL_COMMENT = core.NewTokenType(
 				nextState := -1
 				next := Token_SL_COMMENT_Next[1]
 				lookup := Token_SL_COMMENT_Lookup[1]
-				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-					lo := rune(lowHigh & 0xFFFFFFFF)
-					hi := rune(lowHigh >> 32)
-					return lo <= r && r <= hi
-				})
-				if searchIndex > -1 {
-					nextState = next[searchIndex]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
 				}
 				if nextState > -1 {
 					state = nextState
@@ -535,13 +512,11 @@ var Token_SL_COMMENT = core.NewTokenType(
 				nextState := -1
 				next := Token_SL_COMMENT_Next[2]
 				lookup := Token_SL_COMMENT_Lookup[2]
-				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-					lo := rune(lowHigh & 0xFFFFFFFF)
-					hi := rune(lowHigh >> 32)
-					return lo <= r && r <= hi
-				})
-				if searchIndex > -1 {
-					nextState = next[searchIndex]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
 				}
 				if nextState > -1 {
 					state = nextState

--- a/internal/grammar/lexer_gen.go
+++ b/internal/grammar/lexer_gen.go
@@ -3,7 +3,6 @@
 package grammar
 
 import (
-	"slices"
 	"strings"
 	core "typefox.dev/fastbelt"
 	"typefox.dev/fastbelt/lexer"
@@ -537,13 +536,11 @@ var Token_SL_COMMENT = core.NewTokenType(
 				nextState := -1
 				next := Token_SL_COMMENT_Next[0]
 				lookup := Token_SL_COMMENT_Lookup[0]
-				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-					lo := rune(lowHigh & 0xFFFFFFFF)
-					hi := rune(lowHigh >> 32)
-					return lo <= r && r <= hi
-				})
-				if searchIndex > -1 {
-					nextState = next[searchIndex]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
 				}
 				if nextState > -1 {
 					state = nextState
@@ -554,13 +551,11 @@ var Token_SL_COMMENT = core.NewTokenType(
 				nextState := -1
 				next := Token_SL_COMMENT_Next[1]
 				lookup := Token_SL_COMMENT_Lookup[1]
-				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-					lo := rune(lowHigh & 0xFFFFFFFF)
-					hi := rune(lowHigh >> 32)
-					return lo <= r && r <= hi
-				})
-				if searchIndex > -1 {
-					nextState = next[searchIndex]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
 				}
 				if nextState > -1 {
 					state = nextState
@@ -571,13 +566,11 @@ var Token_SL_COMMENT = core.NewTokenType(
 				nextState := -1
 				next := Token_SL_COMMENT_Next[2]
 				lookup := Token_SL_COMMENT_Lookup[2]
-				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-					lo := rune(lowHigh & 0xFFFFFFFF)
-					hi := rune(lowHigh >> 32)
-					return lo <= r && r <= hi
-				})
-				if searchIndex > -1 {
-					nextState = next[searchIndex]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
 				}
 				if nextState > -1 {
 					state = nextState
@@ -633,13 +626,11 @@ var Token_ML_COMMENT = core.NewTokenType(
 				nextState := -1
 				next := Token_ML_COMMENT_Next[0]
 				lookup := Token_ML_COMMENT_Lookup[0]
-				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-					lo := rune(lowHigh & 0xFFFFFFFF)
-					hi := rune(lowHigh >> 32)
-					return lo <= r && r <= hi
-				})
-				if searchIndex > -1 {
-					nextState = next[searchIndex]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
 				}
 				if nextState > -1 {
 					state = nextState
@@ -650,13 +641,11 @@ var Token_ML_COMMENT = core.NewTokenType(
 				nextState := -1
 				next := Token_ML_COMMENT_Next[1]
 				lookup := Token_ML_COMMENT_Lookup[1]
-				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-					lo := rune(lowHigh & 0xFFFFFFFF)
-					hi := rune(lowHigh >> 32)
-					return lo <= r && r <= hi
-				})
-				if searchIndex > -1 {
-					nextState = next[searchIndex]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
 				}
 				if nextState > -1 {
 					state = nextState
@@ -667,13 +656,11 @@ var Token_ML_COMMENT = core.NewTokenType(
 				nextState := -1
 				next := Token_ML_COMMENT_Next[2]
 				lookup := Token_ML_COMMENT_Lookup[2]
-				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-					lo := rune(lowHigh & 0xFFFFFFFF)
-					hi := rune(lowHigh >> 32)
-					return lo <= r && r <= hi
-				})
-				if searchIndex > -1 {
-					nextState = next[searchIndex]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
 				}
 				if nextState > -1 {
 					state = nextState
@@ -684,13 +671,11 @@ var Token_ML_COMMENT = core.NewTokenType(
 				nextState := -1
 				next := Token_ML_COMMENT_Next[3]
 				lookup := Token_ML_COMMENT_Lookup[3]
-				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-					lo := rune(lowHigh & 0xFFFFFFFF)
-					hi := rune(lowHigh >> 32)
-					return lo <= r && r <= hi
-				})
-				if searchIndex > -1 {
-					nextState = next[searchIndex]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
 				}
 				if nextState > -1 {
 					state = nextState
@@ -701,13 +686,11 @@ var Token_ML_COMMENT = core.NewTokenType(
 				nextState := -1
 				next := Token_ML_COMMENT_Next[4]
 				lookup := Token_ML_COMMENT_Lookup[4]
-				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-					lo := rune(lowHigh & 0xFFFFFFFF)
-					hi := rune(lowHigh >> 32)
-					return lo <= r && r <= hi
-				})
-				if searchIndex > -1 {
-					nextState = next[searchIndex]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
 				}
 				if nextState > -1 {
 					state = nextState
@@ -767,13 +750,11 @@ var Token_StringLiteral = core.NewTokenType(
 				nextState := -1
 				next := Token_StringLiteral_Next[0]
 				lookup := Token_StringLiteral_Lookup[0]
-				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-					lo := rune(lowHigh & 0xFFFFFFFF)
-					hi := rune(lowHigh >> 32)
-					return lo <= r && r <= hi
-				})
-				if searchIndex > -1 {
-					nextState = next[searchIndex]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
 				}
 				if nextState > -1 {
 					state = nextState
@@ -784,13 +765,11 @@ var Token_StringLiteral = core.NewTokenType(
 				nextState := -1
 				next := Token_StringLiteral_Next[1]
 				lookup := Token_StringLiteral_Lookup[1]
-				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-					lo := rune(lowHigh & 0xFFFFFFFF)
-					hi := rune(lowHigh >> 32)
-					return lo <= r && r <= hi
-				})
-				if searchIndex > -1 {
-					nextState = next[searchIndex]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
 				}
 				if nextState > -1 {
 					state = nextState
@@ -801,13 +780,11 @@ var Token_StringLiteral = core.NewTokenType(
 				nextState := -1
 				next := Token_StringLiteral_Next[2]
 				lookup := Token_StringLiteral_Lookup[2]
-				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-					lo := rune(lowHigh & 0xFFFFFFFF)
-					hi := rune(lowHigh >> 32)
-					return lo <= r && r <= hi
-				})
-				if searchIndex > -1 {
-					nextState = next[searchIndex]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
 				}
 				if nextState > -1 {
 					state = nextState
@@ -863,13 +840,11 @@ var Token_ID = core.NewTokenType(
 				nextState := -1
 				next := Token_ID_Next[0]
 				lookup := Token_ID_Lookup[0]
-				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-					lo := rune(lowHigh & 0xFFFFFFFF)
-					hi := rune(lowHigh >> 32)
-					return lo <= r && r <= hi
-				})
-				if searchIndex > -1 {
-					nextState = next[searchIndex]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
 				}
 				if nextState > -1 {
 					state = nextState
@@ -880,13 +855,11 @@ var Token_ID = core.NewTokenType(
 				nextState := -1
 				next := Token_ID_Next[1]
 				lookup := Token_ID_Lookup[1]
-				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-					lo := rune(lowHigh & 0xFFFFFFFF)
-					hi := rune(lowHigh >> 32)
-					return lo <= r && r <= hi
-				})
-				if searchIndex > -1 {
-					nextState = next[searchIndex]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
 				}
 				if nextState > -1 {
 					state = nextState
@@ -940,13 +913,11 @@ var Token_RegexLiteral = core.NewTokenType(
 				nextState := -1
 				next := Token_RegexLiteral_Next[0]
 				lookup := Token_RegexLiteral_Lookup[0]
-				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-					lo := rune(lowHigh & 0xFFFFFFFF)
-					hi := rune(lowHigh >> 32)
-					return lo <= r && r <= hi
-				})
-				if searchIndex > -1 {
-					nextState = next[searchIndex]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
 				}
 				if nextState > -1 {
 					state = nextState
@@ -957,13 +928,11 @@ var Token_RegexLiteral = core.NewTokenType(
 				nextState := -1
 				next := Token_RegexLiteral_Next[1]
 				lookup := Token_RegexLiteral_Lookup[1]
-				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-					lo := rune(lowHigh & 0xFFFFFFFF)
-					hi := rune(lowHigh >> 32)
-					return lo <= r && r <= hi
-				})
-				if searchIndex > -1 {
-					nextState = next[searchIndex]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
 				}
 				if nextState > -1 {
 					state = nextState
@@ -974,13 +943,11 @@ var Token_RegexLiteral = core.NewTokenType(
 				nextState := -1
 				next := Token_RegexLiteral_Next[2]
 				lookup := Token_RegexLiteral_Lookup[2]
-				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-					lo := rune(lowHigh & 0xFFFFFFFF)
-					hi := rune(lowHigh >> 32)
-					return lo <= r && r <= hi
-				})
-				if searchIndex > -1 {
-					nextState = next[searchIndex]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
 				}
 				if nextState > -1 {
 					state = nextState
@@ -991,13 +958,11 @@ var Token_RegexLiteral = core.NewTokenType(
 				nextState := -1
 				next := Token_RegexLiteral_Next[3]
 				lookup := Token_RegexLiteral_Lookup[3]
-				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-					lo := rune(lowHigh & 0xFFFFFFFF)
-					hi := rune(lowHigh >> 32)
-					return lo <= r && r <= hi
-				})
-				if searchIndex > -1 {
-					nextState = next[searchIndex]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
 				}
 				if nextState > -1 {
 					state = nextState
@@ -1008,13 +973,11 @@ var Token_RegexLiteral = core.NewTokenType(
 				nextState := -1
 				next := Token_RegexLiteral_Next[4]
 				lookup := Token_RegexLiteral_Lookup[4]
-				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-					lo := rune(lowHigh & 0xFFFFFFFF)
-					hi := rune(lowHigh >> 32)
-					return lo <= r && r <= hi
-				})
-				if searchIndex > -1 {
-					nextState = next[searchIndex]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
 				}
 				if nextState > -1 {
 					state = nextState
@@ -1025,13 +988,11 @@ var Token_RegexLiteral = core.NewTokenType(
 				nextState := -1
 				next := Token_RegexLiteral_Next[5]
 				lookup := Token_RegexLiteral_Lookup[5]
-				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-					lo := rune(lowHigh & 0xFFFFFFFF)
-					hi := rune(lowHigh >> 32)
-					return lo <= r && r <= hi
-				})
-				if searchIndex > -1 {
-					nextState = next[searchIndex]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
 				}
 				if nextState > -1 {
 					state = nextState
@@ -1042,13 +1003,11 @@ var Token_RegexLiteral = core.NewTokenType(
 				nextState := -1
 				next := Token_RegexLiteral_Next[6]
 				lookup := Token_RegexLiteral_Lookup[6]
-				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-					lo := rune(lowHigh & 0xFFFFFFFF)
-					hi := rune(lowHigh >> 32)
-					return lo <= r && r <= hi
-				})
-				if searchIndex > -1 {
-					nextState = next[searchIndex]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
 				}
 				if nextState > -1 {
 					state = nextState
@@ -1112,13 +1071,11 @@ var Token_WS = core.NewTokenType(
 				nextState := -1
 				next := Token_WS_Next[0]
 				lookup := Token_WS_Lookup[0]
-				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-					lo := rune(lowHigh & 0xFFFFFFFF)
-					hi := rune(lowHigh >> 32)
-					return lo <= r && r <= hi
-				})
-				if searchIndex > -1 {
-					nextState = next[searchIndex]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
 				}
 				if nextState > -1 {
 					state = nextState
@@ -1129,13 +1086,11 @@ var Token_WS = core.NewTokenType(
 				nextState := -1
 				next := Token_WS_Next[1]
 				lookup := Token_WS_Lookup[1]
-				searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-					lo := rune(lowHigh & 0xFFFFFFFF)
-					hi := rune(lowHigh >> 32)
-					return lo <= r && r <= hi
-				})
-				if searchIndex > -1 {
-					nextState = next[searchIndex]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
 				}
 				if nextState > -1 {
 					state = nextState

--- a/internal/regexp/benchmark/generated/email.go
+++ b/internal/regexp/benchmark/generated/email.go
@@ -1,7 +1,6 @@
 package benchmarkGenerated
 
 import (
-	"slices"
 	"unicode/utf8"
 )
 
@@ -39,13 +38,11 @@ loop:
 			nextState := -1
 			next := Email_Next[0]
 			lookup := Email_Lookup[0]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -56,13 +53,11 @@ loop:
 			nextState := -1
 			next := Email_Next[1]
 			lookup := Email_Lookup[1]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -73,13 +68,11 @@ loop:
 			nextState := -1
 			next := Email_Next[2]
 			lookup := Email_Lookup[2]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -90,13 +83,11 @@ loop:
 			nextState := -1
 			next := Email_Next[3]
 			lookup := Email_Lookup[3]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -107,13 +98,11 @@ loop:
 			nextState := -1
 			next := Email_Next[4]
 			lookup := Email_Lookup[4]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -124,13 +113,11 @@ loop:
 			nextState := -1
 			next := Email_Next[5]
 			lookup := Email_Lookup[5]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState

--- a/internal/regexp/benchmark/generated/ipv4.go
+++ b/internal/regexp/benchmark/generated/ipv4.go
@@ -1,7 +1,6 @@
 package benchmarkGenerated
 
 import (
-	"slices"
 	"unicode/utf8"
 )
 
@@ -79,13 +78,11 @@ loop:
 			nextState := -1
 			next := IPv4_Next[0]
 			lookup := IPv4_Lookup[0]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -96,13 +93,11 @@ loop:
 			nextState := -1
 			next := IPv4_Next[1]
 			lookup := IPv4_Lookup[1]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -113,13 +108,11 @@ loop:
 			nextState := -1
 			next := IPv4_Next[2]
 			lookup := IPv4_Lookup[2]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -130,13 +123,11 @@ loop:
 			nextState := -1
 			next := IPv4_Next[3]
 			lookup := IPv4_Lookup[3]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -147,13 +138,11 @@ loop:
 			nextState := -1
 			next := IPv4_Next[4]
 			lookup := IPv4_Lookup[4]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -164,13 +153,11 @@ loop:
 			nextState := -1
 			next := IPv4_Next[5]
 			lookup := IPv4_Lookup[5]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -181,13 +168,11 @@ loop:
 			nextState := -1
 			next := IPv4_Next[6]
 			lookup := IPv4_Lookup[6]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -198,13 +183,11 @@ loop:
 			nextState := -1
 			next := IPv4_Next[7]
 			lookup := IPv4_Lookup[7]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -215,13 +198,11 @@ loop:
 			nextState := -1
 			next := IPv4_Next[8]
 			lookup := IPv4_Lookup[8]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -232,13 +213,11 @@ loop:
 			nextState := -1
 			next := IPv4_Next[9]
 			lookup := IPv4_Lookup[9]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -249,13 +228,11 @@ loop:
 			nextState := -1
 			next := IPv4_Next[10]
 			lookup := IPv4_Lookup[10]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -266,13 +243,11 @@ loop:
 			nextState := -1
 			next := IPv4_Next[11]
 			lookup := IPv4_Lookup[11]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -283,13 +258,11 @@ loop:
 			nextState := -1
 			next := IPv4_Next[12]
 			lookup := IPv4_Lookup[12]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -300,13 +273,11 @@ loop:
 			nextState := -1
 			next := IPv4_Next[13]
 			lookup := IPv4_Lookup[13]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -317,13 +288,11 @@ loop:
 			nextState := -1
 			next := IPv4_Next[14]
 			lookup := IPv4_Lookup[14]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -334,13 +303,11 @@ loop:
 			nextState := -1
 			next := IPv4_Next[15]
 			lookup := IPv4_Lookup[15]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -351,13 +318,11 @@ loop:
 			nextState := -1
 			next := IPv4_Next[16]
 			lookup := IPv4_Lookup[16]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -368,13 +333,11 @@ loop:
 			nextState := -1
 			next := IPv4_Next[17]
 			lookup := IPv4_Lookup[17]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -385,13 +348,11 @@ loop:
 			nextState := -1
 			next := IPv4_Next[18]
 			lookup := IPv4_Lookup[18]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -402,13 +363,11 @@ loop:
 			nextState := -1
 			next := IPv4_Next[19]
 			lookup := IPv4_Lookup[19]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -419,13 +378,11 @@ loop:
 			nextState := -1
 			next := IPv4_Next[20]
 			lookup := IPv4_Lookup[20]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -436,13 +393,11 @@ loop:
 			nextState := -1
 			next := IPv4_Next[21]
 			lookup := IPv4_Lookup[21]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -453,13 +408,11 @@ loop:
 			nextState := -1
 			next := IPv4_Next[22]
 			lookup := IPv4_Lookup[22]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -470,13 +423,11 @@ loop:
 			nextState := -1
 			next := IPv4_Next[23]
 			lookup := IPv4_Lookup[23]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState

--- a/internal/regexp/benchmark/generated/url.go
+++ b/internal/regexp/benchmark/generated/url.go
@@ -1,7 +1,6 @@
 package benchmarkGenerated
 
 import (
-	"slices"
 	"unicode/utf8"
 )
 
@@ -51,13 +50,11 @@ loop:
 			nextState := -1
 			next := URL_Next[0]
 			lookup := URL_Lookup[0]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -68,13 +65,11 @@ loop:
 			nextState := -1
 			next := URL_Next[1]
 			lookup := URL_Lookup[1]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -85,13 +80,11 @@ loop:
 			nextState := -1
 			next := URL_Next[2]
 			lookup := URL_Lookup[2]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -102,13 +95,11 @@ loop:
 			nextState := -1
 			next := URL_Next[3]
 			lookup := URL_Lookup[3]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -119,13 +110,11 @@ loop:
 			nextState := -1
 			next := URL_Next[4]
 			lookup := URL_Lookup[4]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -136,13 +125,11 @@ loop:
 			nextState := -1
 			next := URL_Next[5]
 			lookup := URL_Lookup[5]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -153,13 +140,11 @@ loop:
 			nextState := -1
 			next := URL_Next[6]
 			lookup := URL_Lookup[6]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -170,13 +155,11 @@ loop:
 			nextState := -1
 			next := URL_Next[7]
 			lookup := URL_Lookup[7]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -187,13 +170,11 @@ loop:
 			nextState := -1
 			next := URL_Next[8]
 			lookup := URL_Lookup[8]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -204,13 +185,11 @@ loop:
 			nextState := -1
 			next := URL_Next[9]
 			lookup := URL_Lookup[9]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -221,13 +200,11 @@ loop:
 			nextState := -1
 			next := URL_Next[10]
 			lookup := URL_Lookup[10]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState
@@ -238,13 +215,11 @@ loop:
 			nextState := -1
 			next := URL_Next[11]
 			lookup := URL_Lookup[11]
-			searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {
-				lo := rune(lowHigh & 0xFFFFFFFF)
-				hi := rune(lowHigh >> 32)
-				return lo <= r && r <= hi
-			})
-			if searchIndex > -1 {
-				nextState = next[searchIndex]
+			for i, lowHigh := range lookup {
+				if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+					nextState = next[i]
+					break
+				}
 			}
 			if nextState > -1 {
 				state = nextState

--- a/internal/regexp/regexp_generator.go
+++ b/internal/regexp/regexp_generator.go
@@ -42,17 +42,14 @@ func GenerateTransitionsUsingBinarySearch(bySource *automatons.RuneRangeTargetsM
 	n.AppendLine(fmt.Sprintf("lookup := %s_Lookup[%d]", tokenName, source))
 
 	if len(transitions) < 16 {
-		imports["slices"] = true
-		n.AppendLine("searchIndex := slices.IndexFunc(lookup, func(lowHigh int64) bool {")
+		n.AppendLine("for i, lowHigh := range lookup {")
 		n.Indent(func(n generator.Node) {
-			n.AppendLine("lo := rune(lowHigh & 0xFFFFFFFF)")
-			n.AppendLine("hi := rune(lowHigh >> 32)")
-			n.AppendLine("return lo <= r && r <= hi")
-		})
-		n.AppendLine("})")
-		n.AppendLine("if searchIndex > -1 {")
-		n.Indent(func(n generator.Node) {
-			n.AppendLine("nextState = next[searchIndex]")
+			n.AppendLine("if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {")
+			n.Indent(func(n generator.Node) {
+				n.AppendLine("nextState = next[i]")
+				n.AppendLine("break")
+			})
+			n.AppendLine("}")
 		})
 		n.AppendLine("}")
 	} else {

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -6,42 +6,52 @@
 package lexer
 
 import (
+	"math"
+	"sync/atomic"
 	"unicode/utf8"
 
 	core "typefox.dev/fastbelt"
 )
 
 type LexerResult struct {
-	Tokens   []*core.Token
-	Comments []*core.Token
+	Tokens   []core.Token
+	Comments []core.Token
 	Errors   []*core.LexerError
-	Groups   map[int][]*core.Token
+	Groups   map[int][]core.Token
 }
 
 type Lexer interface {
 	Lex(input string) *LexerResult
 }
 
+// Allocate a new token every ~5 characters on average
+// This average is updated after lexing to adapt to the actual language
+const defaultTokenRatio = 1.0 / 5.0
+
 type DefaultLexer struct {
 	tokenTypes []*core.TokenType
 	tokenMap   [][]*core.TokenType
+	// running exponential moving average of tokens-per-byte
+	// stores a float64 as uint64 bits for atomic access
+	avgRatio atomic.Uint64
 }
 
 func (l *DefaultLexer) Lex(input string) *LexerResult {
 	length := len(input)
-	tokens := make([]*core.Token, 0, length/5) // rough estimate
-	comments := make([]*core.Token, 0)
+	ratio := math.Float64frombits(l.avgRatio.Load())
+	if ratio == 0 {
+		ratio = defaultTokenRatio
+	}
+	tokens := make([]core.Token, 0, int(float64(length)*ratio*1.1))
+	comments := make([]core.Token, 0)
 	errors := make([]*core.LexerError, 0)
-	groups := make(map[int][]*core.Token)
+	var groups map[int][]core.Token
 
 	var offset, line, column int
 	line = 0
 	column = 0
 	for offset < length {
-		r, size := rune(input[offset]), 1
-		if r >= utf8.RuneSelf {
-			r, size = utf8.DecodeRuneInString(input[offset:])
-		}
+		r, size := utf8.DecodeRuneInString(input[offset:])
 		mapIndex := int(r) % maxChar
 		candidates := l.tokenMap[mapIndex]
 		longestMatch := 0
@@ -95,6 +105,19 @@ func (l *DefaultLexer) Lex(input string) *LexerResult {
 					startColumn,
 					column,
 				))
+			default:
+				if groups == nil {
+					groups = make(map[int][]core.Token)
+				}
+				groups[longestType.Group] = append(groups[longestType.Group], core.NewToken(
+					longestType,
+					input[offset:end],
+					offset, end,
+					startLine,
+					line,
+					startColumn,
+					column,
+				))
 			}
 		} else {
 			errors = append(errors, core.NewLexerError(
@@ -108,6 +131,16 @@ func (l *DefaultLexer) Lex(input string) *LexerResult {
 			))
 		}
 		offset = end
+	}
+
+	if length > 0 {
+		// Update the average tokens-per-byte
+		actual := float64(len(tokens)) / float64(length)
+		prev := math.Float64frombits(l.avgRatio.Load())
+		if prev == 0 {
+			prev = defaultTokenRatio
+		}
+		l.avgRatio.Store(math.Float64bits(prev*0.9 + actual*0.1))
 	}
 
 	return &LexerResult{

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -20,12 +20,10 @@ type ParseResult struct {
 }
 
 type ParserState struct {
-	Tokens []*core.Token
+	Tokens []core.Token
 	Length int
 	Index  int
 	State  int
-
-	next *core.Token
 	// Indicates whether a parsing error has occurred
 	// and the parser is in error recovery mode.
 	// The parser will not consume any more tokens while in error mode.
@@ -48,17 +46,12 @@ type LookaheadPath []int
 type LookaheadOption []LookaheadPath
 type LLkLookahead []LookaheadOption
 
-func NewParserState(tokens []*core.Token) *ParserState {
-	var next *core.Token
-	if len(tokens) > 0 {
-		next = tokens[0]
-	}
+func NewParserState(tokens []core.Token) *ParserState {
 	return &ParserState{
 		Tokens:  tokens,
 		Length:  len(tokens),
 		Index:   0,
 		State:   0,
-		next:    next,
 		inError: false,
 		errors:  []*core.ParserError{},
 	}
@@ -69,7 +62,7 @@ func (p *ParserState) LA(offset int) *core.Token {
 	if pos < 0 || pos >= p.Length || p.inError {
 		return nil
 	}
-	return p.Tokens[pos]
+	return &p.Tokens[pos]
 }
 
 func (p *ParserState) LAId(offset int) int {
@@ -84,7 +77,7 @@ func (p *ParserState) Consume(tokenType int) *core.Token {
 	if p.inError {
 		return nil
 	}
-	current := p.next
+	current := p.LA(1)
 	if current == nil {
 		// EOF reached
 		p.appendError("Unexpected end of input.", nil)
@@ -96,11 +89,6 @@ func (p *ParserState) Consume(tokenType int) *core.Token {
 		return nil
 	}
 	p.Index++
-	if p.Index < p.Length {
-		p.next = p.Tokens[p.Index]
-	} else {
-		p.next = nil
-	}
 	return current
 }
 

--- a/token.go
+++ b/token.go
@@ -64,8 +64,8 @@ type Token struct {
 	Kind    int
 }
 
-func NewToken(tokenType *TokenType, image string, startOffset, endOffset, startLine, endLine, startColumn, endColumn int) *Token {
-	return &Token{
+func NewToken(tokenType *TokenType, image string, startOffset, endOffset, startLine, endLine, startColumn, endColumn int) Token {
+	return Token{
 		Type:  tokenType,
 		Image: image,
 		TextSegment: TextSegment{
@@ -118,7 +118,7 @@ func (t *Token) Owner() AstNode {
 	return t.Element
 }
 
-type TokenSlice []*Token
+type TokenSlice []Token
 
 // Searches for the token that contains the given offset.
 // Expects that the tokens are sorted by their offsets to perform a binary search.
@@ -132,7 +132,7 @@ func (ts TokenSlice) SearchOffset(offset int) *Token {
 		} else if offset >= int(token.TextSegment.Indices.End) {
 			low = mid + 1
 		} else {
-			return token
+			return &token
 		}
 	}
 	return nil


### PR DESCRIPTION
Performs some minor and a major performance optimizations:
1. (major) The `TokenSlice` uses the `Token` struct directly instead of using a pointer. This improves lexing performance by ~40%
2. (minor) Adds a running tokens-per-byte average to the lexer. This ensures (1) that we rarely try to increase the slice capacity and (2) keep the capacity as low as possible. Improves performance by ~3%.
3. (minor) changes the lookup from `slices.IndexFunc` to a custom loop. Does not influence performance - it seems like the Go compiler was able to inline the function call. However, this still makes everything easier to read.
4. (minor) Do not put the utf8 conversion behind a conditional. Improves performance by 3%.