### PR TITLE
Publish VS Code extension

### DIFF
--- a/internal/vscode-extensions/fastbelt/.vscodeignore
+++ b/internal/vscode-extensions/fastbelt/.vscodeignore
@@ -1,3 +1,6 @@
 .vscode/**
 .vscode-test/**
 .gitignore
+*.vsix
+esbuild.js
+publish.sh

--- a/internal/vscode-extensions/fastbelt/LICENSE
+++ b/internal/vscode-extensions/fastbelt/LICENSE
@@ -1,0 +1,16 @@
+Copyright 2025 TypeFox GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/internal/vscode-extensions/fastbelt/README.md
+++ b/internal/vscode-extensions/fastbelt/README.md
@@ -1,0 +1,59 @@
+# Fastbelt VS Code Extension
+
+This extension contributes editor support for the Fastbelt Grammar language (`.fb` files) in Visual Studio Code and other compatible editors.
+
+For Fastbelt concepts, APIs, generator usage, and CLI details, use the library documentation as the primary reference: https://pkg.go.dev/typefox.dev/fastbelt
+
+## Installation
+
+### Adding to a Module
+
+Fastbelt ships as a Go module:
+
+```sh
+go get typefox.dev/fastbelt@latest
+go get -tool typefox.dev/fastbelt/cmd/fastbelt@latest
+```
+
+### Global Install
+
+You can also globally install the fastbelt CLI:
+
+```sh
+go install typefox.dev/fastbelt/cmd/fastbelt@latest
+```
+
+## Quick start
+
+The first step is to write a grammar definition file, e.g. `grammar.fb`, which has a similar format as the grammar language of Langium.
+
+To run the code generator for your grammar definition:
+
+```sh
+# globally installed
+fastbelt -g ./grammar.fb -o ./
+```
+
+```sh
+# on demand install
+go run typefox.dev/fastbelt/cmd/fastbelt@latest -g ./grammar.fb -o ./
+```
+
+This writes generated Go files for services such as lexer, parser, linker, and type definitions.
+
+Typically you will want to run generation using `go generate`.
+Add a directive to some file in your module (assumes install with `go tool`):
+
+```go
+//go:generate go tool typefox.dev/fastbelt/cmd/fastbelt -g ./grammar.fb -o ./
+```
+
+## Scaffolding
+
+To bootstrap a **new Go module** for a language (minimal `.fb` grammar, `go:generate` using `go tool` on this CLI, LSP command, and VS Code extension layout), run:
+
+```sh
+fastbelt scaffold -module example.com/you/mylang -language "MyLanguage"
+```
+
+That creates a directory named after the last segment of `-module` (here `./mylang`) in the current working directory, runs `go mod init`, pulls in fastbelt as a library and tool dependency, lays down the files, and runs `go generate`. Use `fastbelt scaffold -h` for full usage.

--- a/internal/vscode-extensions/fastbelt/package.json
+++ b/internal/vscode-extensions/fastbelt/package.json
@@ -1,17 +1,22 @@
 {
   "name": "fastbelt-vscode",
-  "publisher": "typefox",
+  "publisher": "fastbelt",
+  "version": "0.0.1",
+  "preview": true,
   "displayName": "Fastbelt",
   "description": "Support for the Fastbelt grammar language",
-  "version": "0.0.0",
-  "engines": {
-    "vscode": "^1.104.0"
-  },
+  "homepage": "https://pkg.go.dev/typefox.dev/fastbelt",
   "categories": [
     "Programming Languages"
   ],
-  "activationEvents": [],
-  "main": "./dist/extension.js",
+  "license": "MIT",
+  "galleryBanner": {
+    "color": "#262626",
+    "theme": "dark"
+  },
+  "engines": {
+    "vscode": "^1.104.0"
+  },
   "contributes": {
     "languages": [{
       "id": "fastbelt",
@@ -25,15 +30,31 @@
       "path": "./data/fastbelt.tmLanguage.json"
     }]
   },
+  "activationEvents": [],
+  "vsce": {
+    "dependencies": false
+  },
+  "main": "./dist/extension.js",
   "scripts": {
     "build": "npm run check-types && node esbuild.js && npm run build-server",
     "watch": "node esbuild.js --watch",
     "watch:tsc": "tsc --noEmit --watch",
-    "vscode:prepublish": "npm run check-types && node esbuild.js --production",
+    "vscode:prepublish": "npm run check-types && node esbuild.js --production && npm run build-server",
+    "publish:platforms": "bash ./publish-platform-extensions.sh",
     "check-types": "tsc --noEmit",
     "build-server": "go build -o dist/ ../../grammar/server"
   },
   "dependencies": {
     "vscode-languageclient": "~9.0.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TypeFox/fastbelt",
+    "directory": "internal/vscode-extensions/fastbelt"
+  },
+  "bugs": "https://github.com/TypeFox/fastbelt/issues",
+  "author": {
+    "name": "TypeFox",
+    "url": "https://www.typefox.io"
   }
 }

--- a/internal/vscode-extensions/fastbelt/publish.sh
+++ b/internal/vscode-extensions/fastbelt/publish.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Require tokens for both marketplaces before doing any work.
+if [[ -z "${VSCE_TOKEN:-}" ]]; then
+  echo "VSCE_TOKEN is required."
+  exit 1
+fi
+
+if [[ -z "${OVSX_TOKEN:-}" ]]; then
+  echo "OVSX_TOKEN is required."
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# Derive output file names from extension metadata.
+PACKAGE_NAME="$(node -p "require('./package.json').name")"
+PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+
+# Format: "<vsce-target> <GOOS> <GOARCH>"
+targets=(
+  "win32-x64 windows amd64"
+  "linux-x64 linux amd64"
+  "darwin-x64 darwin amd64"
+  "darwin-arm64 darwin arm64"
+)
+
+for target_info in "${targets[@]}"; do
+  read -r target goos goarch <<<"$target_info"
+  # Keep a stable filename so the exact same artifact can be
+  # published to both VS Marketplace and Open VSX.
+  vsix_file="${PACKAGE_NAME}-${PACKAGE_VERSION}-${target}.vsix"
+
+  echo "==> Building and packaging for ${target} (GOOS=${goos}, GOARCH=${goarch})"
+  # Rebuild from a clean dist directory for this platform.
+  rm -rf dist
+
+  GOOS="$goos" GOARCH="$goarch" npx vsce package --target "$target" --out "$vsix_file"
+
+  echo "==> Publishing ${vsix_file} to VS Marketplace"
+  npx vsce publish --packagePath "$vsix_file" -p "$VSCE_TOKEN"
+
+  echo "==> Publishing ${vsix_file} to Open VSX"
+  npx ovsx publish "$vsix_file" -p "$OVSX_TOKEN"
+done
+
+echo "Done publishing all platform-specific extensions."

--- a/internal/vscode-extensions/fastbelt/publish.sh
+++ b/internal/vscode-extensions/fastbelt/publish.sh
@@ -3,13 +3,13 @@
 set -euo pipefail
 
 # Require tokens for both marketplaces before doing any work.
-if [[ -z "${VSCE_TOKEN:-}" ]]; then
-  echo "VSCE_TOKEN is required."
+if [[ -z "${VSCE_PAT:-}" ]]; then
+  echo "VSCE_PAT is required."
   exit 1
 fi
 
-if [[ -z "${OVSX_TOKEN:-}" ]]; then
-  echo "OVSX_TOKEN is required."
+if [[ -z "${OVSX_PAT:-}" ]]; then
+  echo "OVSX_PAT is required."
   exit 1
 fi
 
@@ -41,10 +41,10 @@ for target_info in "${targets[@]}"; do
   GOOS="$goos" GOARCH="$goarch" npx vsce package --target "$target" --out "$vsix_file"
 
   echo "==> Publishing ${vsix_file} to VS Marketplace"
-  npx vsce publish --packagePath "$vsix_file" -p "$VSCE_TOKEN"
+  npx vsce publish --packagePath "$vsix_file"
 
   echo "==> Publishing ${vsix_file} to Open VSX"
-  npx ovsx publish "$vsix_file" -p "$OVSX_TOKEN"
+  npx ovsx publish "$vsix_file"
 done
 
 echo "Done publishing all platform-specific extensions."


### PR DESCRIPTION
Added README.md, LICENSE, and a publishing script for cross-compiling for multiple platforms. This is meant as a starting point – we can extend the available platforms later and can also consider migrating to another scripting language or a GitHub Action.