### PR TITLE
Support document highlight LSP feature

### DIFF
--- a/examples/statemachine/statemachine_highlight_test.go
+++ b/examples/statemachine/statemachine_highlight_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+package statemachine
+
+import (
+	"testing"
+
+	"typefox.dev/fastbelt/test"
+)
+
+func TestHighlightOnEventName(t *testing.T) {
+	f := test.New(t, CreateLspServices())
+	doc := f.Parse(`
+		statemachine Toggle
+
+		events <|flick><|flick|>
+
+		initialState a
+
+		state a
+		  <|flick|> => b
+		end
+
+		state b
+		  <|flick|> => a
+		end
+	`).AssertNoErrors()
+
+	doc.AssertHighlights("flick")
+}
+
+func TestHighlightOnEventReference(t *testing.T) {
+	f := test.New(t, CreateLspServices())
+	doc := f.Parse(`
+		statemachine Toggle
+
+		events <|flick|>
+
+		initialState a
+
+		state a
+		  <|flick><|flick|> => b
+		end
+
+		state b
+		  <|flick|> => a
+		end
+	`).AssertNoErrors()
+
+	doc.AssertHighlights("flick")
+}
+
+func TestHighlightOnStateName(t *testing.T) {
+	f := test.New(t, CreateLspServices())
+	doc := f.Parse(`
+		statemachine Toggle
+
+		events flick
+
+		initialState <|a|>
+
+		state <|a><|a|>
+		  flick => b
+		end
+
+		state b
+		  flick => <|a|>
+		end
+	`).AssertNoErrors()
+
+	doc.AssertHighlights("a")
+}
+
+// An event and a command can share the same name. Highlighting one kind of
+// element must not bleed into the equally named element of the other kind.
+func TestHighlightDistinguishesCommandFromEvent(t *testing.T) {
+	f := test.New(t, CreateLspServices())
+	doc := f.Parse(`
+		statemachine Toggle
+
+		events <|ev><|ev:flick|>
+
+		commands <|cmd><|cmd:flick|>
+
+		initialState a
+
+		state a
+		  actions { <|cmd:flick|> }
+		  <|ev:flick|> => b
+		end
+
+		state b
+		  <|ev:flick|> => a
+		end
+	`).AssertNoErrors()
+
+	// Cursor on the command declaration: only command occurrences are highlighted.
+	doc.AssertHighlights("cmd")
+	// Cursor on the event declaration: only event occurrences are highlighted.
+	doc.AssertHighlights("ev")
+}

--- a/server/document_highlight_provider.go
+++ b/server/document_highlight_provider.go
@@ -1,0 +1,59 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+package server
+
+import (
+	"context"
+
+	core "typefox.dev/fastbelt"
+	"typefox.dev/fastbelt/util/service"
+	"typefox.dev/fastbelt/workspace"
+	"typefox.dev/lsp"
+)
+
+type DocumentHighlightProvider interface {
+	HandleDocumentHighlightRequest(ctx context.Context, params *lsp.DocumentHighlightParams) ([]lsp.DocumentHighlight, error)
+}
+
+type DefaultDocumentHighlightProvider struct {
+	sc *service.Container
+}
+
+func NewDefaultDocumentHighlightProvider(sc *service.Container) DocumentHighlightProvider {
+	return &DefaultDocumentHighlightProvider{sc: sc}
+}
+
+func (s *DefaultDocumentHighlightProvider) HandleDocumentHighlightRequest(ctx context.Context, params *lsp.DocumentHighlightParams) ([]lsp.DocumentHighlight, error) {
+	documentManager := service.MustGet[workspace.DocumentManager](s.sc)
+	uri := core.ParseURI(string(params.TextDocument.URI))
+	targetDoc := documentManager.Get(uri)
+	if targetDoc == nil {
+		return nil, nil // Document not found
+	}
+	offset := targetDoc.TextDoc.OffsetAt(params.Position)
+	tokens := targetDoc.Tokens
+	sourceToken := tokens.SearchOffset(offset)
+	if sourceToken == nil {
+		return nil, nil // No token at the given position
+	}
+	nameFinder := service.MustGet[NameFinder](s.sc)
+	foundName := nameFinder.Find(ctx, sourceToken)
+	if foundName.Target == nil || foundName.Source == nil {
+		return nil, nil // Could not find a name
+	}
+	target := foundName.Target.Owner()
+	referencesFinder := service.MustGet[ReferencesFinder](s.sc)
+	highlights := []lsp.DocumentHighlight{}
+	for refDesc := range referencesFinder.Find(ctx, target, FindReferencesOptions{
+		IncludeDeclaration: true,
+		TargetURI:          uri,
+	}) {
+		highlight := lsp.DocumentHighlight{
+			Range: refDesc.Segment.Range.LspRange(),
+		}
+		highlights = append(highlights, highlight)
+	}
+	return highlights, nil
+}

