### PR TITLE
Import only grammar symbols from same package

### DIFF
--- a/internal/grammar/imported_symbols.go
+++ b/internal/grammar/imported_symbols.go
@@ -1,0 +1,41 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+package grammar
+
+import (
+	"context"
+	"iter"
+	"path"
+
+	core "typefox.dev/fastbelt"
+	"typefox.dev/fastbelt/linking"
+	"typefox.dev/fastbelt/util/extiter"
+	"typefox.dev/fastbelt/util/service"
+)
+
+type importedSymbolsProviderImpl struct {
+	sc *service.Container
+}
+
+func newImportedSymbolsProviderImpl(sc *service.Container) linking.SymbolImporter {
+	return &importedSymbolsProviderImpl{sc: sc}
+}
+
+func (s *importedSymbolsProviderImpl) ImportSymbols(ctx context.Context, doc *core.Document, allDocs iter.Seq[*core.Document]) core.SymbolContainer {
+	// Only grammar definitions in the same package are visible
+	sameFolderDocs := extiter.Filter(allDocs, func(other *core.Document) bool {
+		return sameFolder(doc.URI, other.URI)
+	})
+	allExportedSymbols := extiter.Map(sameFolderDocs, func(d *core.Document) core.SymbolContainer {
+		return d.ExportedSymbols
+	})
+	imported := core.MergeSymbolContainers(allExportedSymbols)
+	doc.ImportedSymbols = imported
+	return imported
+}
+
+func sameFolder(first, second core.URI) bool {
+	return path.Dir(first.Path()) == path.Dir(second.Path())
+}

--- a/internal/grammar/services.go
+++ b/internal/grammar/services.go
@@ -25,6 +25,7 @@ func SetupServices(sc *service.Container) {
 
 	// Override the default scope provider
 	service.Override[FastbeltScopeProvider](sc, newScopeProviderImpl(sc))
+	service.Override[linking.SymbolImporter](sc, newImportedSymbolsProviderImpl(sc))
 }
 
 // CreateServices creates a service container for the grammar language to be used in the CLI and tests.

--- a/linking/exported_symbols.go
+++ b/linking/exported_symbols.go
@@ -11,25 +11,25 @@ import (
 	"typefox.dev/fastbelt/util/service"
 )
 
-// ExportedSymbolsProvider is a service that computes the symbols to be exported from a document,
+// SymbolExporter is a service that computes the symbols to be exported from a document,
 // so they can be imported into other documents.
