### PR TITLE
Match lazy regexp correctly

### DIFF
--- a/examples/statemachine/lexer_gen.go
+++ b/examples/statemachine/lexer_gen.go
@@ -353,7 +353,7 @@ var Token_ML_COMMENT = core.NewTokenType(
 	Token_ML_COMMENT_Idx,
 	"ML_COMMENT",
 	"ML_COMMENT",
-	core.SkippedGroup,
+	core.CommentGroup,
 	core.TokenKindToken,
 	0,
 	false,
@@ -442,6 +442,21 @@ var Token_ML_COMMENT = core.NewTokenType(
 				} else {
 					break loop
 				}
+			case 5:
+				nextState := -1
+				next := Token_ML_COMMENT_Next[5]
+				lookup := Token_ML_COMMENT_Lookup[5]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
+				}
+				if nextState > -1 {
+					state = nextState
+				} else {
+					break loop
+				}
 			default:
 				break loop
 			}
@@ -460,15 +475,17 @@ var Token_ML_COMMENT_Lookup = [][]int64{
 	{0x0000002900000000, 0x0000002A0000002A, 0x0010FFFF0000002B},
 	{0x0000002900000000, 0x0000002A0000002A, 0x0000002E0000002B, 0x0000002F0000002F, 0x0010FFFF00000030},
 	{0x0000002900000000, 0x0000002A0000002A, 0x0010FFFF0000002B},
+	{0x0000002900000000, 0x0000002A0000002A, 0x0010FFFF0000002B},
 }
 var Token_ML_COMMENT_Next = [][]int{
 	{1},
 	{2},
 	{2, 3, 2},
 	{2, 3, 2, 4, 2},
-	{2, 3, 2},
+	{5, 5, 5},
+	{5, 5, 5},
 }