--- a/server/references_finder.go
+++ b/server/references_finder.go
@@ -19,6 +19,10 @@ type FindReferencesOptions struct {
 	// Whether to include the declaration of the symbol as a dedicated [core.ReferenceDescription] in the results.
 	// If true, will contain the declaration as a reference with the same source and target node, and the range of the name as the first element.
 	IncludeDeclaration bool
+	// If set to a non-nil value, the references finder will only return references that are located in the document with the given URI.
+	//
+	// If IncludeDeclaration is true, the declaration will only be included if it is located in the document with the given URI.
+	TargetURI core.URI
 }
 
 type ReferencesFinder interface {
@@ -36,17 +40,41 @@ func NewDefaultReferencesFinder(sc *service.Container) ReferencesFinder {
 func (rf *DefaultReferencesFinder) Find(ctx context.Context, target core.AstNode, options FindReferencesOptions) iter.Seq[*core.ReferenceDescription] {
 	sequences := []iter.Seq[*core.ReferenceDescription]{}
 	if options.IncludeDeclaration {
-		nameUnit := linking.Name(target)
-		if nameUnit != nil {
-			selfDescription := core.NewReferenceDescription(target, target, nameUnit.Segment())
-			sequences = append(sequences, extiter.Of(selfDescription))
+		selfReference := findSelfReference(target, options)
+		if selfReference != nil {
+			sequences = append(sequences, extiter.Of(selfReference))
 		}
 	}
 	documentManager := service.MustGet[workspace.DocumentManager](rf.sc)
-	// Iterate through all documents and collect references to the symbol
-	for doc := range documentManager.All() {
-		refDescriptions := doc.ReferenceDescriptions.ForTarget(target)
-		sequences = append(sequences, refDescriptions)
+	if options.TargetURI == nil {
+		// Iterate through all documents and collect references to the symbol
+		for doc := range documentManager.All() {
+			refDescriptions := doc.ReferenceDescriptions.ForTarget(target)
+			sequences = append(sequences, refDescriptions)
+		}
+	} else {
+		// Only look for references in the document with the given URI
+		doc := documentManager.Get(options.TargetURI)
+		if doc != nil {
+			refDescriptions := doc.ReferenceDescriptions.ForTarget(target)
+			sequences = append(sequences, refDescriptions)
+		}
 	}
+
 	return extiter.Concat(sequences...)
+}
+
+func findSelfReference(target core.AstNode, options FindReferencesOptions) *core.ReferenceDescription {
+	if options.TargetURI != nil {
+		document := target.Document()
+		if document == nil || !document.URI.Equal(options.TargetURI) {
+			return nil
+		}
+	}
+	nameUnit := linking.Name(target)
+	if nameUnit != nil {
+		selfDescription := core.NewReferenceDescription(target, target, nameUnit.Segment())
+		return selfDescription
+	}
+	return nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -63,6 +63,9 @@ func (s *DefaultLanguageServer) Initialize(ctx context.Context, params *lsp.Para
 			FoldingRangeProvider: &lsp.Or_ServerCapabilities_foldingRangeProvider{
 				Value: service.Has[FoldingRangeProvider](s.sc),
 			},
+			DocumentHighlightProvider: &lsp.Or_ServerCapabilities_documentHighlightProvider{
+				Value: service.Has[DocumentHighlightProvider](s.sc),
+			},
 		},
 	}, nil
 }
@@ -246,7 +249,22 @@ func (s *DefaultLanguageServer) DocumentColor(ctx context.Context, params *lsp.D
 	return nil, nil
 }
 func (s *DefaultLanguageServer) DocumentHighlight(ctx context.Context, params *lsp.DocumentHighlightParams) ([]lsp.DocumentHighlight, error) {
-	return nil, nil
+	var result []lsp.DocumentHighlight
+	var providerErr error
+	lock, err := service.Get[workspace.Lock](s.sc)
+	if err != nil {
+		return nil, err
+	}
+	provider, err := service.Get[DocumentHighlightProvider](s.sc)
+	if err != nil {
+		return nil, err
+	}
+	if err := lock.Read(ctx, func(ctx context.Context) {
+		result, providerErr = provider.HandleDocumentHighlightRequest(ctx, params)
+	}); err != nil {
+		return nil, err
+	}
+	return result, providerErr
 }
 func (s *DefaultLanguageServer) DocumentLink(ctx context.Context, params *lsp.DocumentLinkParams) ([]lsp.DocumentLink, error) {
 	return nil, nil

--- a/server/services.go
+++ b/server/services.go
@@ -78,4 +78,7 @@ func SetupDefaultServices(sc *service.Container) {
 	if !service.Has[CompletionContributor](sc) {
 		service.Put(sc, NewDefaultCompletionContributor())
 	}
+	if !service.Has[DocumentHighlightProvider](sc) {
+		service.Put(sc, NewDefaultDocumentHighlightProvider(sc))
+	}
 }

--- a/test/doc_fixture_lsp.go
+++ b/test/doc_fixture_lsp.go
@@ -157,6 +157,51 @@ func (d *Doc) AssertReferences(label string) {
 	}
 }
 
+func (d *Doc) AssertHighlights(label string) {
+	d.fixture.t.Helper()
+	location, err := d.markerLocation(label, false)
+	if err != nil {
+		d.fixture.t.Fatalf("fbtest: %v", err)
+	}
+	highlightProvider, err := service.Get[server.DocumentHighlightProvider](d.fixture.sc)
+	if err != nil {
+		d.fixture.t.Fatalf("fbtest: no document highlight provider available: %v", err)
+	}
+	highlights, err := highlightProvider.HandleDocumentHighlightRequest(d.fixture.ctx, &lsp.DocumentHighlightParams{
+		TextDocumentPositionParams: lsp.TextDocumentPositionParams{
+			TextDocument: lsp.TextDocumentIdentifier{URI: d.Document.URI.DocumentURI()},
+			Position:     location.LspPosition(),
+		},
+	})
+	if err != nil {
+		d.fixture.t.Fatalf("fbtest: document highlight request failed: %v", err)
+	}
+	expectedLocations := []lsp.DocumentHighlight{}
+	for _, doc := range d.fixture.docs {
+		ranges := doc.markerRanges(label)
+		for _, r := range ranges {
+			expectedLocations = append(expectedLocations, lsp.DocumentHighlight{
+				Range: r.LspRange(),
+			})
+		}
+	}
+	if len(highlights) != len(expectedLocations) {
+		d.fixture.t.Fatalf("fbtest: expected %d document highlights, got %d", len(expectedLocations), len(highlights))
+	}
+	for _, expected := range expectedLocations {
+		found := false
+		for _, highlight := range highlights {
+			if highlight.Range == expected.Range {
+				found = true
+				break
+			}
+		}
+		if !found {
+			d.fixture.t.Errorf("fbtest: expected document highlight not found: range %v", expected.Range)
+		}
+	}
+}
+
 // AssertFoldingRanges verifies that folding ranges exist for all specified marker labels.
 // Returns the Doc for chaining.
 func (d *Doc) AssertFoldingRanges(labels ...string) *Doc {


### PR DESCRIPTION
Does as the title says. Works just like the references provider - but just for the current file.

Slightly adjusts the `ReferencesFinder` to have a `TargetURI` property. Implements a fast path if that property is set to only look at the selected URI.