### PR TITLE
Documentation for root package and grammar

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,132 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+// Package fastbelt is a language engineering toolkit for Go.
+//
+// # Overview
+//
+// Fastbelt covers lexing, parsing, AST creation, cross-reference linking,
+// workspace handling, and Language Server Protocol (LSP) support.
+//
+// Fastbelt is primarily inspired by [Xtext] (Java)
+// and [Langium] (TypeScript).
+//
+// Like these frameworks, Fastbelt uses a grammar definition file as the
+// entry point, based on a Grammar language that is itself implemented with
+// Fastbelt. See [typefox.dev/fastbelt/grammar] for details.
+//
+// The [typefox.dev/fastbelt/cmd/fastbelt] command generates Go code from a
+// grammar definition, which you can integrate and customize with additional
+// code.
+//
+// # Scaffolding
+//
+// The [typefox.dev/fastbelt/cmd/fastbelt] command can scaffold a new language
+// project with:
+//
+//	fastbelt scaffold -module example.com/you/mylang -language "MyLanguage"
+//
+// The scaffold creates these root files in the generated package directory:
+//
+//   - gen.go with go:generate directives for grammar-based code generation.
+//   - services.go with customization points for generated services.
+//   - <language-id>.fb as the initial grammar definition file.
+//   - cmd/<language-id>-lsp/main.go as the LSP server entrypoint.
+//
+// By default, scaffolding also creates VS Code extension files in a
+// `vscode-extension` subfolder.
+//
+// After writing templates, scaffolding runs go generate and go mod tidy so the
+// generated parser, lexer, linker, and supporting files are ready to use.
+//
+// # Defining the Grammar
+//
+// Defining a language in Fastbelt is an iterative design process. You
+// co-design the concrete syntax that users write and the abstract syntax tree
+// (AST) that your tooling consumes.
+//
+// In practice, you write interface declarations for AST node types and parser
+// rules that describe how instances of those node types are created from input
+// text. Each assignment in a parser rule maps matched input to a field on the
+// node that the rule builds.
+//
+// Parser rules always consume contiguous regions of text. They match keywords
+// and tokens directly and delegate to other rules for nested regions. This
+// keeps grammar structure aligned with language structure and makes it clear
+// how parsed text becomes AST subtrees.
+//
+// Cross-references provide built-in linking from symbol usage to symbol
+// definition. Instead of creating a new node, a cross-reference records an
+// identifier that the linker resolves to an existing AST node in scope.
+//
+// Because Go interfaces are generated directly from grammar interfaces, these
+// interfaces should reflect how you plan to implement semantic checks,
+// interpreters, or code generators. At the same time, there's a 1:1
+// correspondence between interfaces and parser rules so the parse model and
+// runtime model stay easy to reason about.
+//
+// The grammar language itself is documented in
+// [typefox.dev/fastbelt/grammar], while the code generation workflow is
+// documented in [typefox.dev/fastbelt/cmd/fastbelt]. A common workflow is to
+// evolve the grammar in small steps and run code generation after each change.
+//
+// # Customization
+//
+// There are two ways to add custom behavior to your language:
+//
+//   - Attach behavior directly to specific generated AST node `Impl` types.
+//   - Implement custom services and wire them through the service container.
+//
+// Validations are implemented with the first approach. To add validation checks
+// for a node type, implement [Validator] on that node's generated `Impl`
+// struct:
+//
+//	type PersonImpl struct {
+//	    PersonData
+//	}
+//
+//	func (p *PersonImpl) Validate(_ context.Context, _ string, accept fastbelt.ValidationAcceptor) {
+//	    if name := p.Name(); name != "" && !unicode.IsUpper([]rune(name)[0]) {
+//	        accept(fastbelt.NewDiagnostic(
+//	            fastbelt.SeverityError,
+//	            "Name must start with an uppercase letter.",
+//	            p,
+//	            fastbelt.WithToken(p.NameToken()),
+//	        ))
+//	    }
+//	}
+//
+// This keeps checks close to the node they validate and works naturally with
+// generated AST types.
+//
+// For service-container based customization, define a language-specific
+// `SetupServices` function and a `CreateServices` helper. The service container
+// API is documented at [typefox.dev/fastbelt/util/service].
+//
+// By convention, `SetupServices`:
+//   - registers custom values and service implementations,
+//   - calls needed `SetupDefaultServices` functions from framework packages, and
+//   - calls `SetupGeneratedServices` from generated code.
+//
+// When you scaffold a new language project, Fastbelt generates a `services.go`
+// file that follows this pattern and can be used as a starting point for your
+// own service-container customization.
+//
+// # To Go Further
+//
+// For implementing the exact behavior of your language, these subpackages are
+// the most relevant:
+//
+//   - [typefox.dev/fastbelt/linking] for everything related to
+//     cross-reference linking, including scopes and making symbols reachable
+//     between files.
+//   - [typefox.dev/fastbelt/workspace] for handling a collection of files in a
+//     workspace folder, processing file changes by executing phases such as
+//     parsing, linking, and validating.
+//   - [typefox.dev/fastbelt/server] for everything related to the Language
+//     Server Protocol (LSP).
+//
+// [Xtext]: https://eclipse.dev/Xtext/
+// [Langium]: https://langium.org
+package fastbelt