-var Token_ML_COMMENT_Accepting = [5]bool{
+var Token_ML_COMMENT_Accepting = [6]bool{
 	4: true,
 }
 

--- a/examples/statemachine/statemachine.fb
+++ b/examples/statemachine/statemachine.fb
@@ -57,5 +57,5 @@ Transition returns Transition:
 token ID: /[_a-zA-Z][\w_]*/;
 
 hidden token WS: /\s+/;
-hidden token ML_COMMENT: /\/\*[\s\S]*?\*\//;
+comment token ML_COMMENT: /\/\*[\s\S]*?\*\//;
 hidden token SL_COMMENT: /\/\/[^\n\r]*/;

--- a/examples/statemachine/statemachine_test.go
+++ b/examples/statemachine/statemachine_test.go
@@ -44,6 +44,47 @@ func TestParsing(t *testing.T) {
 	doc.AssertState(fastbelt.DocStateLinked)
 }
 
+// TestMultilineCommentsBetweenContent guards against the regression where
+// the ML_COMMENT lexer regex `\/\*[\s\S]*?\*\/` was treated greedily.
+func TestMultilineCommentsBetweenContent(t *testing.T) {
+	const input = `
+/* header 
+ * comment1
+ * comment2
+ * comment3
+ */
+statemachine LightSwitch
+
+events
+  flick
+
+commands
+  turnOn
+  turnOff
+
+initialState off
+
+/* 
+ * between
+ * states
+ */
+state off
+  actions { turnOff }
+  flick => on
+end
+
+state on
+  actions { turnOn }
+  flick => off
+end
+`
+	f := test.New(t, CreateServices())
+	doc := f.Parse(input).AssertNoErrors()
+	sm := test.MustFindNode[Statemachine](doc)
+	assert.Equal(t, "LightSwitch", sm.Name())
+	assert.Len(t, sm.States(), 2)
+}
+
 func TestAST(t *testing.T) {
 	f := test.New(t, CreateServices())
 	doc := f.Parse(lightSwitch).AssertNoErrors()

--- a/internal/automatons/construct.go
+++ b/internal/automatons/construct.go
@@ -200,3 +200,23 @@ func (ck *ConstructionKit) Intersect(a, b *NFA) *NFA {
 	notAOrB := ck.Alternate(notA, notB)
 	return ck.Complement(notAOrB)
 }
+
+// LazyMatch returns the NFA matching the shortest string of the form
+// body{bodyMin,bodyMax} followed by tail. bodyMax == -1 means unbounded.
+//
+// This is the non-greedy equivalent of Concat(Repeat(body, bodyMin, bodyMax), tail).
+// The construction is:
+//
+//	greedy = repeat(body) tail
+//	result = greedy intersect complement(greedy ".+")
+//
+// A string is a minimal match exactly when it is in greedy and no proper
+// prefix of it is in greedy (otherwise the prefix-followed-by-more form would
+// place it in greedy ".+").
+func (ck *ConstructionKit) LazyMatch(body *NFA, bodyMin, bodyMax int, tail *NFA) *NFA {
+	greedy := ck.Concat(ck.Repeat(body, bodyMin, bodyMax), tail)
+	anyChar := ck.Consume(NewRuneSetFull())
+	anyPlus := ck.Repeat(anyChar, 1, -1)
+	extended := ck.Concat(greedy, anyPlus)
+	return ck.Intersect(greedy, ck.Complement(extended))
+}

--- a/internal/grammar/grammar.fb
+++ b/internal/grammar/grammar.fb
@@ -154,7 +154,7 @@ CompositeElement returns Element: (Keyword | RuleCall | "(" CompositeAlternative
 
 // Move comments in front of RegexLiteral
 comment token SL_COMMENT: /\/\/[^\r\n]*/;
-comment token ML_COMMENT: /\/\*[^*]*\*\//;
+comment token ML_COMMENT: /\/\*[\s\S]*?\*\//;
 
 token StringLiteral: /"[^"]*"/;
 token ID: /[a-zA-Z_][a-zA-Z0-9_]*/;

--- a/internal/grammar/lexer_gen.go
+++ b/internal/grammar/lexer_gen.go
@@ -727,6 +727,21 @@ var Token_ML_COMMENT = core.NewTokenType(
 				} else {
 					break loop
 				}
+			case 5:
+				nextState := -1
+				next := Token_ML_COMMENT_Next[5]
+				lookup := Token_ML_COMMENT_Lookup[5]
+				for i, lowHigh := range lookup {
+					if rune(lowHigh&0xFFFFFFFF) <= r && r <= rune(lowHigh>>32) {
+						nextState = next[i]
+						break
+					}
+				}
+				if nextState > -1 {
+					state = nextState
+				} else {
+					break loop
+				}
 			default:
 				break loop
 			}
@@ -743,17 +758,19 @@ var Token_ML_COMMENT_Lookup = [][]int64{
 	{0x0000002F0000002F},
 	{0x0000002A0000002A},
 	{0x0000002900000000, 0x0000002A0000002A, 0x0010FFFF0000002B},
-	{0x0000002F0000002F},
-	{},
+	{0x0000002900000000, 0x0000002A0000002A, 0x0000002E0000002B, 0x0000002F0000002F, 0x0010FFFF00000030},
+	{0x0000002900000000, 0x0000002A0000002A, 0x0010FFFF0000002B},
+	{0x0000002900000000, 0x0000002A0000002A, 0x0010FFFF0000002B},
 }
 var Token_ML_COMMENT_Next = [][]int{
 	{1},
 	{2},
 	{2, 3, 2},
-	{4},
-	{},
+	{2, 3, 2, 4, 2},
+	{5, 5, 5},
+	{5, 5, 5},
 }
-var Token_ML_COMMENT_Accepting = [5]bool{
+var Token_ML_COMMENT_Accepting = [6]bool{
 	4: true,
 }
 

--- a/internal/regexp/regexp.go
+++ b/internal/regexp/regexp.go
@@ -108,11 +108,7 @@ func newNFAFromSyntax(op *syntax.Regexp) *automatons.NFA {
 		runeSet := automatons.NewRuneSetFull()
 		return kit.Consume(runeSet)
 	case syntax.OpConcat:
-		chain := make([]*automatons.NFA, len(op.Sub))
-		for i, sub := range op.Sub {
-			chain[i] = newNFAFromSyntax(sub)
-		}
-		return kit.Concat(chain...)
+		return buildConcat(kit, op.Sub)
 	case syntax.OpAlternate:
 		alternatives := make([]*automatons.NFA, len(op.Sub))
 		for i, sub := range op.Sub {
@@ -120,15 +116,27 @@ func newNFAFromSyntax(op *syntax.Regexp) *automatons.NFA {
 		}
 		return kit.Alternate(alternatives...)
 	case syntax.OpStar:
+		if isNonGreedy(op) {
+			panic(unsupportedLazyMsg(op))
+		}
 		nfa := newNFAFromSyntax(op.Sub[0])
 		return kit.Repeat(nfa, 0, -1)
 	case syntax.OpPlus:
+		if isNonGreedy(op) {
+			panic(unsupportedLazyMsg(op))
+		}
 		nfa := newNFAFromSyntax(op.Sub[0])
 		return kit.Repeat(nfa, 1, -1)
 	case syntax.OpQuest:
+		if isNonGreedy(op) {
+			panic(unsupportedLazyMsg(op))
+		}
 		nfa := newNFAFromSyntax(op.Sub[0])
 		return kit.Repeat(nfa, 0, 1)
 	case syntax.OpRepeat:
+		if isNonGreedy(op) {
+			panic(unsupportedLazyMsg(op))
+		}
 		nfa := newNFAFromSyntax(op.Sub[0])
 		return kit.Repeat(nfa, int(op.Min), int(op.Max))
 	case syntax.OpCapture:
@@ -156,4 +164,73 @@ func newNFAFromSyntax(op *syntax.Regexp) *automatons.NFA {
 	default:
 		panic(fmt.Sprintf("unsupported syntax operation: %v", op.Op))
 	}
+}
+
+// isNonGreedy reports whether op carries the syntax.NonGreedy flag.
+func isNonGreedy(op *syntax.Regexp) bool {
+	return op.Flags&syntax.NonGreedy != 0
+}
+
+// isLazyQuantifier reports whether op is a quantifier with the non-greedy flag set.
+func isLazyQuantifier(op *syntax.Regexp) bool {
+	switch op.Op {
+	case syntax.OpStar, syntax.OpPlus, syntax.OpQuest, syntax.OpRepeat:
+		return isNonGreedy(op)
+	}
+	return false
+}
+
+func unsupportedLazyMsg(op *syntax.Regexp) string {
+	return fmt.Sprintf("non-greedy quantifier %v is only supported when followed by a fixed tail in a concatenation", op)
+}
+
+// quantifierBounds extracts the (min, max) bounds of a quantifier op.
+// max == -1 means unbounded.
+func quantifierBounds(op *syntax.Regexp) (int, int) {
+	switch op.Op {
+	case syntax.OpStar:
+		return 0, -1
+	case syntax.OpPlus:
+		return 1, -1
+	case syntax.OpQuest:
+		return 0, 1
+	case syntax.OpRepeat:
+		return int(op.Min), int(op.Max)
+	}
+	panic(fmt.Sprintf("not a quantifier: %v", op.Op))
+}
+
+// buildConcat builds the NFA for an OpConcat's children. When a child is a
+// non-greedy (lazy) quantifier, it delegates to ConstructionKit.LazyMatch to
+// produce the shortest-match construction. Recurses on the tail so multiple
+// lazy quantifiers compose.
+func buildConcat(kit *automatons.ConstructionKit, subs []*syntax.Regexp) *automatons.NFA {
+	for i, sub := range subs {
+		if !isLazyQuantifier(sub) {
+			// Skip non-lazy expressions in the regexp
+			// If there are non, simply build the concatenation as usual
+			continue
+		}
+		// Recurse into buildConcat to handle multiple lazy quantifiers
+		prefixNFA := buildConcat(kit, subs[:i])
+		tailNFA := buildConcat(kit, subs[i+1:])
+		bodyNFA := newNFAFromSyntax(sub.Sub[0])
+		minRep, maxRep := quantifierBounds(sub)
+		return kit.Concat(prefixNFA, kit.LazyMatch(bodyNFA, minRep, maxRep, tailNFA))
+	}
+
+	// Simplifications for common cases
+	if len(subs) == 0 {
+		return kit.Empty()
+	}
+	if len(subs) == 1 {
+		return newNFAFromSyntax(subs[0])
+	}
+	// Simply concatenate all subexpressions
+	// This is the default case if there are no lazy quantifiers
+	chain := make([]*automatons.NFA, len(subs))
+	for i, sub := range subs {
+		chain[i] = newNFAFromSyntax(sub)
+	}
+	return kit.Concat(chain...)
 }

--- a/internal/regexp/regexp_test.go
+++ b/internal/regexp/regexp_test.go
@@ -60,6 +60,30 @@ func TestRegexpLiteral(t *testing.T) {
 	checkRegexp(t, regexp, "/github.com/", []int{0, 12})
 }
 
+func TestMultilineComment(t *testing.T) {
+	regexp := MustCompile(`\/\*[\s\S]*?\*\/`)
+	cases := []struct {
+		input    string
+		expected []int
+	}{
+		{"/**/", []int{0, 4}},
+		{"/* foo */", []int{0, 9}},
+		{"/* foo * bar */", []int{0, 15}},
+		{"/* * */", []int{0, 7}},
+		{"/***/", []int{0, 5}},
+		{"/****/", []int{0, 6}},
+		{"/* * * */", []int{0, 9}},
+		{"/* foo **/", []int{0, 10}},
+		{"/* a */ /* b */", []int{0, 7}},
+		{"/* a */ x * y /* b */", []int{0, 7}},
+	}
+	for _, c := range cases {
+		t.Run(c.input, func(t *testing.T) {
+			checkRegexp(t, regexp, c.input, c.expected)
+		})
+	}
+}
+
 func TestStartChars_SingleRune(t *testing.T) {
 	regexp := MustCompile("a[bc]d")
 	startChars := regexp.(*RegexpImpl).GetStartChars()


### PR DESCRIPTION
I've noticed during manual testing that `/* * */` broke the lexer for the multi line comment token.

This change makes the DFA/NFA generator take the greedyness properly into account.