### PR TITLE
Package documentation: lexer, textdoc, util/*

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,15 @@ For project documentation, read the package documentation written in Go doc form
 
 - `doc.go`: General overview of the Fastbelt framework
 - `grammar/doc.go`: Reference documentation for the grammar language
+- `lexer/doc.go`: Shared lexer runtime used by Fastbelt-generated languages
+- `textdoc/doc.go`: Text documents, overlays, and LSP position mapping
+
+Utility packages:
+
+- `util/codegen/doc.go`: Building indented multi-line source for code generators
+- `util/collections/doc.go`: Generic collection data structures (e.g. MultiMap)
+- `util/extiter/doc.go`: Utilities for `iter.Seq` sequences
+- `util/service/doc.go`: Typed dependency injection container
 
 ## VS Code extensions
 

--- a/README.md
+++ b/README.md
@@ -48,15 +48,27 @@ Add a directive to some file in your module (assumes install with `go tool`):
 ```go
 //go:generate go tool typefox.dev/fastbelt/cmd/fastbelt generate ./grammar.fb -o ./
 ```
+
 ## Scaffolding
 
-To bootstrap a **new Go module** for a language (minimal `.fb` grammar, `go:generate` using `go tool` on this CLI, LSP command, and VS Code extension layout), run:
+To bootstrap a **new Go module** for a language, run:
 
 ```sh
 fastbelt scaffold --module example.com/you/mylang --language "MyLanguage" --vscode
 ```
 
-That creates a directory named after the last segment of `--module` (here `./mylang`) in the current working directory, runs `go mod init`, pulls in fastbelt as a library and tool dependency, lays down the files, and runs `go generate`. Use `fastbelt scaffold -h` for full usage.
+That creates a directory named after the last segment of `--module` (here `./mylang`) in the current working directory, runs `go mod init`, pulls in fastbelt as a library and tool dependency, and runs `go generate` and `go mod tidy` so generated parser, lexer, linker, and supporting files are ready to use.
+
+In the generated package directory you get:
+
+- `gen.go` with `go:generate` directives for grammar-based code generation
+- `services.go` with customization points for generated services
+- `<language-id>.fb` as the initial grammar definition
+- `cmd/<language-id>-lsp/main.go` as the LSP server entrypoint
+
+Pass `--vscode` to also add a `vscode-extension` subfolder for editor integration.
+
+To add a language package to an **existing** module, omit `--module` and use `--package` (or `-p`) instead; see `fastbelt scaffold -h` for full usage.
 
 ## Examples
 

--- a/doc.go
+++ b/doc.go
@@ -20,26 +20,6 @@
 // grammar definition, which you can integrate and customize with additional
 // code.
 //
-// # Scaffolding
-//
-// The [typefox.dev/fastbelt/cmd/fastbelt] command can scaffold a new language
-// project with:
-//
-//	fastbelt scaffold -module example.com/you/mylang -language "MyLanguage"
-//
-// The scaffold creates these root files in the generated package directory:
-//
-//   - gen.go with go:generate directives for grammar-based code generation.
-//   - services.go with customization points for generated services.
-//   - <language-id>.fb as the initial grammar definition file.
-//   - cmd/<language-id>-lsp/main.go as the LSP server entrypoint.
-//
-// By default, scaffolding also creates VS Code extension files in a
-// `vscode-extension` subfolder.
-//
-// After writing templates, scaffolding runs go generate and go mod tidy so the
-// generated parser, lexer, linker, and supporting files are ready to use.
-//
 // # Defining the Grammar
 //
 // Defining a language in Fastbelt is an iterative design process. You
@@ -109,9 +89,9 @@
 //   - calls needed `SetupDefaultServices` functions from framework packages, and
 //   - calls `SetupGeneratedServices` from generated code.
 //
-// When you scaffold a new language project, Fastbelt generates a `services.go`
-// file that follows this pattern and can be used as a starting point for your
-// own service-container customization.
+// Scaffolded language projects include a generated `services.go` that follows
+// this pattern and can be used as a starting point for service-container
+// customization.
 //
 // # To Go Further
 //

--- a/lexer/doc.go
+++ b/lexer/doc.go
@@ -38,7 +38,9 @@
 //     types in a fixed-size map keyed by rune % 256 (each [core.TokenType]'s
 //     StartChars slice).
 //  2. Run each candidate's [core.Matcher] and keep the longest match (maximal
-//     munch). Keywords and regex token rules compete on equal footing.
+//     munch). Among equal-length matches, the first registered token type wins;
+//     generated lexers list keywords before regex token rules, so keywords take
+//     precedence when both match the same span.
 //  3. Route the match by [core.TokenType.Group]: default tokens go to
 //     [LexerResult.Tokens], hidden tokens are dropped, comments go to
 //     [LexerResult.Comments], and other groups are collected in

--- a/lexer/doc.go
+++ b/lexer/doc.go
@@ -1,0 +1,56 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+// Package lexer provides the shared lexer runtime used by Fastbelt-generated
+// languages. It does not implement lexing for any particular language; each
+// grammar gets its own generated lexer that wires this package together with
+// language-specific [core.TokenType] values.
+//
+// Run [typefox.dev/fastbelt/cmd/fastbelt] generate on a .fb grammar file to
+// emit `lexer_gen.go` (token type variables plus `NewLexer`) and register that
+// lexer in the generated service setup. See [typefox.dev/fastbelt] for the
+// overall toolchain and [typefox.dev/fastbelt/grammar] for how keywords and
+// token rules are declared in the grammar language.
+//
+// # Generated lexers
+//
+// Code generation turns grammar terminals into Go values:
+//
+//   - Keyword literals from parser rules become [core.TokenType] values with
+//     prefix [core.Matcher] functions and [core.TokenKindKeyword].
+//   - Named `token` rules become [core.TokenType] values whose matchers are
+//     compiled from the rule's regular expression, with [core.StartChars] taken
+//     from the expression's possible first runes (the StartChars field).
+//
+// The generated `NewLexer` function returns a [DefaultLexer] constructed via
+// [NewDefaultLexer] with every keyword and token type for that language.
+// [typefox.dev/fastbelt/workspace.DefaultDocumentParser] obtains a [Lexer] from
+// the service container, calls [Lexer.Lex], and stores [LexerResult.Tokens],
+// [LexerResult.Comments], and [LexerResult.Errors] on the document before
+// parsing.
+//
+// # Lexing model
+//
+// Fastbelt uses a table-driven scanner with the following approach:
+//
+//  1. At each input offset, decode the current rune and look up candidate token
+//     types in a fixed-size map keyed by rune % 256 (each [core.TokenType]'s
+//     StartChars slice).
+//  2. Run each candidate's [core.Matcher] and keep the longest match (maximal
+//     munch). Keywords and regex token rules compete on equal footing.
+//  3. Route the match by [core.TokenType.Group]: default tokens go to
+//     [LexerResult.Tokens], hidden tokens are dropped, comments go to
+//     [LexerResult.Comments], and other groups are collected in
+//     [LexerResult.Groups].
+//  4. If no token type matches, emit a [core.LexerError] and advance by one
+//     UTF-8 code point so lexing can continue.
+//
+// [DefaultLexer] tracks line and column while scanning and adapts its initial
+// token-slice capacity from a running average of tokens per byte across prior
+// [Lexer.Lex] calls on the same instance.
+//
+// Custom language projects rarely import this package directly unless they
+// replace the generated lexer. Typical integration is to call the generated
+// `SetupGeneratedServices` which registers [Lexer].
+package lexer

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -12,21 +12,32 @@ import (
 	core "typefox.dev/fastbelt"
 )
 
-type LexerResult struct {
-	Tokens   []core.Token
-	Comments []core.Token
-	Errors   []*core.LexerError
-	Groups   map[int][]core.Token
-}
-
+// Lexer tokenizes a complete source string in one shot.
 type Lexer interface {
 	Lex(input string) *LexerResult
+}
+
+// LexerResult holds everything produced by a single [Lexer.Lex] pass over
+// source text.
+type LexerResult struct {
+	// Tokens is the main token stream passed to the parser.
+	Tokens []core.Token
+	// Comments holds tokens whose [core.TokenType] uses [core.CommentGroup].
+	Comments []core.Token
+	// Errors lists recoverable lexing problems (unrecognized input).
+	Errors []*core.LexerError
+	// Groups collects tokens routed to custom [core.TokenType.Group] values
+	// other than the default, skipped, or comment groups. Nil when empty.
+	Groups map[int][]core.Token
 }
 
 // Allocate a new token every ~5 characters on average
 // This average is updated after lexing to adapt to the actual language
 const defaultTokenRatio = 1.0 / 5.0
 
+// DefaultLexer is the standard [Lexer] implementation. Generated `NewLexer`
+// functions build one from the [core.TokenType] descriptors emitted for a
+// grammar.
 type DefaultLexer struct {
 	tokenTypes []*core.TokenType
 	tokenMap   [][]*core.TokenType
@@ -35,6 +46,8 @@ type DefaultLexer struct {
 	avgRatio atomic.Uint64
 }
 
+// Lex scans input from left to right using longest-match disambiguation among
+// token types registered at construction time.
 func (l *DefaultLexer) Lex(input string) *LexerResult {
 	length := len(input)
 	ratio := math.Float64frombits(l.avgRatio.Load())
@@ -152,6 +165,9 @@ func (l *DefaultLexer) Lex(input string) *LexerResult {
 
 const maxChar = 256
 
+// NewDefaultLexer returns a lexer that recognizes the given token types.
+// The order of arguments is not significant; matching uses longest match at
+// each position.
 func NewDefaultLexer(tokenTypes ...*core.TokenType) *DefaultLexer {
 	tokenMap := make([][]*core.TokenType, maxChar)
 	for i := range maxChar {

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -166,8 +166,8 @@ func (l *DefaultLexer) Lex(input string) *LexerResult {
 const maxChar = 256
 
 // NewDefaultLexer returns a lexer that recognizes the given token types.
-// The order of arguments is not significant; matching uses longest match at
-// each position.
+// At each position the longest match wins; among equal-length matches, the
+// first argument wins.
 func NewDefaultLexer(tokenTypes ...*core.TokenType) *DefaultLexer {
 	tokenMap := make([][]*core.TokenType, maxChar)
 	for i := range maxChar {

--- a/textdoc/doc.go
+++ b/textdoc/doc.go
@@ -1,0 +1,46 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+// Package textdoc provides text documents and LSP position mapping for Fastbelt.
+//
+// textdoc is the text layer of the framework. It holds source text together
+// with LSP metadata (URI, language identifier, version) and converts between
+// byte offsets and [typefox.dev/lsp] positions. It does not parse text or
+// attach semantic data such as ASTs, symbols, or diagnostics. That role
+// belongs to [typefox.dev/fastbelt.Document] and the
+// [typefox.dev/fastbelt/workspace] package.
+//
+// # Document handles
+//
+// [Handle] is the common read interface for document text. Lexers, parsers,
+// and other consumers work against Handle so they do not depend on whether
+// the text came from disk or from an open editor buffer.
+//
+//   - [File] is an immutable snapshot of on-disk content.
+//   - [Overlay] is a mutable editor buffer that may contain unsaved changes.
+//
+// When a workspace is initialized, files read from disk become [File] values
+// and are wrapped in [typefox.dev/fastbelt.Document] instances by the workspace
+// initializer. When a language client opens a document, the LSP server creates
+// an [Overlay] for the same URI. Incremental didChange notifications update
+// that overlay in place via [Overlay.Update].
+//
+// [Store] caches open overlays and, optionally, file snapshots. [Store.Get]
+// returns the overlay when one exists for a URI, otherwise the cached file,
+// so callers always see the effective editor content for open documents.
+//
+// On didClose, the server removes the overlay and reverts the workspace to
+// on-disk [File] content when the URI refers to a local file.
+//
+// # Service registration
+//
+// Call [SetupDefaultServices] during service container setup to register a
+// [DefaultStore]. Language projects typically invoke it from their
+// SetupServices function alongside other framework SetupDefaultServices
+// functions.
+//
+// For tests and standalone tooling that do not run an LSP server, create
+// [File] or [Overlay] values directly and pass them to
+// [typefox.dev/fastbelt.NewDocument].
+package textdoc

--- a/textdoc/overlay.go
+++ b/textdoc/overlay.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Overlay represents an open text document in the editor.
-// It may have unsaved edits and implements both Handle and Mapper.
+// It may have unsaved edits and implements [Handle].
 // Conceptually, an overlay models in-memory edits layered on top of any on-disk file content.
 type Overlay struct {
 	File

--- a/util/codegen/codegen.go
+++ b/util/codegen/codegen.go
@@ -16,15 +16,34 @@ func eol() string {
 	return "\n"
 }
 
+// EOL is the line separator used when joining logical lines in [Node.String].
+// It is "\r\n" on Windows hosts and "\n" elsewhere, fixed at package init time.
 var EOL = eol()
 
+// Callback receives a [Node] to populate, typically from [Node.Indent].
 type Callback func(node Node)
 
+// Node is a mutable buffer for building indented, multi-line text. Generators
+// assemble source by appending to the current line, starting new lines, nesting
+// blocks with [Node.Indent], and merging completed subtrees with [Node.AppendNode].
+// Methods return the receiver so calls can be chained.
 type Node interface {
+	// Append adds texts to the current line without starting a new line. When the
+	// current line is empty, leading indentation for the node's depth is inserted
+	// before the first text.
 	Append(texts ...string) Node
+	// AppendLine adds texts to the current line and then begins a new line.
 	AppendLine(texts ...string) Node
+	// AppendNode merges nodes into the receiver. Each child's first line is
+	// concatenated onto the receiver's current line; any further lines from the
+	// child become subsequent lines of the receiver.
 	AppendNode(nodes ...Node) Node
+	// Indent runs cb with a child node indented one level deeper (four spaces
+	// per level), then splices the child's content into the receiver. If the
+	// receiver's current line is non-empty, a line break is inserted before the
+	// merged content.
 	Indent(cb Callback) Node
+	// String returns the accumulated text with [EOL] between logical lines.
 	String() string
 }
 
@@ -126,6 +145,7 @@ func newNode() *node {
 	}
 }
 
+// NewNode returns an empty [Node] with one blank line ready for appending.
 func NewNode() Node {
 	return newNode()
 }

--- a/util/codegen/doc.go
+++ b/util/codegen/doc.go
@@ -1,0 +1,15 @@
+// Copyright 2025 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+// Package codegen provides a small builder for assembling multi-line source
+// text with indentation. Fastbelt's own code generators use it to construct
+// Go (and other) source before passing the result to a formatter. Fastbelt
+// adopters can use the same API when writing custom code generators for their
+// own languages.
+//
+// Create a root with [NewNode], write lines with [Node.Append] and
+// [Node.AppendLine], increase nesting with [Node.Indent], splice completed
+// fragments with [Node.AppendNode], and read the result from [Node.String].
+// Line breaks in the output use [EOL], which matches the host platform.
+package codegen

--- a/util/collections/doc.go
+++ b/util/collections/doc.go
@@ -1,0 +1,8 @@
+// Copyright 2025 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+// Package collections provides generic collection data structures shared across
+// Fastbelt. Use [MultiMap] when a key may map to many values and callers need
+// grouped lookup, ordered values per key, or a total element count.
+package collections

--- a/util/collections/multi_map.go
+++ b/util/collections/multi_map.go
@@ -9,22 +9,51 @@ import (
 	"maps"
 )
 
+// A MultiMap is a map from keys to ordered lists of values.
+// Each key can hold zero or more values; [Put] and [PutAll] append to a key's
+// list and preserve insertion order within that list.
+//
+// MultiMap is not safe for concurrent use by multiple goroutines.
 type MultiMap[K comparable, V any] interface {
+	// Get returns the values stored for key in insertion order.
+	// The result is nil when key is absent.
+	// Callers must not modify the returned slice.
 	Get(key K) []V
+	// Has reports whether key has at least one stored value.
 	Has(key K) bool
+	// TryGet returns the values stored for key and reports whether key is present.
+	// The result is nil when key is absent.
+	// Callers must not modify the returned slice.
 	TryGet(key K) ([]V, bool)
+	// Put appends value to the list for key.
 	Put(key K, value V)
+	// PutAll appends values to the list for key.
 	PutAll(key K, values []V)
+	// Remove deletes key and all of its values.
 	Remove(key K)
+	// RemoveWhen deletes values for key that satisfy predicate.
+	// If no values remain for key, the key is removed.
 	RemoveWhen(key K, predicate func(V) bool)
+	// Clear removes all keys and values.
 	Clear()
+	// Keys iterates the distinct keys in the multimap.
+	// Iteration order is unspecified.
 	Keys() iter.Seq[K]
+	// Values iterates every stored value, flattened across keys.
+	// Order within a key follows insertion order; order across keys is unspecified.
 	Values() iter.Seq[V]
+	// All iterates every stored key-value pair.
+	// Each value is yielded separately with its key.
+	// Order within a key follows insertion order; order across keys is unspecified.
 	All() iter.Seq2[K, V]
+	// Groups iterates each key with its full value slice.
+	// Iteration order is unspecified.
 	Groups() iter.Seq2[K, []V]
+	// Size returns the total number of stored values across all keys.
 	Size() int
 }
 
+// NewMultiMap returns an empty [MultiMap].
 func NewMultiMap[K comparable, V any]() MultiMap[K, V] {
 	return &multiMap[K, V]{
 		data: make(map[K][]V),

--- a/util/extiter/doc.go
+++ b/util/extiter/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2025 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+// Package extiter provides utilities for working with [iter.Seq] sequences.
+//
+// Most functions fall into two groups. Sequence builders and lazy transforms
+// such as [Of], [Empty], [Map], [Filter], [FlatMap], and [Concat] return a
+// new sequence and defer work until a consumer iterates. Eager operations
+// such as [Count], [IsEmpty], [Every], [Find], and [Reduce] walk the input
+// sequence immediately and return a value.
+//
+// Fastbelt uses extiter throughout symbol lookup and linking: [Empty] and
+// [IsEmpty] represent and test empty symbol iterators, [Map] and [Filter]
+// reshape document and scope collections, [FlatMap] flattens nested symbol
+// containers, and [Concat] chains local and outer scope elements.
+package extiter

--- a/util/extiter/extiter.go
+++ b/util/extiter/extiter.go
@@ -12,16 +12,23 @@ import (
 	"strings"
 )
 
-// Empty returns an empty sequence of type T.
+// Empty returns an empty [iter.Seq] of type T.
+//
+// The returned sequence yields no elements. It can be reused as a stable
+// sentinel, for example when an API must return a sequence but has nothing
+// to enumerate.
 func Empty[T any]() iter.Seq[T] {
 	return func(yield func(T) bool) {}
 }
 
+// Of returns a sequence over the given elements in order.
 func Of[T any](elements ...T) iter.Seq[T] {
 	return slices.Values(elements)
 }
 
-// Count returns the number of elements in the sequence
+// Count returns the number of elements in seq.
+//
+// Count fully consumes seq.
 func Count[T any](seq iter.Seq[T]) int {
 	count := 0
 	for range seq {
@@ -30,7 +37,9 @@ func Count[T any](seq iter.Seq[T]) int {
 	return count
 }
 
-// IsEmpty returns true if the sequence contains no elements
+// IsEmpty reports whether seq yields no elements.
+//
+// A nil sequence is treated as empty.
 func IsEmpty[T any](seq iter.Seq[T]) bool {
 	if seq == nil {
 		return true
@@ -41,7 +50,11 @@ func IsEmpty[T any](seq iter.Seq[T]) bool {
 	return true
 }
 
-// Join concatenates all elements into a string, separated by the specified separator
+// Join concatenates the string form of each element in seq, separated by separator.
+//
+// Strings pass through unchanged. Values implementing [fmt.Stringer] use
+// String(). Numeric and boolean types use default formatting. Nil is rendered
+// as "nil"; other types use a default %v representation.
 func Join[T any](seq iter.Seq[T], separator string) string {
 	var parts []string
 	for value := range seq {
@@ -50,7 +63,8 @@ func Join[T any](seq iter.Seq[T], separator string) string {
 	return strings.Join(parts, separator)
 }
 
-// IndexOf returns the index of the first occurrence of a value, or -1 if not found
+// IndexOf returns the index of the first element equal to searchElement, or -1
+// if seq does not contain it.
 func IndexOf[T comparable](seq iter.Seq[T], searchElement T) int {
 	index := 0
 	for value := range seq {
@@ -62,7 +76,9 @@ func IndexOf[T comparable](seq iter.Seq[T], searchElement T) int {
 	return -1
 }
 
-// Every returns true if all elements satisfy the predicate
+// Every reports whether predicate holds for every element in seq.
+//
+// An empty sequence satisfies Every.
 func Every[T any](seq iter.Seq[T], predicate func(T) bool) bool {
 	for value := range seq {
 		if !predicate(value) {
@@ -72,7 +88,9 @@ func Every[T any](seq iter.Seq[T], predicate func(T) bool) bool {
 	return true
 }
 
-// Any returns true if any element satisfies the predicate
+// Any reports whether predicate holds for at least one element in seq.
+//
+// An empty sequence does not satisfy Any.
 func Any[T any](seq iter.Seq[T], predicate func(T) bool) bool {
 	for value := range seq {
 		if predicate(value) {
@@ -82,7 +100,9 @@ func Any[T any](seq iter.Seq[T], predicate func(T) bool) bool {
 	return false
 }
 
-// ForEach performs the specified action for each element
+// ForEach calls action once for each element in seq.
+//
+// The second argument to action is the zero-based index of the element.
 func ForEach[T any](seq iter.Seq[T], action func(T, int)) {
 	index := 0
 	for value := range seq {
@@ -91,7 +111,9 @@ func ForEach[T any](seq iter.Seq[T], action func(T, int)) {
 	}
 }
 
-// Map returns a sequence that yields the results of applying the function to each element
+// Map returns a lazy sequence that applies fn to each element of seq.
+//
+// Iteration stops early when the consumer stops the sequence.
 func Map[T, U any](seq iter.Seq[T], fn func(T) U) iter.Seq[U] {
 	return func(yield func(U) bool) {
 		for value := range seq {
@@ -102,7 +124,9 @@ func Map[T, U any](seq iter.Seq[T], fn func(T) U) iter.Seq[U] {
 	}
 }
 
-// Filter returns a sequence containing only elements that satisfy the predicate
+// Filter returns a lazy sequence of elements in seq for which predicate is true.
+//
+// Iteration stops early when the consumer stops the sequence.
 func Filter[T any](seq iter.Seq[T], predicate func(T) bool) iter.Seq[T] {
 	return func(yield func(T) bool) {
 		for value := range seq {
@@ -115,6 +139,10 @@ func Filter[T any](seq iter.Seq[T], predicate func(T) bool) iter.Seq[T] {
 	}
 }
 
+// FilterType returns a lazy sequence of elements in seq that have dynamic type U.
+//
+// Each element is type-asserted to U; elements that do not assert are skipped.
+// Iteration stops early when the consumer stops the sequence.
 func FilterType[T, U any](seq iter.Seq[T]) iter.Seq[U] {
 	return func(yield func(U) bool) {
 		for value := range seq {
@@ -127,14 +155,23 @@ func FilterType[T, U any](seq iter.Seq[T]) iter.Seq[U] {
 	}
 }
 
-// NonZero returns a sequence containing only non-zero values
+// NonZero returns a lazy sequence of elements in seq that are not the zero
+// value of their type.
+//
+// Numeric zero, false booleans, empty strings, nil pointers and interfaces,
+// and other types' zero values as determined by [reflect.Value.IsZero] are
+// removed.
 func NonZero[T any](seq iter.Seq[T]) iter.Seq[T] {
 	return Filter(seq, func(value T) bool {
 		return !isZero(value)
 	})
 }
 
-// Reduce applies a function to each element, accumulating the result
+// Reduce folds seq with fn, using the first element as the initial accumulator.
+//
+// The returned bool is false when seq is empty; otherwise it is true and the
+// result is the folded value. For a single element, that element is returned
+// unchanged.
 func Reduce[T any](seq iter.Seq[T], fn func(T, T) T) (T, bool) {
 	var result T
 	found := false
@@ -150,7 +187,9 @@ func Reduce[T any](seq iter.Seq[T], fn func(T, T) T) (T, bool) {
 	return result, found
 }
 
-// ReduceWithInitial applies a function to each element with an initial value
+// ReduceWithInitial folds seq into initialValue using fn.
+//
+// An empty sequence returns initialValue unchanged.
 func ReduceWithInitial[T, U any](seq iter.Seq[T], fn func(U, T) U, initialValue U) U {
 	result := initialValue
 	for value := range seq {
@@ -159,7 +198,11 @@ func ReduceWithInitial[T, U any](seq iter.Seq[T], fn func(U, T) U, initialValue 
 	return result
 }
 
-// ReduceRight applies a function to each element in reverse order
+// ReduceRight folds seq from right to left with fn.
+//
+// The sequence is materialized before folding. The last element becomes the
+// initial accumulator; fn is then applied to the accumulator and each
+// preceding element in turn. The returned bool is false when seq is empty.
 func ReduceRight[T any](seq iter.Seq[T], fn func(T, T) T) (T, bool) {
 	// Collect all elements first since we need to iterate in reverse
 	elements := slices.Collect(seq)
@@ -175,7 +218,10 @@ func ReduceRight[T any](seq iter.Seq[T], fn func(T, T) T) (T, bool) {
 	return result, true
 }
 
-// ReduceRightWithInitial applies a function to each element in reverse order with an initial value
+// ReduceRightWithInitial folds seq from right to left into initialValue using fn.
+//
+// The sequence is materialized before folding. Elements are combined starting
+// with the last element in seq.
 func ReduceRightWithInitial[T, U any](seq iter.Seq[T], fn func(U, T) U, initialValue U) U {
 	elements := slices.Collect(seq)
 	result := initialValue
@@ -185,7 +231,10 @@ func ReduceRightWithInitial[T, U any](seq iter.Seq[T], fn func(U, T) U, initialV
 	return result
 }
 
-// Find returns the first element that satisfies the predicate, its index, and whether it was found
+// Find returns the first element in seq for which predicate is true, its
+// zero-based index, and a bool indicating whether such an element exists.
+//
+// When no element matches, Find returns the zero value of T, index -1, and false.
 func Find[T any](seq iter.Seq[T], predicate func(T) bool) (T, int, bool) {
 	index := 0
 	for value := range seq {
@@ -198,7 +247,7 @@ func Find[T any](seq iter.Seq[T], predicate func(T) bool) (T, int, bool) {
 	return zero, -1, false
 }
 
-// Contains returns true if the sequence contains the specified element
+// Contains reports whether seq includes an element equal to element.
 func Contains[T comparable](seq iter.Seq[T], element T) bool {
 	for value := range seq {
 		if value == element {
@@ -208,7 +257,10 @@ func Contains[T comparable](seq iter.Seq[T], element T) bool {
 	return false
 }
 
-// FlatMap applies a function to each element and flattens the results
+// FlatMap returns a lazy sequence formed by applying fn to each element of seq
+// and concatenating the resulting sequences in order.
+//
+// Iteration stops early when the consumer stops the sequence.
 func FlatMap[T, U any](seq iter.Seq[T], fn func(T) iter.Seq[U]) iter.Seq[U] {
 	return func(yield func(U) bool) {
 		for value := range seq {
@@ -221,7 +273,9 @@ func FlatMap[T, U any](seq iter.Seq[T], fn func(T) iter.Seq[U]) iter.Seq[U] {
 	}
 }
 
-// Head returns the first element, or the zero value and false if empty
+// Head returns the first element of seq and whether one exists.
+//
+// When seq is empty, Head returns the zero value of T and false.
 func Head[T any](seq iter.Seq[T]) (T, bool) {
 	for value := range seq {
 		return value, true
@@ -230,7 +284,9 @@ func Head[T any](seq iter.Seq[T]) (T, bool) {
 	return zero, false
 }
 
-// Tail returns a sequence that skips the first n elements
+// Tail returns a lazy sequence of the elements in seq after skipping the first n.
+//
+// If n is greater than or equal to the length of seq, the result is empty.
 func Tail[T any](seq iter.Seq[T], n int) iter.Seq[T] {
 	return func(yield func(T) bool) {
 		count := 0
@@ -245,7 +301,9 @@ func Tail[T any](seq iter.Seq[T], n int) iter.Seq[T] {
 	}
 }
 
-// Limit returns a sequence limited to the specified number of elements
+// Limit returns a lazy sequence of at most maxSize elements from seq.
+//
+// If maxSize is zero or negative, the result is empty.
 func Limit[T any](seq iter.Seq[T], maxSize int) iter.Seq[T] {
 	return func(yield func(T) bool) {
 		count := 0
@@ -261,8 +319,12 @@ func Limit[T any](seq iter.Seq[T], maxSize int) iter.Seq[T] {
 	}
 }
 
-// Distinct returns a sequence containing only unique elements
-// If keyFn is provided, it's used to determine uniqueness
+// Distinct returns a lazy sequence of the first occurrence of each distinct
+// element in seq.
+//
+// When keyFn is nil, elements are compared by value. Otherwise keyFn defines
+// the key used to decide whether two elements are the same; the first element
+// for each key is kept.
 func Distinct[T any](seq iter.Seq[T], keyFn func(T) any) iter.Seq[T] {
 	return func(yield func(T) bool) {
 		seen := make(map[any]struct{})
@@ -284,8 +346,10 @@ func Distinct[T any](seq iter.Seq[T], keyFn func(T) any) iter.Seq[T] {
 	}
 }
 
-// Exclude returns a sequence containing elements that don't exist in the other sequence
-// If keyFn is provided, it's used to determine equality
+// Exclude returns a lazy sequence of elements in seq whose key is not present in other.
+//
+// The other sequence is fully consumed before filtering begins. When keyFn is
+// nil, elements are compared by value; otherwise keyFn defines the comparison key.
 func Exclude[T any](seq iter.Seq[T], other iter.Seq[T], keyFn func(T) any) iter.Seq[T] {
 	// Collect keys from the other sequence
 	otherKeySet := make(map[any]struct{})
@@ -311,7 +375,9 @@ func Exclude[T any](seq iter.Seq[T], other iter.Seq[T], keyFn func(T) any) iter.
 	})
 }
 
-// Concat combines multiple sequences into one
+// Concat returns a lazy sequence that yields every element of sequences in order.
+//
+// Iteration stops early when the consumer stops the sequence.
 func Concat[T any](sequences ...iter.Seq[T]) iter.Seq[T] {
 	return func(yield func(T) bool) {
 		for _, seq := range sequences {
@@ -333,7 +399,7 @@ func toString(item any) string {
 	if str, ok := item.(string); ok {
 		return str
 	}
-	if stringer, ok := item.(interface{ String() string }); ok {
+	if stringer, ok := item.(fmt.Stringer); ok {
 		return stringer.String()
 	}
 	// Handle basic types

--- a/util/service/doc.go
+++ b/util/service/doc.go
@@ -1,0 +1,68 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+// Package service provides a typed dependency injection container used across
+// Fastbelt. Framework packages and language implementations register shared
+// components (parsers, linkers, workspace builders, LSP handlers, etc.) in a
+// [Container] keyed by Go type, then retrieve them with [Get] or [MustGet]
+// after the container is sealed.
+//
+// # Container lifecycle
+//
+// DI containers have two phases. During setup, register services with [Put]
+// and replace existing registrations with [Override]. Call [Container.Seal]
+// when wiring is complete; after that, [Put] and [Override] panic and [Get]
+// becomes available. [Has] reports whether a type is registered and may be
+// called before sealing.
+//
+// A typical factory helper looks like:
+//
+//	func CreateServices() *service.Container {
+//	    sc := service.NewContainer()
+//	    SetupServices(sc)
+//	    sc.Seal()
+//	    return sc
+//	}
+//
+// Framework code that must resolve a dependency at runtime calls
+// [MustGet] after the container has been sealed.
+//
+// # SetupDefaultServices in framework packages
+//
+// Each key package of Fastbelt exposes a SetupDefaultServices function that
+// registers its default implementations into a container:
+//
+//   - [typefox.dev/fastbelt/textdoc.SetupDefaultServices]
+//   - [typefox.dev/fastbelt/linking.SetupDefaultServices]
+//   - [typefox.dev/fastbelt/workspace.SetupDefaultServices]
+//   - [typefox.dev/fastbelt/server.SetupDefaultServices]
+//
+// These functions are idempotent: they call [Has] before [Put] and skip types
+// that are already registered, so a language can pre-register custom
+// implementations and still call the framework defaults for everything else.
+//
+// # SetupServices and CreateServices in language implementations
+//
+// Each language project defines SetupServices to wire a complete container
+// for that language. By convention, SetupServices:
+//
+//   - registers language-specific configuration such as
+//     [typefox.dev/fastbelt/workspace.LanguageID] and
+//     [typefox.dev/fastbelt/workspace.FileExtensions],
+//   - calls the framework SetupDefaultServices functions listed above,
+//   - calls SetupGeneratedServices from generated code (registers the lexer,
+//     parser, scope provider, and other grammar-specific services), and
+//   - optionally replaces defaults with [Override] for language-specific
+//     behavior.
+//
+// CreateServices is the usual entry point for CLI tools and tests: it creates
+// a container with [NewContainer], calls SetupServices, seals the container,
+// and returns it. Language servers follow the same pattern but also call
+// SetupGeneratedServerServices and [typefox.dev/fastbelt/server.SetupDefaultServices]
+// before sealing; many projects expose a separate CreateLspServices helper for
+// that path.
+//
+// Scaffolded language projects include a generated services.go that follows
+// this layout and can be extended for customization.
+package service

--- a/util/service/doc.go
+++ b/util/service/doc.go
@@ -25,9 +25,6 @@
 //	    return sc
 //	}
 //
-// Framework code that must resolve a dependency at runtime calls
-// [MustGet] after the container has been sealed.
-//
 // # SetupDefaultServices in framework packages
 //
 // Each key package of Fastbelt exposes a SetupDefaultServices function that
@@ -39,8 +36,10 @@
 //   - [typefox.dev/fastbelt/server.SetupDefaultServices]
 //
 // These functions are idempotent: they call [Has] before [Put] and skip types
-// that are already registered, so a language can pre-register custom
-// implementations and still call the framework defaults for everything else.
+// that are already registered. A language can pre-register custom
+// implementations before calling them, or call [Override] afterward to replace
+// specific defaults while still using the framework defaults for everything
+// else.
 //
 // # SetupServices and CreateServices in language implementations
 //

--- a/util/service/service.go
+++ b/util/service/service.go
@@ -11,7 +11,10 @@ import (
 	"reflect"
 )
 
-// Container holds a collection of services to be used in the framework.
+// A Container holds a collection of services keyed by Go type.
+// Register services with [Put] and [Override] during setup, call [Container.Seal]
+// when wiring is complete, then retrieve services with [Get] or [MustGet].
+// The zero value is not usable; create containers with [NewContainer].
 type Container struct {
 	services map[reflect.Type]any
 	sealed   bool


### PR DESCRIPTION
Adding more documentation:

- lexer package
- textdoc package
- All util packages
- Removed redundancy between root package doc and README.md, which is included in the public documentation