--- a/doc.go
+++ b/doc.go
@@ -62,7 +62,7 @@
 //
 // Because Go interfaces are generated directly from grammar interfaces, these
 // interfaces should reflect how you plan to implement semantic checks,
-// interpreters, or code generators. At the same time, there's a 1:1
+// interpreters, or code generators. At the same time, there's a close
 // correspondence between interfaces and parser rules so the parse model and
 // runtime model stay easy to reason about.
 //

--- a/grammar/doc.go
+++ b/grammar/doc.go
@@ -6,8 +6,8 @@
 //
 // A grammar definition file (extension .fb) describes the concrete syntax
 // and type structure of a language. Fastbelt reads .fb files and generates
-// Go lexers, parsers, and AST types from them. The grammar language is
-// itself implemented as a Fastbelt grammar.
+// Go code from them. The grammar language is itself implemented as a
+// Fastbelt grammar.
 //
 // See [typefox.dev/fastbelt] for the toolchain overview and the
 // [typefox.dev/fastbelt/cmd/fastbelt] command for code generation.
@@ -110,9 +110,9 @@
 //	token ID:  /[_a-zA-Z][\w_]*/;
 //	token INT: /[0-9]+/;
 //
-// The order in which token rules are declared is significant: the lexer
-// returns the first match, so more specific patterns should appear before
-// more general ones.
+// The lexer returns the first, longest match. If multiple token rules
+// match the same text with equal length, the token rule declared first wins.
+// Keywords are always considered before explicitly declared token rules.
 //
 // # Hidden Tokens
 //
@@ -123,7 +123,8 @@
 //	hidden token ML_COMMENT: /\/\*[\s\S]*?\*\//;
 //	hidden token SL_COMMENT: /\/\/[^\r\n]*/;
 //
-// Hidden tokens are global and apply to the entire grammar.
+// Hidden tokens are global and apply to the entire grammar. They may
+// appear anywhere without interrupting assignment groups.
 //
 // # Comment Tokens
 //
@@ -132,9 +133,8 @@
 //
 //	comment token SL_COMMENT: /\/\/[^\r\n]*/;
 //
-// Comment tokens are moved in front of the element they precede during
-// parsing, making them available for tooling such as hover documentation in
-// a language server.
+// Parsed comment tokens are stored in the document's `Comments []Token`
+// slice, where tooling can access them.
 //
 // # Parser Rules
 //
@@ -185,8 +185,7 @@
 // # Keywords
 //
 // A keyword is a literal string in double quotes. Keywords guide the parser
-// and provide visible structure to the language. They must not be empty and
-// must not contain whitespace:
+// and provide visible structure to the language. They must not be empty:
 //
 //	Person returns Person:
 //	    "person" Name=ID "age" Age=INT;
@@ -233,19 +232,19 @@
 //
 // Assignments with cardinality + or * form a contiguous group: the sequence
 // of matched values must not be interrupted by elements belonging to a
-// different assignment before the group is complete. Hidden tokens such as
-// whitespace and comments may appear anywhere without interrupting a group.
+// different assignment before the group is complete.
 //
 // # Cross-References
 //
-// A cross-reference reads an identifying token from the input and resolves it
-// to an existing object rather than creating a new one. The syntax is:
+// A cross-reference reads an identifying token from the input and usually
+// resolves it to an existing object. The syntax is:
 //
 //	property=[Type:TOKEN]
 //
-// Type is the name of an interface and TOKEN is the name of a token rule that
-// identifies objects of that type. If TOKEN is omitted, Fastbelt uses the
-// token matched by the Name field assignment of the referenced type:
+// Type is the name of an interface and TOKEN is the name of a token rule or
+// composite rule that identifies objects of that type. If TOKEN is omitted,
+// Fastbelt uses the token matched by the Name field assignment of the
+// referenced type:
 //
 //	interface State {
 //	    Name string
