### PR TITLE
Fix ATN generation for composite rules

### DIFF
--- a/internal/atn/atn.go
+++ b/internal/atn/atn.go
@@ -164,10 +164,7 @@ func convertRuleCall(
 	lookaheadName := rb.GetLookaheadNameByElement(rc)
 
 	switch typed := rule.(type) {
-	case grammar.CompositeRule:
-		handle := rb.RuleRef(typed)
-		return wrapWithCardinality(rb, handle, cardinality, lookaheadName), nil
-	case grammar.ParserRule:
+	case grammar.AbstractRuleWithBody:
 		handle := rb.RuleRef(typed)
 		return wrapWithCardinality(rb, handle, cardinality, lookaheadName), nil
 	case grammar.Token:

--- a/internal/atn/atn.go
+++ b/internal/atn/atn.go
@@ -5,6 +5,7 @@
 package atn
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 
@@ -13,19 +14,26 @@ import (
 	"typefox.dev/fastbelt/parser"
 )
 
-func CreateATN(grammr grammar.Grammar, tokenTypeIds map[string]int) (*ATN, map[string]*grammar.ParserRule) {
+func CreateATN(grammr grammar.Grammar, tokenTypeIds map[string]int) (*ATN, map[string]grammar.AbstractRuleWithBody) {
 	lookaheadNames := ComputeLookaheadNames(grammr)
-	byName := map[string]*grammar.ParserRule{}
+	byName := map[string]grammar.AbstractRuleWithBody{}
 	for _, gr := range grammr.Rules() {
-		byName[gr.Name()] = &gr
+		byName[gr.Name()] = gr
 	}
 	builder := NewATNBuilder(lookaheadNames, tokenTypeIds, byName)
 
-	entries := map[grammar.ParserRule]ATNRuleBuilder{}
+	entries := map[grammar.AbstractRuleWithBody]ATNRuleBuilder{}
+	allRules := []grammar.AbstractRuleWithBody{}
 	for _, gr := range grammr.Rules() {
-		entries[gr] = builder.DeclareRule(&gr)
+		allRules = append(allRules, gr)
 	}
-	for _, gr := range grammr.Rules() {
+	for _, gr := range grammr.Composites() {
+		allRules = append(allRules, gr)
+	}
+	for _, gr := range allRules {
+		entries[gr] = builder.DeclareRule(gr)
+	}
+	for _, gr := range allRules {
 		ruleBuilder := entries[gr]
 		handle, err := convertElement(ruleBuilder, gr.Body())
 		if err != nil {
@@ -152,27 +160,28 @@ func convertRuleCall(
 	rc grammar.RuleCall,
 	cardinality string,
 ) (*ATNHandle, error) {
-	name := rc.Rule().Text()
+	rule := rc.Rule().Ref(context.Background())
 	lookaheadName := rb.GetLookaheadNameByElement(rc)
 
-	if rule := rb.GetRuleByName(name); rule != nil {
-		handle := rb.RuleRef(rule)
+	switch typed := rule.(type) {
+	case grammar.CompositeRule:
+		handle := rb.RuleRef(typed)
 		return wrapWithCardinality(rb, handle, cardinality, lookaheadName), nil
+	case grammar.ParserRule:
+		handle := rb.RuleRef(typed)
+		return wrapWithCardinality(rb, handle, cardinality, lookaheadName), nil
+	case grammar.Token:
+		id := rb.GetTokenTypeByName(typed.Name())
+		termHandle := rb.TokenRef(id)
+		return wrapWithCardinality(rb, termHandle, cardinality, lookaheadName), nil
 	}
-
-	// Otherwise treat it as a terminal (lexer rule reference).
-	id := rb.GetTokenTypeByName(name)
-	termHandle := rb.TokenRef(id)
-	return wrapWithCardinality(rb, termHandle, cardinality, lookaheadName), nil
+	panic(fmt.Sprintf("unexpected rule type %T", rule))
 }
 
 func convertCrossRef(
 	rb ATNRuleBuilder,
 	cr grammar.CrossRef,
 ) (*ATNHandle, error) {
-	if cr.Rule() == nil || cr.Rule().Rule() == nil || cr.Rule().Rule().Text() == "" {
-		panic("CrossRef has no valid rule reference")
-	}
 	name := cr.Rule().Rule().Text()
 	id := rb.GetTokenTypeByName(name)
 	termHandle := rb.TokenRef(id)

--- a/internal/atn/atn_test.go
+++ b/internal/atn/atn_test.go
@@ -167,3 +167,12 @@ func TestCompositeRuleWithAlternativesRef(t *testing.T) {
 	`, false)
 	RequireATNRecognizes(t, atn, rules, tokenTypes, "Start", []string{"ID"}, 1)
 }
+
+func TestCompositeRuleWithMultipleTokens(t *testing.T) {
+	atn, rules, tokenTypes := FixtureATN(t, `
+		interface Start { Name composite }
+		composite FQN: ID ("." ID)*;
+		Start: Name=FQN;
+	`, false)
+	RequireATNRecognizes(t, atn, rules, tokenTypes, "Start", []string{"ID"}, 1)
+}

--- a/internal/atn/atn_test.go
+++ b/internal/atn/atn_test.go
@@ -149,3 +149,21 @@ func TestThreePaths(t *testing.T) {
 	`, false)
 	RequireATNRecognizes(t, atn, rules, tokenTypes, "Start", []string{"ID"}, 3)
 }
+
+func TestCompositeRuleRef(t *testing.T) {
+	atn, rules, tokenTypes := FixtureATN(t, `
+		interface Start { Name string }
+		composite SimpleComposite: ID;
+		Start: Name=SimpleComposite;
+	`, false)
+	RequireATNRecognizes(t, atn, rules, tokenTypes, "Start", []string{"ID"}, 1)
+}
+
+func TestCompositeRuleWithAlternativesRef(t *testing.T) {
+	atn, rules, tokenTypes := FixtureATN(t, `
+		interface Start { Name string }
+		composite IDOrNumber: ID | NUMBER;
+		Start: Name=IDOrNumber;
+	`, false)
+	RequireATNRecognizes(t, atn, rules, tokenTypes, "Start", []string{"ID"}, 1)
+}

--- a/internal/atn/atn_test.go
+++ b/internal/atn/atn_test.go
@@ -174,5 +174,7 @@ func TestCompositeRuleWithMultipleTokens(t *testing.T) {
 		composite FQN: ID ("." ID)*;
 		Start: Name=FQN;
 	`, false)
-	RequireATNRecognizes(t, atn, rules, tokenTypes, "Start", []string{"ID"}, 1)
+	RequireATNRecognizes(t, atn, rules, tokenTypes, "Start", []string{
+		"ID", "\".\"", "ID", "\".\"", "ID",
+	}, 1)
 }

--- a/internal/atn/builder.go
+++ b/internal/atn/builder.go
@@ -20,7 +20,7 @@ type ATNRuleBuilder interface {
 	MakeAlternatives(lookaheadName string, start *ATNState, alts []*ATNHandle) *ATNHandle
 	MakeConcatenation(alts []*ATNHandle) *ATNHandle
 	TokenRef(tokenTypeId int) *ATNHandle
-	RuleRef(otherRule *grammar.ParserRule) *ATNHandle
+	RuleRef(otherRule grammar.AbstractRuleWithBody) *ATNHandle
 
 	NewEpsilonTransition(source *ATNState, target *ATNState)
 
@@ -28,32 +28,32 @@ type ATNRuleBuilder interface {
 	RemoveState(state *ATNState)
 
 	GetTokenTypeByName(name string) int
-	GetRuleByName(name string) *grammar.ParserRule
+	GetRuleByName(name string) grammar.AbstractRuleWithBody
 	GetLookaheadNameByElement(el grammar.Element) string
 }
 
 type ATNBuilder interface {
-	DeclareRule(rule *grammar.ParserRule) ATNRuleBuilder
+	DeclareRule(rule grammar.AbstractRuleWithBody) ATNRuleBuilder
 	Build() *ATN
 }
 
 type ATNBuilderImpl struct {
-	rules        map[*grammar.ParserRule]*ATNRuleBuilderImpl
+	rules        map[grammar.AbstractRuleWithBody]*ATNRuleBuilderImpl
 	atn          *ATN
 	names        map[grammar.Element]string
 	tokenTypeIds map[string]int
-	rulesByName  map[string]*grammar.ParserRule
+	rulesByName  map[string]grammar.AbstractRuleWithBody
 }
 
-func NewATNBuilder(names map[grammar.Element]string, tokenTypeIds map[string]int, rulesByName map[string]*grammar.ParserRule) *ATNBuilderImpl {
+func NewATNBuilder(names map[grammar.Element]string, tokenTypeIds map[string]int, rulesByName map[string]grammar.AbstractRuleWithBody) *ATNBuilderImpl {
 	return &ATNBuilderImpl{
-		rules: map[*grammar.ParserRule]*ATNRuleBuilderImpl{},
+		rules: map[grammar.AbstractRuleWithBody]*ATNRuleBuilderImpl{},
 		atn: &ATN{
 			DecisionMap:      map[string]*ATNState{},
 			States:           []*ATNState{},
 			DecisionStates:   []*ATNState{},
-			RuleToStartState: map[grammar.ParserRule]*ATNState{},
-			RuleToStopState:  map[grammar.ParserRule]*ATNState{},
+			RuleToStartState: map[grammar.AbstractRuleWithBody]*ATNState{},
+			RuleToStopState:  map[grammar.AbstractRuleWithBody]*ATNState{},
 		},
 		names:        names,
 		tokenTypeIds: tokenTypeIds,
@@ -68,7 +68,7 @@ func (rb *ATNRuleBuilderImpl) GetTokenTypeByName(name string) int {
 	return -1
 }
 
-func (rb *ATNRuleBuilderImpl) GetRuleByName(name string) *grammar.ParserRule {
+func (rb *ATNRuleBuilderImpl) GetRuleByName(name string) grammar.AbstractRuleWithBody {
 	if rule, ok := rb.parent.rulesByName[name]; ok {
 		return rule
 	}
@@ -82,13 +82,13 @@ func (rb *ATNRuleBuilderImpl) GetLookaheadNameByElement(el grammar.Element) stri
 	panic("no lookahead name found for element")
 }
 
-func (b *ATNBuilderImpl) DeclareRule(rule *grammar.ParserRule) ATNRuleBuilder {
+func (b *ATNBuilderImpl) DeclareRule(rule grammar.AbstractRuleWithBody) ATNRuleBuilder {
 	left := newATNState(b.atn, rule, parser.ATNRuleStart)
 	right := newATNState(b.atn, rule, parser.ATNRuleStop)
 	ruleBuilder := NewATNRuleBuilder(b, rule, &ATNHandle{Left: left, Right: right})
 	b.rules[rule] = ruleBuilder
-	b.atn.RuleToStartState[*rule] = left
-	b.atn.RuleToStopState[*rule] = right
+	b.atn.RuleToStartState[rule] = left
+	b.atn.RuleToStopState[rule] = right
 	return ruleBuilder
 }
 
@@ -98,11 +98,11 @@ func (b *ATNBuilderImpl) Build() *ATN {
 
 type ATNRuleBuilderImpl struct {
 	parent *ATNBuilderImpl
-	rule   *grammar.ParserRule
+	rule   grammar.AbstractRuleWithBody
 	handle *ATNHandle
 }
 
-func NewATNRuleBuilder(parent *ATNBuilderImpl, rule *grammar.ParserRule, handle *ATNHandle) *ATNRuleBuilderImpl {
+func NewATNRuleBuilder(parent *ATNBuilderImpl, rule grammar.AbstractRuleWithBody, handle *ATNHandle) *ATNRuleBuilderImpl {
 	return &ATNRuleBuilderImpl{
 		parent: parent,
 		rule:   rule,
@@ -238,8 +238,8 @@ func (rb *ATNRuleBuilderImpl) TokenRef(tokenTypeId int) *ATNHandle {
 	return &ATNHandle{Left: left, Right: right}
 }
 
-func (rb *ATNRuleBuilderImpl) RuleRef(otherRule *grammar.ParserRule) *ATNHandle {
-	ruleStart := rb.parent.atn.RuleToStartState[*otherRule]
+func (rb *ATNRuleBuilderImpl) RuleRef(otherRule grammar.AbstractRuleWithBody) *ATNHandle {
+	ruleStart := rb.parent.atn.RuleToStartState[otherRule]
 	left := rb.NewState(parser.ATNBasic)
 	right := rb.NewState(parser.ATNBasic)
 	addTransition(left, &RuleTransition{
@@ -265,7 +265,7 @@ func (rb *ATNRuleBuilderImpl) RemoveState(state *ATNState) {
 	}
 }
 
-func newATNState(atn *ATN, rule *grammar.ParserRule, typ parser.ATNStateType) *ATNState {
+func newATNState(atn *ATN, rule grammar.AbstractRuleWithBody, typ parser.ATNStateType) *ATNState {
 	s := &ATNState{
 		ATN:         atn,
 		Production:  nil,

--- a/internal/atn/fixture.go
+++ b/internal/atn/fixture.go
@@ -25,12 +25,14 @@ var TokenTypeIds = map[string]int{
 	"ID":     0,
 	"NUMBER": 1,
 	"WS":     2,
+	"\".\"":  3,
 }
 
 var TokenTypeNames = []string{
 	0: "ID",
 	1: "NUMBER",
 	2: "WS",
+	3: "Dot",
 }
 
 func FixtureATN(t *testing.T, ruleText string, emitATNMarkdown bool) (*ATN, map[string]grammar.AbstractRuleWithBody, map[string]int) {

--- a/internal/atn/fixture.go
+++ b/internal/atn/fixture.go
@@ -33,7 +33,7 @@ var TokenTypeNames = []string{
 	2: "WS",
 }
 
-func FixtureATN(t *testing.T, ruleText string, emitATNMarkdown bool) (*ATN, map[string]*grammar.ParserRule, map[string]int) {
+func FixtureATN(t *testing.T, ruleText string, emitATNMarkdown bool) (*ATN, map[string]grammar.AbstractRuleWithBody, map[string]int) {
 	t.Helper()
 	f := test.New(t, grammar.CreateServices())
 	text := GrammarTemplate(ruleText)
@@ -50,9 +50,9 @@ func FixtureATN(t *testing.T, ruleText string, emitATNMarkdown bool) (*ATN, map[
 	return atn, rules, TokenTypeIds
 }
 
-func RequireATNRecognizes(t *testing.T, atn *ATN, rules map[string]*grammar.ParserRule, tokenTypes map[string]int, start string, inputTokenTypes []string, expected int) {
+func RequireATNRecognizes(t *testing.T, atn *ATN, rules map[string]grammar.AbstractRuleWithBody, tokenTypes map[string]int, start string, inputTokenTypes []string, expected int) {
 	t.Helper()
-	startRule := *rules[start]
+	startRule := rules[start]
 	inputTokenTypeIds := make([]int, len(inputTokenTypes))
 	for i, tokenType := range inputTokenTypes {
 		id := tokenTypes[tokenType]
@@ -92,7 +92,7 @@ func (ctx parserContext) Next(atnState *ATNState) parserContext {
 	}
 }
 
-func recognizeATN(atn *ATN, startRule grammar.ParserRule, inputTokenTypeIds []int) int {
+func recognizeATN(atn *ATN, startRule grammar.AbstractRuleWithBody, inputTokenTypeIds []int) int {
 	recognitionContext := recognitionContext{
 		inputTokenTypeIds: inputTokenTypeIds,
 		position:          0,
@@ -108,11 +108,11 @@ func recognizeATN(atn *ATN, startRule grammar.ParserRule, inputTokenTypeIds []in
 	return len(finished)
 }
 
-func recognizeParserRule(atn *ATN, rule grammar.ParserRule, context recognitionContext) []parserContext {
+func recognizeParserRule(atn *ATN, rule grammar.AbstractRuleWithBody, context recognitionContext) []parserContext {
 	END := atn.RuleToStopState[rule]
 
 	contextQueue := []parserContext{
-		parserContext{
+		{
 			recognitionContext: context,
 			atnState:           atn.RuleToStartState[rule],
 		},
@@ -132,7 +132,7 @@ func recognizeParserRule(atn *ATN, rule grammar.ParserRule, context recognitionC
 					contextQueue = append(contextQueue, context.ReadInput().Next(atomTransition.Target()))
 				}
 			} else if ruleTransition, ok := transition.(*RuleTransition); ok {
-				nextContext := recognizeParserRule(atn, *ruleTransition.Rule, context.recognitionContext)
+				nextContext := recognizeParserRule(atn, ruleTransition.Rule, context.recognitionContext)
 				for _, nextCtx := range nextContext {
 					contextQueue = append(contextQueue, nextCtx.Next(ruleTransition.FollowState))
 				}

--- a/internal/atn/md_emit.go
+++ b/internal/atn/md_emit.go
@@ -27,7 +27,7 @@ func EmitMarkdownSource(pkgName string, atn *ATN, tokenTypeNames []string) codeg
 	ruleOrder := []string{}
 	ruleStates := map[string][]*ATNState{}
 	for _, s := range atn.States {
-		ruleName := (*s.Rule).Name()
+		ruleName := s.Rule.Name()
 		if _, seen := ruleStates[ruleName]; !seen {
 			ruleOrder = append(ruleOrder, ruleName)
 		}
@@ -57,7 +57,7 @@ func EmitMarkdownSource(pkgName string, atn *ATN, tokenTypeNames []string) codeg
 					tokenName := strings.ReplaceAll(tokenTypeNames[tr.TokenTypeId], "\"", "&quot;")
 					n.AppendLine("    q", src, " -->|\"tok(", tokenName, ")\"| q", fmt.Sprintf("%d", idx[tr.Target()]))
 				case *RuleTransition:
-					n.AppendLine("    q", src, " -.->|\"[", (*tr.Target().Rule).Name(), "]\"| q", fmt.Sprintf("%d", idx[tr.FollowState]))
+					n.AppendLine("    q", src, " -.->|\"[", tr.Target().Rule.Name(), "]\"| q", fmt.Sprintf("%d", idx[tr.FollowState]))
 				}
 			}
 		}

--- a/internal/atn/types.go
+++ b/internal/atn/types.go
@@ -15,7 +15,7 @@ type ATNState struct {
 	ATN                    *ATN
 	Production             grammar.Element // nil for rule start/stop
 	StateNumber            int
-	Rule                   *grammar.ParserRule
+	Rule                   grammar.AbstractRuleWithBody
 	EpsilonOnlyTransitions bool
 	Transitions            []Transition
 	Type                   parser.ATNStateType
@@ -39,8 +39,8 @@ type ATN struct {
 	DecisionMap      map[string]*ATNState
 	States           []*ATNState
 	DecisionStates   []*ATNState
-	RuleToStartState map[grammar.ParserRule]*ATNState
-	RuleToStopState  map[grammar.ParserRule]*ATNState
+	RuleToStartState map[grammar.AbstractRuleWithBody]*ATNState
+	RuleToStopState  map[grammar.AbstractRuleWithBody]*ATNState
 }
 
 // Transition is the interface implemented by all ATN transitions.
@@ -74,7 +74,7 @@ func (t *EpsilonTransition) SetTarget(target *ATNState) { t.TargetState = target
 // RuleTransition enters a sub-rule and returns to FollowState.
 type RuleTransition struct {
 	TargetState *ATNState // the rule's RuleStartState
-	Rule        *grammar.ParserRule
+	Rule        grammar.AbstractRuleWithBody
 	FollowState *ATNState
 }
 


### PR DESCRIPTION
Closes https://github.com/TypeFox/fastbelt/issues/72 and closes https://github.com/TypeFox/fastbelt/pull/71.

Simply adds support to composite types in the ATN generation by using the common `AbstractRuleWithBody` type.

Also removes a bunch of unnecessary interface-pointers.