### PR TITLE
WASM Prototype

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -65,6 +65,20 @@
 			"outFiles": [
 				"${workspaceFolder}/internal/vscode-extensions/statemachine/dist/**/*.js"
 			]
+		},
+		{
+			"name": "Statemachine Web Extension",
+			"type": "extensionHost",
+			"request": "launch",
+			"args": [
+				"${workspaceFolder}/examples/statemachine",
+				"--extensionDevelopmentPath=${workspaceFolder}/internal/vscode-extensions/statemachine",
+				"--extensionDevelopmentKind=web"
+			],
+			"sourceMaps": true,
+			"outFiles": [
+				"${workspaceFolder}/internal/vscode-extensions/statemachine/dist/**/*.js"
+			]
 		}
 	]
 }

--- a/examples/statemachine/server/main.go
+++ b/examples/statemachine/server/main.go
@@ -2,6 +2,8 @@
 // This program and the accompanying materials are made available under the
 // terms of the MIT License, which is available in the project root.
 
+//go:build !js || !wasm
+
 package main
 
 import (
@@ -14,7 +16,7 @@ import (
 
 func main() {
 	ctx := context.Background()
-	sc := statemachine.CreateLspServices()
+	sc := statemachine.CreateLspServices(server.SetupStdioServices)
 
 	if err := server.StartLanguageServer(ctx, sc); err != nil {
 		log.Fatalf("Error: %v", err)

--- a/examples/statemachine/server/main_wasm.go
+++ b/examples/statemachine/server/main_wasm.go
@@ -1,0 +1,42 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+//go:build js && wasm
+
+package main
+
+import (
+	"context"
+
+	"typefox.dev/fastbelt/examples/statemachine"
+	"typefox.dev/fastbelt/server"
+	"typefox.dev/fastbelt/util/service"
+	"typefox.dev/fastbelt/workspace"
+	"typefox.dev/lsp"
+)
+
+// noopInitializer is used in the browser build, where there is no filesystem to
+// scan. The server only operates on documents delivered over the LSP connection.
+type noopInitializer struct{}
+
+func (noopInitializer) Initialize(ctx context.Context, folders []lsp.WorkspaceFolder) error {
+	return nil
+}
+
+func main() {
+	ctx := context.Background()
+
+	sc := statemachine.CreateLspServices(func(sc *service.Container) {
+		// Override the default services with browser-compatible implementations.
+		server.SetupWasmServices(sc)
+		service.Override[workspace.Initializer](sc, noopInitializer{})
+	})
+
+	// StartLanguageServer blocks on the connection until it is closed, which
+	// keeps the WASM instance alive while the worker is running.
+	if err := server.StartLanguageServer(ctx, sc); err != nil {
+		// Logging goes to the worker console via the WASM runtime.
+		panic(err)
+	}
+}

--- a/examples/statemachine/services.go
+++ b/examples/statemachine/services.go
@@ -33,11 +33,14 @@ func CreateServices() *service.Container {
 }
 
 // CreateLspServices creates a service container for the statemachine language to be used in the language server.
-func CreateLspServices() *service.Container {
+func CreateLspServices(setup func(*service.Container)) *service.Container {
 	sc := service.NewContainer()
 	SetupServices(sc)
 	SetupGeneratedServerServices(sc)
 	server.SetupDefaultServices(sc)
+	if setup != nil {
+		setup(sc)
+	}
 	sc.Seal()
 	return sc
 }

--- a/examples/statemachine/statemachine_definition_test.go
+++ b/examples/statemachine/statemachine_definition_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestDefinitionOnName(t *testing.T) {
-	f := test.New(t, CreateLspServices())
+	f := test.New(t, CreateLspServices(nil))
 	doc := f.Parse(`
 		statemachine Toggle
 
@@ -32,7 +32,7 @@ func TestDefinitionOnName(t *testing.T) {
 }
 
 func TestDefinitionOnReference(t *testing.T) {
-	f := test.New(t, CreateLspServices())
+	f := test.New(t, CreateLspServices(nil))
 	doc := f.Parse(`
 		statemachine Toggle
 

--- a/examples/statemachine/statemachine_highlight_test.go
+++ b/examples/statemachine/statemachine_highlight_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestHighlightOnEventName(t *testing.T) {
-	f := test.New(t, CreateLspServices())
+	f := test.New(t, CreateLspServices(nil))
 	doc := f.Parse(`
 		statemachine Toggle
 
@@ -32,7 +32,7 @@ func TestHighlightOnEventName(t *testing.T) {
 }
 
 func TestHighlightOnEventReference(t *testing.T) {
-	f := test.New(t, CreateLspServices())
+	f := test.New(t, CreateLspServices(nil))
 	doc := f.Parse(`
 		statemachine Toggle
 
@@ -53,7 +53,7 @@ func TestHighlightOnEventReference(t *testing.T) {
 }
 
 func TestHighlightOnStateName(t *testing.T) {
-	f := test.New(t, CreateLspServices())
+	f := test.New(t, CreateLspServices(nil))
 	doc := f.Parse(`
 		statemachine Toggle
 
@@ -76,7 +76,7 @@ func TestHighlightOnStateName(t *testing.T) {
 // An event and a command can share the same name. Highlighting one kind of
 // element must not bleed into the equally named element of the other kind.
 func TestHighlightDistinguishesCommandFromEvent(t *testing.T) {
-	f := test.New(t, CreateLspServices())
+	f := test.New(t, CreateLspServices(nil))
 	doc := f.Parse(`
 		statemachine Toggle
 

--- a/examples/statemachine/statemachine_references_test.go
+++ b/examples/statemachine/statemachine_references_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestReferencesOnName(t *testing.T) {
-	f := test.New(t, CreateLspServices())
+	f := test.New(t, CreateLspServices(nil))
 	doc := f.Parse(`
 		statemachine Toggle
 
@@ -32,7 +32,7 @@ func TestReferencesOnName(t *testing.T) {
 }
 
 func TestReferencesOnReference(t *testing.T) {
-	f := test.New(t, CreateLspServices())
+	f := test.New(t, CreateLspServices(nil))
 	doc := f.Parse(`
 		statemachine Toggle
 

--- a/examples/statemachine/statemachine_rename_test.go
+++ b/examples/statemachine/statemachine_rename_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestRenameOnDefinition(t *testing.T) {
-	f := test.New(t, CreateLspServices())
+	f := test.New(t, CreateLspServices(nil))
 	doc := f.Parse(`
 		statemachine Toggle
 
@@ -36,7 +36,7 @@ func TestRenameOnDefinition(t *testing.T) {
 }
 
 func TestRenameOnReference(t *testing.T) {
-	f := test.New(t, CreateLspServices())
+	f := test.New(t, CreateLspServices(nil))
 	doc := f.Parse(`
 		statemachine Toggle
 

--- a/internal/grammar/server/main.go
+++ b/internal/grammar/server/main.go
@@ -19,6 +19,7 @@ func CreateServices() *service.Container {
 	grammar.SetupServices(sc)
 	grammar.SetupGeneratedServerServices(sc)
 	server.SetupDefaultServices(sc)
+	server.SetupStdioServices(sc)
 	sc.Seal()
 	return sc
 }

--- a/internal/scaffold/templates/cmd/main.go.tmpl
+++ b/internal/scaffold/templates/cmd/main.go.tmpl
@@ -18,6 +18,7 @@ func CreateServices() *service.Container {
 	sc := service.NewContainer()
 	lang.SetupServices(sc)
 	server.SetupDefaultServices(sc)
+	server.SetupStdioServices(sc)
 	sc.Seal()
 	return sc
 }

--- a/internal/vscode-extensions/fastbelt/tsconfig.json
+++ b/internal/vscode-extensions/fastbelt/tsconfig.json
@@ -7,6 +7,7 @@
 		],
 		"sourceMap": true,
 		"rootDir": "src",
+		"skipLibCheck": true,
 		"strict": true,   /* enable all strict type-checking options */
 		/* Additional Checks */
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */

--- a/internal/vscode-extensions/package-lock.json
+++ b/internal/vscode-extensions/package-lock.json
@@ -10,11 +10,11 @@
         "statemachine"
       ],
       "devDependencies": {
-        "@types/node": "22.x",
+        "@types/node": "24.x",
         "@types/vscode": "^1.104.0",
         "esbuild": "^0.27.0",
         "shx": "^0.4.0",
-        "typescript": "^5.9.3"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -23,7 +23,8 @@
     },
     "fastbelt": {
       "name": "fastbelt-vscode",
-      "version": "0.0.0",
+      "version": "0.0.1",
+      "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "~9.0.1"
       },
@@ -512,13 +513,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.19.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz",
-      "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
+      "version": "24.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.0.tgz",
+      "integrity": "sha512-5vtOqGQr4NJKeEzV441FcOi2MeG9UTWq9LqVLGneDdu4vlX17H8kQ2PA2UmNwCUGPVDj4oBjNhS7ReVEIWJJrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/vscode": {
@@ -1158,9 +1159,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1172,9 +1173,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },

--- a/internal/vscode-extensions/package.json
+++ b/internal/vscode-extensions/package.json
@@ -12,10 +12,10 @@
   },
   "devDependencies": {
     "@types/vscode": "^1.104.0",
-    "@types/node": "22.x",
+    "@types/node": "24.x",
     "esbuild": "^0.27.0",
     "shx": "^0.4.0",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "workspaces": [
     "fastbelt",

--- a/internal/vscode-extensions/statemachine/build-wasm.js
+++ b/internal/vscode-extensions/statemachine/build-wasm.js
@@ -1,0 +1,23 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+// Builds the statemachine language server as a WebAssembly module. Go's
+// `wasm_exec.js` runtime is inlined into the worker bundle by esbuild, so it is
+// not copied here.
+
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const dist = path.join(__dirname, 'dist');
+fs.mkdirSync(dist, { recursive: true });
+
+// Compile the Go server for the JS/WASM target.
+execFileSync('go', ['build', '-o', path.join(dist, 'server.wasm'), '../../../examples/statemachine/server'], {
+    cwd: __dirname,
+    stdio: 'inherit',
+    env: { ...process.env, GOOS: 'js', GOARCH: 'wasm' },
+});
+
+console.log('Built dist/server.wasm');

--- a/internal/vscode-extensions/statemachine/esbuild.js
+++ b/internal/vscode-extensions/statemachine/esbuild.js
@@ -1,7 +1,17 @@
 const esbuild = require('esbuild');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const production = process.argv.includes('--production');
 const watch = process.argv.includes('--watch');
+
+// Go's WASM runtime support script (an IIFE that defines `globalThis.Go`). It is
+// inlined into the worker bundle so the worker is self-contained and does not
+// rely on `importScripts` with a relative URL, which fails when the browser
+// extension host loads the worker from a blob URL.
+const goroot = execFileSync('go', ['env', 'GOROOT']).toString().trim();
+const wasmExecSource = fs.readFileSync(path.join(goroot, 'lib', 'wasm', 'wasm_exec.js'), 'utf8');
 
 /**
  * @type {import('esbuild').Plugin}
@@ -23,30 +33,59 @@ const esbuildProblemMatcherPlugin = {
 	},
 };
 
+const shared = {
+	bundle: true,
+	minify: production,
+	sourcemap: !production,
+	sourcesContent: false,
+	external: ['vscode'],
+	logLevel: 'silent',
+	plugins: [
+		/* add to the end of plugins array */
+		esbuildProblemMatcherPlugin,
+	],
+};
+
+// Desktop (Node.js) extension host: spawns the native Go server over stdio.
+const nodeConfig = {
+	...shared,
+	entryPoints: ['src/extension.ts'],
+	format: 'cjs',
+	platform: 'node',
+	outfile: 'dist/extension.js',
+};
+
+// Browser (Web Worker) extension host: runs the WASM Go server in a worker.
+const webConfig = {
+	...shared,
+	entryPoints: ['src/extension.web.ts'],
+	format: 'cjs',
+	platform: 'browser',
+	outfile: 'dist/extension.web.js',
+};
+
+// The worker is loaded as a classic worker via `new Worker(...)`. Go's WASM
+// runtime is inlined via the banner so the worker bundle is self-contained.
+const workerConfig = {
+	...shared,
+	entryPoints: ['src/server.worker.ts'],
+	format: 'iife',
+	platform: 'browser',
+	outfile: 'dist/server.worker.js',
+	banner: { js: wasmExecSource },
+};
+
 async function main() {
-	const ctx = await esbuild.context({
-		entryPoints: [
-			'src/extension.ts'
-		],
-		bundle: true,
-		format: 'cjs',
-		minify: production,
-		sourcemap: !production,
-		sourcesContent: false,
-		platform: 'node',
-		outfile: 'dist/extension.js',
-		external: ['vscode'],
-		logLevel: 'silent',
-		plugins: [
-			/* add to the end of plugins array */
-			esbuildProblemMatcherPlugin,
-		],
-	});
+	const ctxs = await Promise.all(
+		[nodeConfig, webConfig, workerConfig].map((config) => esbuild.context(config))
+	);
 	if (watch) {
-		await ctx.watch();
+		await Promise.all(ctxs.map((ctx) => ctx.watch()));
 	} else {
-		await ctx.rebuild();
-		await ctx.dispose();
+		await Promise.all(ctxs.map(async (ctx) => {
+			await ctx.rebuild();
+			await ctx.dispose();
+		}));
 	}
 }
 

--- a/internal/vscode-extensions/statemachine/package.json
+++ b/internal/vscode-extensions/statemachine/package.json
@@ -12,6 +12,7 @@
   ],
   "activationEvents": [],
   "main": "./dist/extension.js",
+  "browser": "./dist/extension.web.js",
   "contributes": {
     "languages": [{
       "id": "statemachine",
@@ -26,12 +27,13 @@
     }]
   },
   "scripts": {
-    "build": "npm run check-types && node esbuild.js && npm run build-server",
+    "build": "npm run check-types && node esbuild.js && npm run build-server && npm run build-server-wasm",
     "watch": "node esbuild.js --watch",
     "watch:tsc": "tsc --noEmit --watch",
     "vscode:prepublish": "npm run check-types && node esbuild.js --production",
     "check-types": "tsc --noEmit",
-    "build-server": "go build -gcflags=\"all=-N -l\" -o dist/ ../../../examples/statemachine/server"
+    "build-server": "go build -gcflags=\"all=-N -l\" -o dist/ ../../../examples/statemachine/server",
+    "build-server-wasm": "node build-wasm.js"
   },
   "dependencies": {
     "vscode-languageclient": "~9.0.1"

--- a/internal/vscode-extensions/statemachine/src/extension.web.ts
+++ b/internal/vscode-extensions/statemachine/src/extension.web.ts
@@ -1,0 +1,61 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+import * as vscode from 'vscode';
+import type { LanguageClientOptions } from 'vscode-languageclient/browser.js';
+import { LanguageClient } from 'vscode-languageclient/browser.js';
+
+let client: LanguageClient;
+
+// This function is called when the extension is activated in a browser host
+// (e.g. VS Code Web). The language server runs as a WebAssembly module inside a
+// Web Worker instead of as a spawned process.
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
+    client = await startLanguageClient(context);
+}
+
+// This function is called when the extension is deactivated.
+export function deactivate(): Thenable<void> | undefined {
+    if (client) {
+        return client.stop();
+    }
+    return undefined;
+}
+
+async function startLanguageClient(context: vscode.ExtensionContext): Promise<LanguageClient> {
+    // The worker hosts the WASM-compiled Go language server and bridges
+    // JSON-RPC messages to it over postMessage. We read the WASM bytes here (the
+    // extension host can access its own bundled resources regardless of scheme)
+    // and transfer them to the worker as its first message, because the worker
+    // cannot fetch/resolve resources from its own blob/file URL.
+    const workerUri = vscode.Uri.joinPath(context.extensionUri, 'dist', 'server.worker.js');
+    const wasmUri = vscode.Uri.joinPath(context.extensionUri, 'dist', 'server.wasm');
+    const worker = new Worker(workerUri.toString(true));
+    const wasm = await loadWasm(wasmUri);
+    worker.postMessage({ __init: true, wasm }, [wasm.buffer]);
+
+    const clientOptions: LanguageClientOptions = {
+        documentSelector: [{ language: 'statemachine' }]
+    };
+    const client = new LanguageClient(
+        'statemachine',
+        'Statemachine',
+        clientOptions,
+        worker
+    );
+
+    await client.start();
+    return client;
+}
+
+// Reads the bundled WASM module. Uses the workspace file system (handles
+// file:// and virtual schemes) and falls back to fetch for http(s) hosts.
+async function loadWasm(uri: vscode.Uri): Promise<Uint8Array> {
+    try {
+        return await vscode.workspace.fs.readFile(uri);
+    } catch {
+        const response = await fetch(uri.toString(true));
+        return new Uint8Array(await response.arrayBuffer());
+    }
+}

--- a/internal/vscode-extensions/statemachine/src/server.worker.ts
+++ b/internal/vscode-extensions/statemachine/src/server.worker.ts
@@ -1,0 +1,81 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+// This Web Worker hosts the WASM-compiled Go language server. Go's
+// `wasm_exec.js` runtime is inlined ahead of this bundle (esbuild banner) and
+// defines `Go` on the global scope.
+//
+// The worker receives the WASM module bytes as its first message (the extension
+// reads them and transfers them in), then relays JSON-RPC messages between the
+// worker's postMessage channel and the WASM server. The bytes are passed in
+// rather than fetched here because the worker is loaded from a blob/file URL it
+// cannot resolve resources against.
+//
+// The browser LanguageClient (vscode-languageclient/browser) exchanges JSON-RPC
+// *objects* over postMessage, while the Go server speaks bare JSON *strings*
+// (jsonrpc2.RawFramer). This glue translates between the two representations.
+
+declare const Go: {
+    new(): {
+        importObject: WebAssembly.Imports;
+        run(instance: WebAssembly.Instance): Promise<void>
+    }
+};
+
+interface InitMessage {
+    __init: true;
+    wasm: Uint8Array<ArrayBuffer>;
+}
+
+const glue = globalThis as {
+    wasmSend?: (message: string) => void;
+    wasmReady?: () => void;
+    wasmReceive?: (message: string) => void;
+};
+
+// Messages that arrive before the WASM server has registered its receive
+// callback are buffered and flushed once it signals readiness.
+const pending: string[] = [];
+let ready = false;
+let started = false;
+
+// Server -> client: the Go side hands us a JSON string; forward it as an object.
+glue.wasmSend = (message: string) => {
+    self.postMessage(JSON.parse(message));
+};
+
+// Called by the Go side once `wasmReceive` is registered.
+glue.wasmReady = () => {
+    ready = true;
+    for (const message of pending) {
+        glue.wasmReceive?.(message);
+    }
+    pending.length = 0;
+};
+
+self.onmessage = (event) => {
+    const data = event.data as Partial<InitMessage> | unknown;
+    // The first message carries the WASM bytes and starts the server.
+    if (!started && (data as Partial<InitMessage>)?.__init) {
+        started = true;
+        startServer((data as InitMessage).wasm);
+        return;
+    }
+    // Client -> server: stringify the JSON-RPC object for the Go side.
+    const message = JSON.stringify(data);
+    if (ready && glue.wasmReceive) {
+        glue.wasmReceive(message);
+    } else {
+        pending.push(message);
+    }
+};
+
+async function startServer(wasm: Uint8Array<ArrayBuffer>): Promise<void> {
+    const go = new Go();
+    const source = await WebAssembly.instantiate(wasm, go.importObject, {});
+    const instance = source.instance;
+    // go.run resolves only when the Go program exits; the server blocks on its
+    // connection, so this keeps the WASM instance alive for the worker's life.
+    await go.run(instance);
+}

--- a/internal/vscode-extensions/statemachine/tsconfig.json
+++ b/internal/vscode-extensions/statemachine/tsconfig.json
@@ -3,10 +3,12 @@
 		"module": "Node16",
 		"target": "ES2022",
 		"lib": [
-			"ES2022"
+			"ES2022",
+			"DOM"
 		],
 		"sourceMap": true,
 		"rootDir": "src",
+		"skipLibCheck": true,
 		"strict": true,   /* enable all strict type-checking options */
 		/* Additional Checks */
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */

--- a/server/server.go
+++ b/server/server.go
@@ -7,9 +7,7 @@ package server
 import (
 	"context"
 	"encoding/json"
-	"io"
 	"log/slog"
-	"os"
 
 	"golang.org/x/exp/jsonrpc2"
 	core "typefox.dev/fastbelt"
@@ -543,7 +541,7 @@ type DefaultBinder struct {
 }
 
 // NewDefaultBinder creates a new default binder.
-func NewDefaultBinder(sc *service.Container) jsonrpc2.Binder {
+func NewDefaultBinder(sc *service.Container) *DefaultBinder {
 	return &DefaultBinder{sc: sc}
 }
 
@@ -562,25 +560,4 @@ func (b *DefaultBinder) Bind(ctx context.Context, conn *jsonrpc2.Connection) (js
 	return jsonrpc2.ConnectionOptions{
 		Handler: lsp.ServerHandler(server),
 	}, nil
-}
-
-// StdioDialer implements jsonrpc2.Dialer for stdio communication
-type StdioDialer struct{}
-
-func (d StdioDialer) Dial(ctx context.Context) (io.ReadWriteCloser, error) {
-	return &stdioReadWriteCloser{
-		Reader: os.Stdin,
-		Writer: os.Stdout,
-	}, nil
-}
-
-// stdioReadWriteCloser combines stdin/stdout into a ReadWriteCloser
-type stdioReadWriteCloser struct {
-	io.Reader
-	io.Writer
-}
-
-func (rw *stdioReadWriteCloser) Close() error {
-	// stdin/stdout don't need explicit closing
-	return nil
 }

--- a/server/services.go
+++ b/server/services.go
@@ -23,18 +23,13 @@ type Connection struct {
 }
 
 // SetupDefaultServices sets up the default services for the language server.
+// It should be called together with [SetupStdioServices] or [SetupWasmServices].
 // If any service is already set, it's not overwritten.
 func SetupDefaultServices(sc *service.Container) {
 	service.Put(sc, &WorkspaceFolders{})
 	service.Put(sc, &Connection{})
 	if !service.Has[slog.Handler](sc) {
 		service.Put(sc, NewSlogHandler(sc))
-	}
-	if !service.Has[jsonrpc2.Binder](sc) {
-		service.Put(sc, NewDefaultBinder(sc))
-	}
-	if !service.Has[jsonrpc2.Dialer](sc) {
-		service.Put[jsonrpc2.Dialer](sc, &StdioDialer{})
 	}
 	if !service.Has[lsp.Server](sc) {
 		service.Put(sc, NewDefaultLanguageServer(sc))

--- a/server/transport_stdio.go
+++ b/server/transport_stdio.go
@@ -1,0 +1,48 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+package server
+
+import (
+	"context"
+	"io"
+	"os"
+
+	"golang.org/x/exp/jsonrpc2"
+	"typefox.dev/fastbelt/util/service"
+)
+
+func SetupStdioServices(sc *service.Container) {
+	if !service.Has[jsonrpc2.Binder](sc) {
+		service.Put[jsonrpc2.Binder](sc, NewDefaultBinder(sc))
+	}
+	if !service.Has[jsonrpc2.Dialer](sc) {
+		service.Put[jsonrpc2.Dialer](sc, NewStdioDialer())
+	}
+}
+
+// StdioDialer implements jsonrpc2.Dialer for stdio communication
+type StdioDialer struct{}
+
+func NewStdioDialer() *StdioDialer {
+	return &StdioDialer{}
+}
+
+func (d *StdioDialer) Dial(ctx context.Context) (io.ReadWriteCloser, error) {
+	return &stdioReadWriteCloser{
+		Reader: os.Stdin,
+		Writer: os.Stdout,
+	}, nil
+}
+
+// stdioReadWriteCloser combines stdin/stdout into a ReadWriteCloser
+type stdioReadWriteCloser struct {
+	io.Reader
+	io.Writer
+}
+
+func (rw *stdioReadWriteCloser) Close() error {
+	// stdin/stdout don't need explicit closing
+	return nil
+}

--- a/server/transport_wasm.go
+++ b/server/transport_wasm.go
@@ -1,0 +1,144 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+//go:build js && wasm
+
+package server
+
+import (
+	"context"
+	"io"
+	"syscall/js"
+
+	"golang.org/x/exp/jsonrpc2"
+	"typefox.dev/fastbelt/util/service"
+)
+
+func SetupWasmServices(sc *service.Container) {
+	if !service.Has[jsonrpc2.Binder](sc) {
+		service.Put[jsonrpc2.Binder](sc, NewWasmBinder(sc))
+	}
+	if !service.Has[jsonrpc2.Dialer](sc) {
+		service.Put[jsonrpc2.Dialer](sc, NewWasmDialer())
+	}
+}
+
+// WasmReceive is the name of the global JS function that the host calls to deliver incoming messages.
+const WasmReceive = "wasmReceive"
+
+// WasmSend is the name of the global JS function that the server calls to send outgoing messages.
+const WasmSend = "wasmSend"
+
+// WasmReady is the name of the global JS function that the server calls to signal it is ready to receive messages.
+const WasmReady = "wasmReady"
+
+// WasmDialer implements [jsonrpc2.Dialer] for communication with a JavaScript
+// host (typically a Web Worker) instead of stdio. Messages are exchanged as
+// bare JSON strings over the JS bridge:
+//
+//   - Outgoing messages (server -> client) are passed to the JS function
+//     globalThis.wasmSend(message).
+//   - Incoming messages (client -> server) are delivered by the JS host calling
+//     the exported globalThis.wasmReceive(message) function.
+//
+// The host is expected to translate between JSON-RPC message objects (used by
+// vscode-jsonrpc's BrowserMessageReader/Writer over postMessage) and the JSON
+// strings exchanged here.
+type WasmDialer struct{}
+
+// NewWasmDialer creates a dialer that bridges JSON-RPC over the JavaScript host.
+func NewWasmDialer() *WasmDialer {
+	return &WasmDialer{}
+}
+
+func (d *WasmDialer) Dial(ctx context.Context) (io.ReadWriteCloser, error) {
+	conn := &wasmReadWriteCloser{
+		incoming: make(chan []byte, 1024),
+		closed:   make(chan struct{}),
+	}
+
+	// Expose the receive entry point to the JS host. The host calls this with
+	// each incoming JSON-RPC message (as a string) when it arrives.
+	receive := js.FuncOf(func(this js.Value, args []js.Value) any {
+		if len(args) == 0 {
+			return nil
+		}
+		select {
+		case conn.incoming <- []byte(args[0].String()):
+		case <-conn.closed:
+		}
+		return nil
+	})
+	js.Global().Set(WasmReceive, receive)
+
+	// Signal the host that the server is ready to receive messages. The host
+	// flushes any messages it buffered before this point.
+	if ready := js.Global().Get(WasmReady); ready.Type() == js.TypeFunction {
+		ready.Invoke()
+	}
+
+	return conn, nil
+}
+
+// wasmReadWriteCloser adapts the JS bridge to an [io.ReadWriteCloser] consumed
+// by jsonrpc2. It is paired with [jsonrpc2.RawFramer] so each Write carries one
+// complete JSON message and incoming messages are decoded as a JSON stream.
+type wasmReadWriteCloser struct {
+	incoming chan []byte
+	buf      []byte
+	closed   chan struct{}
+}
+
+func (c *wasmReadWriteCloser) Read(p []byte) (int, error) {
+	if len(c.buf) == 0 {
+		select {
+		case b := <-c.incoming:
+			c.buf = b
+		case <-c.closed:
+			return 0, io.EOF
+		}
+	}
+	n := copy(p, c.buf)
+	c.buf = c.buf[n:]
+	return n, nil
+}
+
+func (c *wasmReadWriteCloser) Write(p []byte) (int, error) {
+	send := js.Global().Get(WasmSend)
+	if send.Type() != js.TypeFunction {
+		return 0, io.ErrClosedPipe
+	}
+	send.Invoke(string(p))
+	return len(p), nil
+}
+
+func (c *wasmReadWriteCloser) Close() error {
+	select {
+	case <-c.closed:
+	default:
+		close(c.closed)
+	}
+	return nil
+}
+
+// WasmBinder behaves like [DefaultBinder] but uses [jsonrpc2.RawFramer] so that
+// messages are exchanged as bare JSON values rather than with Content-Length
+// headers, which is the natural format for the postMessage-based JS bridge.
+type WasmBinder struct {
+	DefaultBinder
+}
+
+// NewWasmBinder creates a binder for the WASM/browser transport.
+func NewWasmBinder(sc *service.Container) *WasmBinder {
+	return &WasmBinder{DefaultBinder{sc: sc}}
+}
+
+func (b *WasmBinder) Bind(ctx context.Context, conn *jsonrpc2.Connection) (jsonrpc2.ConnectionOptions, error) {
+	opts, err := b.DefaultBinder.Bind(ctx, conn)
+	if err != nil {
+		return opts, err
+	}
+	opts.Framer = jsonrpc2.RawFramer()
+	return opts, nil
+}


### PR DESCRIPTION
This provides the glue required for Fastbelt to work correctly in a WASM (web) environment. Adds a prototype for the statemachine language. Can be tested by starting the `Statemachine Web Extension` launch config.

We can later think about extracting the JS-glue into its own npm package like `@fastbelt/wasm` or something.

In my initial benchmarks, the WASM runtime is roughly 3x slower than the single-threaded desktop binary - I think this is quite good.