@@ -275,6 +274,10 @@
 // Instead it calls either Definition or DeclaredParameter, and whichever
 // rule matches creates the object. This pattern is the standard way to write
 // rules that match one of several concrete types.
+//
+// After an unassigned subrule has been consumed, following assignments in the
+// same rule can set additional properties on the object returned by that subrule.
+// Such assignments cannot appear before the unassigned subrule.
 //
 // In contrast, an assigned rule call such as parameter=DeclaredParameter
 // creates an object in the current rule and assigns the result of the called
@@ -309,21 +312,24 @@
 //
 // A composite rule matches a structured token value such as a qualified name
 // or dotted path. Unlike parser rules, composite rules do not create AST
-// objects; they yield an opaque composite value that is stored in a field of
-// type composite.
+// objects; they yield a composite value that is stored in a field of type
+// composite and can be inspected through its Tokens() method.
 //
 // Composite rules support keywords, rule calls, parenthesized alternatives,
 // and cardinalities, but not assignments or cross-references:
 //
 //	composite QualifiedName: ID ("." ID)*;
 //
-// Declare the receiving field as composite in the interface, then use a
-// normal = or += assignment on the right side of a parser rule:
+// Composite values can also be used to define object names and resolve
+// cross-references:
 //
-//	interface TypeRef {
+//	interface Type {
 //	    Name composite
 //	}
+//	interface TypeRef {
+//	    Item *Type
+//	}
 //
-//	TypeRef returns TypeRef:
-//	    Name=QualifiedName;
+//	Type: Name=QualifiedName;
+//	TypeRef: Item=[Type:QualifiedName];
 package grammar