-type ExportedSymbolsProvider interface {
-	// ExportedSymbols traverses the document's AST and computes the exported symbols.
+type SymbolExporter interface {
+	// ExportSymbols traverses the document's AST and computes the exported symbols.
 	// The result is stored in the document's ExportedSymbols field.
-	ExportedSymbols(ctx context.Context, document *core.Document) core.SymbolContainer
+	ExportSymbols(ctx context.Context, document *core.Document) core.SymbolContainer
 }
 
-// DefaultExportedSymbolsProvider is the default implementation of [ExportedSymbolsProvider].
+// DefaultSymbolExporter is the default implementation of [SymbolExporter].
 // By default, it exports the root node and its direct children that have a name.
-type DefaultExportedSymbolsProvider struct {
+type DefaultSymbolExporter struct {
 	sc *service.Container
 }
 
-func NewDefaultExportedSymbolsProvider(sc *service.Container) ExportedSymbolsProvider {
-	return &DefaultExportedSymbolsProvider{sc: sc}
+func NewDefaultSymbolExporter(sc *service.Container) SymbolExporter {
+	return &DefaultSymbolExporter{sc: sc}
 }
 
-func (s *DefaultExportedSymbolsProvider) ExportedSymbols(ctx context.Context, document *core.Document) core.SymbolContainer {
+func (s *DefaultSymbolExporter) ExportSymbols(ctx context.Context, document *core.Document) core.SymbolContainer {
 	root := document.Root
 	exports := service.MustGet[core.SymbolContainers](s.sc).New()
 

--- a/linking/imported_symbols.go
+++ b/linking/imported_symbols.go
@@ -13,26 +13,25 @@ import (
 	"typefox.dev/fastbelt/util/service"
 )
 
-// ImportedSymbolsProvider is a service that computes the symbols imported into a document from
+// SymbolImporter is a service that computes the symbols imported into a document from
 // other documents, making them available for cross-document reference resolution.
-type ImportedSymbolsProvider interface {
-	// ImportedSymbols creates a sequence of all symbols that are visible from other documents.
+type SymbolImporter interface {
+	// ImportSymbols creates a sequence of all symbols that are visible from other documents.
 	// The result is stored in the document's ImportedSymbols field.
-	// The caller must hold the document's write lock.
-	ImportedSymbols(ctx context.Context, document *core.Document, allDocuments iter.Seq[*core.Document]) core.SymbolContainer
+	ImportSymbols(ctx context.Context, document *core.Document, allDocuments iter.Seq[*core.Document]) core.SymbolContainer
 }
 
-// DefaultImportedSymbolsProvider is the default implementation of [ImportedSymbolsProvider].
+// DefaultSymbolImporter is the default implementation of [SymbolImporter].
 // It flat-maps the exported symbols of all documents into a single lazy sequence.
-type DefaultImportedSymbolsProvider struct {
+type DefaultSymbolImporter struct {
 	sc *service.Container
 }
 
-func NewDefaultImportedSymbolsProvider(sc *service.Container) ImportedSymbolsProvider {
-	return &DefaultImportedSymbolsProvider{sc: sc}
+func NewDefaultSymbolImporter(sc *service.Container) SymbolImporter {
+	return &DefaultSymbolImporter{sc: sc}
 }
 
-func (s *DefaultImportedSymbolsProvider) ImportedSymbols(ctx context.Context, doc *core.Document, allDocs iter.Seq[*core.Document]) core.SymbolContainer {
+func (s *DefaultSymbolImporter) ImportSymbols(ctx context.Context, doc *core.Document, allDocs iter.Seq[*core.Document]) core.SymbolContainer {
 	allExportedSymbols := extiter.Map(allDocs, func(d *core.Document) core.SymbolContainer {
 		return d.ExportedSymbols
 	})

--- a/linking/services.go
+++ b/linking/services.go
@@ -9,11 +9,11 @@ import "typefox.dev/fastbelt/util/service"
 // SetupDefaultServices sets up the default services for the linking package.
 // If any service is already set, it's not overwritten.
 func SetupDefaultServices(sc *service.Container) {
-	if !service.Has[ExportedSymbolsProvider](sc) {
-		service.Put(sc, NewDefaultExportedSymbolsProvider(sc))
+	if !service.Has[SymbolExporter](sc) {
+		service.Put(sc, NewDefaultSymbolExporter(sc))
 	}
-	if !service.Has[ImportedSymbolsProvider](sc) {
-		service.Put(sc, NewDefaultImportedSymbolsProvider(sc))
+	if !service.Has[SymbolImporter](sc) {
+		service.Put(sc, NewDefaultSymbolImporter(sc))
 	}
 	if !service.Has[Linker](sc) {
 		service.Put(sc, NewDefaultLinker(sc))

--- a/workspace/builder.go
+++ b/workspace/builder.go
@@ -58,7 +58,7 @@ func NewDefaultBuilder(sc *service.Container) Builder {
 func (s *DefaultBuilder) Build(ctx context.Context, docs []*core.Document, downgrade func()) error {
 	// PHASE 1: Parse, and compute exports (parallel per document).
 	parser := service.MustGet[DocumentParser](s.sc)
-	exportedSymbols := service.MustGet[linking.ExportedSymbolsProvider](s.sc)
+	exporter := service.MustGet[linking.SymbolExporter](s.sc)
 	var phase1 sync.WaitGroup
 	for _, doc := range docs {
 		phase1.Go(func() {
@@ -76,7 +76,7 @@ func (s *DefaultBuilder) Build(ctx context.Context, docs []*core.Document, downg
 			}
 			// STEP 1.2: Compute the exported symbols for cross-document references.
 			if !doc.State.Has(core.DocStateExportedSymbols) {
-				exportedSymbols.ExportedSymbols(ctx, doc)
+				exporter.ExportSymbols(ctx, doc)
 				doc.State = doc.State.With(core.DocStateExportedSymbols)
 				s.notifyListeners(ctx, core.DocStateExportedSymbols, doc)
 			}
@@ -91,7 +91,7 @@ func (s *DefaultBuilder) Build(ctx context.Context, docs []*core.Document, downg
 	// PHASE 2: Compute imported/local symbols and link (parallel per document).
 	// This requires the exported symbols of all documents to be available.
 	documentManager := service.MustGet[DocumentManager](s.sc)
-	importedSymbols := service.MustGet[linking.ImportedSymbolsProvider](s.sc)
+	importer := service.MustGet[linking.SymbolImporter](s.sc)
 	localSymbols := service.MustGet[linking.LocalSymbolsProvider](s.sc)
 	linker := service.MustGet[linking.Linker](s.sc)
 	referenceDescriptions := service.MustGet[linking.ReferenceDescriptionsProvider](s.sc)
@@ -104,7 +104,7 @@ func (s *DefaultBuilder) Build(ctx context.Context, docs []*core.Document, downg
 			// STEP 2.1: Collect imported symbols from all other documents.
 			if !doc.State.Has(core.DocStateImportedSymbols) {
 				allDocs := documentManager.All()
-				importedSymbols.ImportedSymbols(ctx, doc, allDocs)
+				importer.ImportSymbols(ctx, doc, allDocs)
 				doc.State = doc.State.With(core.DocStateImportedSymbols)
 				s.notifyListeners(ctx, core.DocStateImportedSymbols, doc)
 			}


### PR DESCRIPTION
I propose that grammars can only see definitions from the same package. This keeps the Fastbelt grammar aligned with Go. At a later stage, we can evaluate adding explicit `import` statements, potentially with the same syntax as Go.

Also two renamings to make service names simpler and shorter:
- ImportedSymbolsProvider → SymbolImporter
- ExportedSymbolsProvider → SymbolExporter

I kept LocalSymbolsProvider as the analogy doesn't work there.