--- a/grammar/doc.go
+++ b/grammar/doc.go
@@ -1,0 +1,329 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+// Package grammar documents the Fastbelt grammar language.
+//
+// A grammar definition file (extension .fb) describes the concrete syntax
+// and type structure of a language. Fastbelt reads .fb files and generates
+// Go lexers, parsers, and AST types from them. The grammar language is
+// itself implemented as a Fastbelt grammar.
+//
+// See [typefox.dev/fastbelt] for the toolchain overview and the
+// [typefox.dev/fastbelt/cmd/fastbelt] command for code generation.
+//
+// # Language Declaration
+//
+// Every grammar file begins with the grammar keyword, the language name,
+// and a semicolon:
+//
+//	grammar MyLanguage;
+//
+// The name is used by Fastbelt when naming the generated package and
+// language server.
+//
+// # Interface Declarations
+//
+// Every type that a parser rule creates must be declared explicitly as an
+// interface. An interface lists the fields of that type along with their
+// types:
+//
+//	interface Person {
+//	    Name string
+//	    Age  string
+//	}
+//
+// The following field types are available:
+//
+//   - string — a string value set by a = or += assignment to a token rule.
+//   - bool — a boolean value set by a ?= assignment.
+//   - composite — a value set by a = or += assignment to a composite rule.
+//   - TypeName — an embedded sub-object whose type is the named interface.
+//   - *TypeName — a cross-reference to an object of the named interface type.
+//   - []FieldType — an array of any of the above types.
+//
+// An interface can extend one or more other interfaces to inherit their
+// fields:
+//
+//	interface NamedElement {
+//	    Name string
+//	}
+//
+//	interface Person extends NamedElement {
+//	    Age string
+//	}
+//
+// # Generated Go Types for Interfaces
+//
+// For every grammar interface, Fastbelt generates a set of Go types in
+// `types_gen.go`:
+//
+//   - a public Go interface that embeds `core.AstNode` and declares
+//     accessors/setters for each grammar field,
+//   - a `<TypeName>Data` struct that stores the field data and implements
+//     the accessor methods, and
+//   - a `<TypeName>Impl` struct that embeds `core.AstNodeBase` plus
+//     `<TypeName>Data`.
+//
+// The split between `Data` and `Impl` keeps type hierarchies composable.
+// `Data` holds one layer of fields and behavior, while `Impl` embeds the
+// data structs for all parent interfaces plus its own. This avoids copying
+// inherited fields into every concrete type and keeps generator output
+// regular as hierarchies grow.
+//
+// For example, this grammar interface:
+//
+//	interface Person {
+//	    Name string
+//	}
+//
+// generates a Go interface like:
+//
+//	type Person interface {
+//	    core.AstNode
+//	    IsPerson()
+//	    Name() string
+//	    NameToken() *core.Token
+//	    SetName(value *core.Token)
+//	}
+//
+// Field types in grammar interfaces map to generated Go API types as follows:
+//
+//   - string -> getter returns `string`, plus `FieldToken() *core.Token`.
+//   - bool -> getter is named `IsField()` and returns `bool`.
+//   - composite -> getter returns `string`; scalar composite fields also get a
+//     `FieldNode() core.CompositeNode` accessor.
+//   - TypeName -> getter returns `TypeName`.
+//   - *TypeName -> getter returns `*core.Reference[TypeName]`.
+//   - []FieldType -> getter returns a slice of the mapped element type.
+//
+// Slice fields use append-style setters (`Set<Field>Item`) in generated code.
+// Scalar fields use `Set<Field>(value ...)`.
+//
+// # Token Rules
+//
+// Lexing transforms a stream of characters into a stream of tokens.
+// A token rule matches a character sequence with a regular expression and
+// assigns it a name. Token rule names are conventionally written in upper
+// case:
+//
+//	token ID:  /[_a-zA-Z][\w_]*/;
+//	token INT: /[0-9]+/;
+//
+// The order in which token rules are declared is significant: the lexer
+// returns the first match, so more specific patterns should appear before
+// more general ones.
+//
+// # Hidden Tokens
+//
+// Tokens that should be silently consumed — whitespace, comments — are
+// declared with the hidden modifier:
+//
+//	hidden token WS:         /\s+/;
+//	hidden token ML_COMMENT: /\/\*[\s\S]*?\*\//;
+//	hidden token SL_COMMENT: /\/\/[^\r\n]*/;
+//
+// Hidden tokens are global and apply to the entire grammar.
+//
+// # Comment Tokens
+//
+// Documentation comments attached to the grammar element that follows them
+// are declared with the comment modifier:
+//
+//	comment token SL_COMMENT: /\/\/[^\r\n]*/;
+//
+// Comment tokens are moved in front of the element they precede during
+// parsing, making them available for tooling such as hover documentation in
+// a language server.
+//
+// # Parser Rules
+//
+// Parser rules define what sequences of tokens are valid and how to populate
+// the fields of the AST nodes they create. The first parser rule in the file
+// is the entry rule: the starting point of the parse.
+//
+// A parser rule starts with its name, an optional returns clause naming the
+// interface type it creates, a colon, the rule body, and a semicolon:
+//
+//	Person returns Person:
+//	    "person" Name=ID;
+//
+// When the rule name matches a declared interface the returns clause may be
+// omitted and Fastbelt resolves the type by name.
+//
+// # Cardinalities
+//
+// A cardinality suffix controls how many times an element may appear:
+//
+//   - (none) — exactly once
+//   - ? — zero or one time
+//   - * — zero or more times
+//   - + — one or more times
+//
+// # Groups
+//
+// Elements in sequence form a group and must appear in the declared order:
+//
+//	Person returns Person:
+//	    "person" Name=ID Address=Address;
+//
+// Parentheses create a sub-group that can carry its own cardinality:
+//
+//	State returns State:
+//	    "state" Name=ID
+//	        ("actions" "{" Actions+=[Command:ID]+ "}")?
+//	    "end";
+//
+// # Alternatives
+//
+// The pipe operator | matches one of several options. Alternatives inside
+// parentheses can carry a cardinality:
+//
+//	Model returns Model:
+//	    (Persons+=Person | Greetings+=Greeting)*;
+//
+// # Keywords
+//
+// A keyword is a literal string in double quotes. Keywords guide the parser
+// and provide visible structure to the language. They must not be empty and
+// must not contain whitespace:
+//
+//	Person returns Person:
+//	    "person" Name=ID "age" Age=INT;
+//
+// Keywords help the parser disambiguate between alternatives that would
+// otherwise be identical:
+//
+//	interface Student { Name string }
+//	interface Teacher { Name string }
+//
+//	Student returns Student:
+//	    "student" Name=ID;
+//
+//	Teacher returns Teacher:
+//	    "teacher" Name=ID;
+//
+//	Person:
+//	    Student | Teacher;
+//
+// Without the "student" and "teacher" keywords the grammar would be
+// ambiguous and the parser could not distinguish the two rules.
+//
+// # Assignments
+//
+// Assignments populate fields on the object being built by the surrounding
+// rule. The left side names a field declared on the return type; the right
+// side names what to parse. There are three forms:
+//
+// Single-value assignment (=) stores one parsed value in the field:
+//
+//	Person returns Person:
+//	    "person" Name=ID;
+//
+// Array assignment (+=) appends each matched value to a slice field:
+//
+//	Model returns Model:
+//	    Events+=Event*;
+//
+// Boolean assignment (?=) sets a bool field to true when the right side is
+// consumed; the field remains false otherwise:
+//
+//	Employee returns Employee:
+//	    "employee" Name=ID (Remote?="remote")?;
+//
+// Assignments with cardinality + or * form a contiguous group: the sequence
+// of matched values must not be interrupted by elements belonging to a
+// different assignment before the group is complete. Hidden tokens such as
+// whitespace and comments may appear anywhere without interrupting a group.
+//
+// # Cross-References
+//
+// A cross-reference reads an identifying token from the input and resolves it
+// to an existing object rather than creating a new one. The syntax is:
+//
+//	property=[Type:TOKEN]
+//
+// Type is the name of an interface and TOKEN is the name of a token rule that
+// identifies objects of that type. If TOKEN is omitted, Fastbelt uses the
+// token matched by the Name field assignment of the referenced type:
+//
+//	interface State {
+//	    Name string
+//	}
+//
+//	interface Transition {
+//	    Event *Event
+//	    State *State
+//	}
+//
+//	Transition returns Transition:
+//	    Event=[Event:ID] "=>" State=[State:ID];
+//
+// The linker resolves cross-references after parsing. If no object matching
+// the token value is found in scope, a diagnostic error is reported.
+//
+// # Unassigned Rule Calls
+//
+// A rule call without an assignment delegates parsing to another rule without
+// creating a new object in the current rule. The called rule is responsible
+// for producing the object:
+//
+//	AbstractDefinition:
+//	    Definition | DeclaredParameter;
+//
+// The parser rule AbstractDefinition does not create an object of its own.
+// Instead it calls either Definition or DeclaredParameter, and whichever
+// rule matches creates the object. This pattern is the standard way to write
+// rules that match one of several concrete types.
+//
+// In contrast, an assigned rule call such as parameter=DeclaredParameter
+// creates an object in the current rule and assigns the result of the called
+// rule to the named property.
+//
+// # Actions
+//
+// Actions explicitly set the type of the object being built at the point
+// where they appear in the rule body. A simple action creates a new object
+// of the named type:
+//
+//	interface TypeOne { Name string }
+//	interface TypeTwo extends TypeOne {}
+//
+//	RuleOne returns TypeOne:
+//	    "one" Name=ID | {TypeTwo} "two" Name=ID;
+//
+// A tree-rewriting action creates a new object of the named type and assigns
+// the object built so far to one of its properties. This technique handles
+// structures that would require left recursion if written directly. The
+// current object is referred to by the keyword current:
+//
+//	Addition returns Expression:
+//	    SimpleExpr ({Addition.Left=current} "+" Right=SimpleExpr)*;
+//
+// When the "+" keyword is found, a new Addition object is created, the
+// object parsed so far is stored in its Left property, and that new Addition
+// becomes the current object. The operator += is also valid for tree-rewriting
+// actions on slice properties.
+//
+// # Composite Rules
+//
+// A composite rule matches a structured token value such as a qualified name
+// or dotted path. Unlike parser rules, composite rules do not create AST
+// objects; they yield an opaque composite value that is stored in a field of
+// type composite.
+//
+// Composite rules support keywords, rule calls, parenthesized alternatives,
+// and cardinalities, but not assignments or cross-references:
+//
+//	composite QualifiedName: ID ("." ID)*;
+//
+// Declare the receiving field as composite in the interface, then use a
+// normal = or += assignment on the right side of a parser rule:
+//
+//	interface TypeRef {
+//	    Name composite
+//	}
+//
+//	TypeRef returns TypeRef:
+//	    Name=QualifiedName;
+package grammar


### PR DESCRIPTION
Added a root package doc to be shown here: https://pkg.go.dev/typefox.dev/fastbelt

This explains the basics of the framework and delegates to subpackages for further details (those need to be documented as well).

Also added a `grammar` package with the sole purpose of documenting the grammar language. We can't do that in `internal/grammar` because that's not public (doesn't need to be – framework users don't interact with the grammar directly).

@msujew please check whether the grammar reference is complete and correct wrt. the current state of the implementation.