### PR TITLE
Properly compute UTF16 positions

### DIFF
--- a/examples/statemachine/statemachine_test.go
+++ b/examples/statemachine/statemachine_test.go
@@ -221,6 +221,41 @@ func TestFindNodeAtLabel(t *testing.T) {
 	assert.Equal(t, "S", sm.Name())
 }
 
+func TestTokenColumnUTF16(t *testing.T) {
+	// Minimal single-line statemachine used as input for column checks.
+	const suffix = ` statemachine S events e initialState idle state idle e => idle end`
+
+	testCases := []struct {
+		name           string
+		prefix         string
+		expectedColumn fastbelt.TextColumn
+	}{
+		{
+			// "/* é */" is 7 UTF-16 code units (8 UTF-8 bytes); + 1 space = column 8.
+			name:           "two-byte rune in comment",
+			prefix:         "/* é */",
+			expectedColumn: 8,
+		},
+		{
+			// "/* 😀 */" is 8 UTF-16 code units (10 UTF-8 bytes); + 1 space = column 9.
+			name:           "surrogate-pair rune in comment",
+			prefix:         "/* 😀 */",
+			expectedColumn: 9,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := test.New(t, CreateServices())
+			doc := f.Parse(tc.prefix + suffix).AssertNoErrors()
+			sm := test.MustFindNode[Statemachine](doc)
+			got := sm.Segment().Range.Start.Column
+			assert.Equal(t, tc.expectedColumn, got,
+				"statemachine keyword should start at UTF-16 column %d", tc.expectedColumn)
+		})
+	}
+}
+
 func TestParseError(t *testing.T) {
 	f := test.New(t, CreateServices())
 	doc := f.Parse(`this is not a valid statemachine`)

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -7,6 +7,7 @@ package lexer
 import (
 	"math"
 	"sync/atomic"
+	"unicode/utf16"
 	"unicode/utf8"
 
 	core "typefox.dev/fastbelt"
@@ -71,12 +72,21 @@ func (l *DefaultLexer) Lex(input string) *LexerResult {
 		startLine := line
 		startColumn := column
 
-		for i := offset; i < end; i++ {
-			if input[i] == '\n' {
-				line++
-				column = 0
+		for i := offset; i < end; {
+			b := input[i]
+			if b < utf8.RuneSelf {
+				// ASCII fast path: single byte, utf16.RuneLen == 1
+				if b == '\n' {
+					line++
+					column = 0
+				} else {
+					column++
+				}
+				i++
 			} else {
-				column++
+				r, size := utf8.DecodeRuneInString(input[i:])
+				column += utf16.RuneLen(r)
+				i += size
 			}
 		}
 

--- a/server/server.go
+++ b/server/server.go
@@ -43,8 +43,10 @@ func (s *DefaultLanguageServer) Initialize(ctx context.Context, params *lsp.Para
 	if triggers, err := service.Get[CompletionTriggers](s.sc); err == nil && triggers != nil {
 		triggerChars = triggers.TriggerCharacters()
 	}
+	positionEncoding := lsp.UTF16
 	return &lsp.InitializeResult{
 		Capabilities: lsp.ServerCapabilities{
+			PositionEncoding: &positionEncoding,
 			TextDocumentSync: lsp.Incremental,
 			CompletionProvider: &lsp.CompletionOptions{
 				ResolveProvider:   false,

--- a/text.go
+++ b/text.go
@@ -12,7 +12,7 @@ type TextIndex int32
 // TextLine is a zero-based line number in source text.
 type TextLine int32
 
-// TextColumn is a zero-based byte column within a line.
+// TextColumn is a zero-based UTF16 column within a line.
 type TextColumn int32
 
 // A TextIndexRange describes a half-open byte range [Start, End).

--- a/textdoc/file.go
+++ b/textdoc/file.go
@@ -6,6 +6,8 @@ package textdoc
 
 import (
 	"errors"
+	"unicode/utf16"
+	"unicode/utf8"
 
 	"typefox.dev/lsp"
 )
@@ -70,7 +72,7 @@ func (f *File) Text(r *lsp.Range) string {
 	return string(f.content)
 }
 
-// PositionAt converts a zero-based offset to a position.
+// PositionAt converts a zero-based byte-offset to a UTF16 position.
 func (f *File) PositionAt(offset int) lsp.Position {
 	offset = max(min(offset, len(f.content)), 0)
 	lineOffsets := f.getLineOffsets()
@@ -80,10 +82,7 @@ func (f *File) PositionAt(offset int) lsp.Position {
 	if len(lineOffsets) == 1 {
 		// Only one line, so we're on line 0
 		offset = f.ensureBeforeEOL(offset, lineOffsets[0])
-		return lsp.Position{
-			Line:      0,
-			Character: uint32(offset - lineOffsets[0]),
-		}
+		return f.toUTF16Position(0, offset, lineOffsets)
 	}
 
 	// Binary search for the line
@@ -99,21 +98,21 @@ func (f *File) PositionAt(offset int) lsp.Position {
 
 	// low is the least x for which lineOffsets[x] > offset
 	// So the line we want is low - 1
-	line := low - 1
-
-	// Ensure line is valid (should never be negative, but be defensive)
-	if line < 0 {
-		line = 0
-	}
+	line := max(low-1, 0)
 
 	offset = f.ensureBeforeEOL(offset, lineOffsets[line])
+	return f.toUTF16Position(line, offset, lineOffsets)
+}
+
+func (f *File) toUTF16Position(line, offset int, offsets []int) lsp.Position {
+	lineOffset := offsets[line]
 	return lsp.Position{
 		Line:      uint32(line),
-		Character: uint32(offset - lineOffsets[line]),
+		Character: uint32(utf16LineLen(f.content, lineOffset, offset)),
 	}
 }
 
-// OffsetAt converts a position to a zero-based offset.
+// OffsetAt converts a UTF16 position to a zero-based byte-offset.
 func (f *File) OffsetAt(position lsp.Position) int {
 	return f.offsetAt(position)
 }
@@ -138,7 +137,13 @@ func (f *File) offsetAt(position lsp.Position) int {
 		nextLineOffset = len(f.content)
 	}
 
-	offset := min(lineOffset+int(position.Character), nextLineOffset)
+	character := int(position.Character)
+	offset := lineOffset
+	for i := 0; i < character && offset < nextLineOffset; {
+		r, size := utf8.DecodeRune(f.content[offset:nextLineOffset])
+		offset += size
+		i += utf16.RuneLen(r)
+	}
 	return f.ensureBeforeEOL(offset, lineOffset)
 }
 
@@ -163,4 +168,15 @@ func (f *File) ensureBeforeEOL(offset, lineOffset int) int {
 		offset--
 	}
 	return offset
+}
+
+// utf16LineLen returns the number of UTF-16 code units in content[start:end].
+func utf16LineLen(content []byte, start, end int) int {
+	count := 0
+	for i := start; i < end; {
+		r, size := utf8.DecodeRune(content[i:end])
+		count += utf16.RuneLen(r)
+		i += size
+	}
+	return count
 }

--- a/textdoc/file_test.go
+++ b/textdoc/file_test.go
@@ -211,6 +211,172 @@ func TestTextWithRange(t *testing.T) {
 	}
 }
 
+func TestPositionAtUTF16(t *testing.T) {
+	testCases := []struct {
+		name    string
+		content string
+		tests   []struct {
+			offset   int
+			expected lsp.Position
+		}
+	}{
+		{
+			// é = U+00E9: 2 UTF-8 bytes, 1 UTF-16 code unit
+			name:    "two-byte rune single line",
+			content: "aéb",
+			tests: []struct {
+				offset   int
+				expected lsp.Position
+			}{
+				{0, lsp.Position{Line: 0, Character: 0}},
+				{1, lsp.Position{Line: 0, Character: 1}}, // after 'a'
+				{3, lsp.Position{Line: 0, Character: 2}}, // after 'é' (2 UTF-8 bytes -> 1 UTF-16 unit)
+				{4, lsp.Position{Line: 0, Character: 3}}, // after 'b'
+			},
+		},
+		{
+			// 😀 = U+1F600: 4 UTF-8 bytes, 2 UTF-16 code units (surrogate pair)
+			name:    "surrogate-pair rune single line",
+			content: "a😀b",
+			tests: []struct {
+				offset   int
+				expected lsp.Position
+			}{
+				{0, lsp.Position{Line: 0, Character: 0}},
+				{1, lsp.Position{Line: 0, Character: 1}}, // after 'a'
+				{5, lsp.Position{Line: 0, Character: 3}}, // after '😀' (4 UTF-8 bytes -> 2 UTF-16 units)
+				{6, lsp.Position{Line: 0, Character: 4}}, // after 'b'
+			},
+		},
+		{
+			name:    "two-byte rune multi-line",
+			content: "aé\nbc",
+			tests: []struct {
+				offset   int
+				expected lsp.Position
+			}{
+				{0, lsp.Position{Line: 0, Character: 0}},
+				{3, lsp.Position{Line: 0, Character: 2}}, // after 'é'
+				{4, lsp.Position{Line: 1, Character: 0}}, // after '\n'
+				{5, lsp.Position{Line: 1, Character: 1}},
+			},
+		},
+		{
+			name:    "surrogate-pair rune multi-line",
+			content: "😀\naé",
+			tests: []struct {
+				offset   int
+				expected lsp.Position
+			}{
+				{0, lsp.Position{Line: 0, Character: 0}},
+				{4, lsp.Position{Line: 0, Character: 2}}, // after '😀' (2 UTF-16 units)
+				{5, lsp.Position{Line: 1, Character: 0}}, // after '\n'
+				{6, lsp.Position{Line: 1, Character: 1}}, // after 'a'
+				{8, lsp.Position{Line: 1, Character: 2}}, // after 'é'
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc, err := NewFile("file:///test.txt", "plaintext", 1, tc.content)
+			if err != nil {
+				t.Fatalf("NewFile failed: %v", err)
+			}
+			for _, test := range tc.tests {
+				pos := doc.PositionAt(test.offset)
+				if pos != test.expected {
+					t.Errorf("PositionAt(%d): expected {%d, %d}, got {%d, %d}",
+						test.offset, test.expected.Line, test.expected.Character, pos.Line, pos.Character)
+				}
+			}
+		})
+	}
+}
+
+func TestOffsetAtUTF16(t *testing.T) {
+	testCases := []struct {
+		name    string
+		content string
+		tests   []struct {
+			position lsp.Position
+			expected int
+		}
+	}{
+		{
+			// é = U+00E9: 2 UTF-8 bytes, 1 UTF-16 code unit
+			name:    "two-byte rune single line",
+			content: "aéb",
+			tests: []struct {
+				position lsp.Position
+				expected int
+			}{
+				{lsp.Position{Line: 0, Character: 0}, 0},
+				{lsp.Position{Line: 0, Character: 1}, 1}, // after 'a'
+				{lsp.Position{Line: 0, Character: 2}, 3}, // UTF-16 char 2 -> byte 3 (after 'é')
+				{lsp.Position{Line: 0, Character: 3}, 4}, // after 'b'
+			},
+		},
+		{
+			// 😀 = U+1F600: 4 UTF-8 bytes, 2 UTF-16 code units (surrogate pair)
+			name:    "surrogate-pair rune single line",
+			content: "a😀b",
+			tests: []struct {
+				position lsp.Position
+				expected int
+			}{
+				{lsp.Position{Line: 0, Character: 0}, 0},
+				{lsp.Position{Line: 0, Character: 1}, 1}, // after 'a'
+				{lsp.Position{Line: 0, Character: 3}, 5}, // UTF-16 char 3 -> byte 5 (after '😀', 2 UTF-16 units)
+				{lsp.Position{Line: 0, Character: 4}, 6}, // after 'b'
+			},
+		},
+		{
+			name:    "two-byte rune multi-line",
+			content: "aé\nbc",
+			tests: []struct {
+				position lsp.Position
+				expected int
+			}{
+				{lsp.Position{Line: 0, Character: 0}, 0},
+				{lsp.Position{Line: 0, Character: 2}, 3}, // UTF-16 char 2 -> byte 3
+				{lsp.Position{Line: 1, Character: 0}, 4},
+				{lsp.Position{Line: 1, Character: 1}, 5},
+			},
+		},
+		{
+			name:    "surrogate-pair rune multi-line",
+			content: "😀\naé",
+			tests: []struct {
+				position lsp.Position
+				expected int
+			}{
+				{lsp.Position{Line: 0, Character: 0}, 0},
+				{lsp.Position{Line: 0, Character: 2}, 4}, // UTF-16 char 2 -> byte 4 (after '😀')
+				{lsp.Position{Line: 1, Character: 0}, 5},
+				{lsp.Position{Line: 1, Character: 1}, 6}, // after 'a'
+				{lsp.Position{Line: 1, Character: 2}, 8}, // UTF-16 char 2 -> byte 8 (after 'é')
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc, err := NewFile("file:///test.txt", "plaintext", 1, tc.content)
+			if err != nil {
+				t.Fatalf("NewFile failed: %v", err)
+			}
+			for _, test := range tc.tests {
+				offset := doc.OffsetAt(test.position)
+				if offset != test.expected {
+					t.Errorf("OffsetAt({%d, %d}): expected %d, got %d",
+						test.position.Line, test.position.Character, test.expected, offset)
+				}
+			}
+		})
+	}
+}
+
 func TestLineOffsets(t *testing.T) {
 	tests := []struct {
 		content  string

--- a/textdoc/overlay.go
+++ b/textdoc/overlay.go
@@ -136,7 +136,7 @@ func (o *Overlay) Text(r *lsp.Range) string {
 	return o.File.Text(r)
 }
 
-// PositionAt converts a zero-based offset to a position.
+// PositionAt converts a zero-based byte-offset to a UTF16 position.
 // This method is thread-safe.
 func (o *Overlay) PositionAt(offset int) lsp.Position {
 	o.mu.RLock()
@@ -144,7 +144,7 @@ func (o *Overlay) PositionAt(offset int) lsp.Position {
 	return o.File.PositionAt(offset)
 }
 
-// OffsetAt converts a position to a zero-based offset.
+// OffsetAt converts a UTF16 position to a zero-based byte-offset.
 // This method is thread-safe.
 func (o *Overlay) OffsetAt(position lsp.Position) int {
 	o.mu.RLock()
@@ -190,7 +190,7 @@ func (o *Overlay) applyChangeLocked(change lsp.TextDocumentContentChangeEvent) e
 			} else {
 				lineEnd = len(o.content)
 			}
-			maxChar := lineEnd - lineStart
+			maxChar := utf16LineLen(o.content, lineStart, lineEnd)
 			if int(pos.Character) > maxChar {
 				return fmt.Errorf("textdoc: invalid range: character %d exceeds line %d length %d",
 					pos.Character, pos.Line, maxChar)

--- a/textdoc/overlay_test.go
+++ b/textdoc/overlay_test.go
@@ -457,6 +457,241 @@ func TestUpdateBackwardsRange(t *testing.T) {
 	}
 }
 
+func TestUpdateUTF16(t *testing.T) {
+	testCases := []struct {
+		name     string
+		content  string
+		changes  []lsp.TextDocumentContentChangeEvent
+		expected string
+	}{
+		{
+			// é = U+00E9: 2 UTF-8 bytes, 1 UTF-16 code unit
+			name:    "replace two-byte rune",
+			content: "aéb",
+			changes: []lsp.TextDocumentContentChangeEvent{
+				{
+					Range: &lsp.Range{
+						Start: lsp.Position{Line: 0, Character: 1},
+						End:   lsp.Position{Line: 0, Character: 2},
+					},
+					Text: "x",
+				},
+			},
+			expected: "axb",
+		},
+		{
+			// 😀 = U+1F600: 4 UTF-8 bytes, 2 UTF-16 code units (surrogate pair)
+			name:    "replace surrogate-pair rune",
+			content: "a😀b",
+			changes: []lsp.TextDocumentContentChangeEvent{
+				{
+					Range: &lsp.Range{
+						Start: lsp.Position{Line: 0, Character: 1},
+						End:   lsp.Position{Line: 0, Character: 3},
+					},
+					Text: "x",
+				},
+			},
+			expected: "axb",
+		},
+		{
+			name:    "insert after two-byte rune",
+			content: "aé\nbc",
+			changes: []lsp.TextDocumentContentChangeEvent{
+				{
+					Range: &lsp.Range{
+						Start: lsp.Position{Line: 0, Character: 2},
+						End:   lsp.Position{Line: 0, Character: 2},
+					},
+					Text: "!",
+				},
+			},
+			expected: "aé!\nbc",
+		},
+		{
+			name:    "cross-line range with multi-byte rune",
+			content: "aé\nbc",
+			changes: []lsp.TextDocumentContentChangeEvent{
+				{
+					// Replace from after 'a' on line 0 to after 'b' on line 1
+					Range: &lsp.Range{
+						Start: lsp.Position{Line: 0, Character: 1},
+						End:   lsp.Position{Line: 1, Character: 1},
+					},
+					Text: "X",
+				},
+			},
+			expected: "aXc",
+		},
+		{
+			name:    "replace surrogate-pair rune on second line",
+			content: "ab\n😀x",
+			changes: []lsp.TextDocumentContentChangeEvent{
+				{
+					Range: &lsp.Range{
+						Start: lsp.Position{Line: 1, Character: 0},
+						End:   lsp.Position{Line: 1, Character: 2},
+					},
+					Text: "y",
+				},
+			},
+			expected: "ab\nyx",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc, err := NewOverlay("file:///test.txt", "plaintext", 1, tc.content)
+			if err != nil {
+				t.Fatalf("NewOverlay failed: %v", err)
+			}
+			err = doc.Update(tc.changes, 2)
+			if err != nil {
+				t.Fatalf("Update failed: %v", err)
+			}
+			if got := doc.Text(nil); got != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestUpdateUTF16Validation(t *testing.T) {
+	testCases := []struct {
+		name        string
+		content     string
+		character   uint32
+		shouldError bool
+	}{
+		{
+			// "aé" has UTF-16 length 2; character 2 is valid (at end of line)
+			name:        "character at end of two-byte rune line is valid",
+			content:     "aé",
+			character:   2,
+			shouldError: false,
+		},
+		{
+			// "aé" has UTF-16 length 2; character 3 exceeds the line
+			name:        "character past end of two-byte rune line is invalid",
+			content:     "aé",
+			character:   3,
+			shouldError: true,
+		},
+		{
+			// "a😀" has UTF-16 length 3 (😀 = 2 units); character 3 is valid
+			name:        "character at end of surrogate-pair line is valid",
+			content:     "a😀",
+			character:   3,
+			shouldError: false,
+		},
+		{
+			// "a😀" has UTF-16 length 3; character 4 exceeds the line
+			name:        "character past end of surrogate-pair line is invalid",
+			content:     "a😀",
+			character:   4,
+			shouldError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc, err := NewOverlay("file:///test.txt", "plaintext", 1, tc.content)
+			if err != nil {
+				t.Fatalf("NewOverlay failed: %v", err)
+			}
+			err = doc.Update([]lsp.TextDocumentContentChangeEvent{
+				{
+					Range: &lsp.Range{
+						Start: lsp.Position{Line: 0, Character: tc.character},
+						End:   lsp.Position{Line: 0, Character: tc.character},
+					},
+					Text: "",
+				},
+			}, 2)
+			if tc.shouldError && err == nil {
+				t.Error("expected error, got nil")
+			} else if !tc.shouldError && err != nil {
+				t.Errorf("expected no error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestApplyEditsUTF16(t *testing.T) {
+	testCases := []struct {
+		name     string
+		content  string
+		edits    []lsp.TextEdit
+		expected string
+	}{
+		{
+			name:    "replace two-byte rune",
+			content: "aéb",
+			edits: []lsp.TextEdit{
+				{
+					Range: lsp.Range{
+						Start: lsp.Position{Line: 0, Character: 1},
+						End:   lsp.Position{Line: 0, Character: 2},
+					},
+					NewText: "x",
+				},
+			},
+			expected: "axb",
+		},
+		{
+			name:    "replace surrogate-pair rune",
+			content: "a😀b",
+			edits: []lsp.TextEdit{
+				{
+					Range: lsp.Range{
+						Start: lsp.Position{Line: 0, Character: 1},
+						End:   lsp.Position{Line: 0, Character: 3},
+					},
+					NewText: "x",
+				},
+			},
+			expected: "axb",
+		},
+		{
+			name:    "multiple edits with multi-byte runes",
+			content: "aé\n😀b",
+			edits: []lsp.TextEdit{
+				{
+					Range: lsp.Range{
+						Start: lsp.Position{Line: 0, Character: 1},
+						End:   lsp.Position{Line: 0, Character: 2},
+					},
+					NewText: "X",
+				},
+				{
+					Range: lsp.Range{
+						Start: lsp.Position{Line: 1, Character: 0},
+						End:   lsp.Position{Line: 1, Character: 2},
+					},
+					NewText: "Y",
+				},
+			},
+			expected: "aX\nYb",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc, err := NewOverlay("file:///test.txt", "plaintext", 1, tc.content)
+			if err != nil {
+				t.Fatalf("NewOverlay failed: %v", err)
+			}
+			result, err := doc.ApplyEdits(tc.edits)
+			if err != nil {
+				t.Fatalf("ApplyEdits failed: %v", err)
+			}
+			if result != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, result)
+			}
+		})
+	}
+}
+
 func TestUpdateConsecutiveUpdates(t *testing.T) {
 	doc, err := NewOverlay("file:///test.txt", "plaintext", 1, "a\nb\nc")
 	if err != nil {


### PR DESCRIPTION
Fixes an issue I've noticed when accidentally typing in non-ascii characters into the editor: The `Overlay` kept outdated text in there due to incorrect offsets. By default, the LSP will assume that all range columns are computed in UTF16 (mainly because the reference implementation is in JavaScript, which uses UTF16 for all strings). We should align to this default (we could also try to communicate that we use UTF8, but not all clients accept this) in our LSP position handling code.

This updates two main parts which are related to this:
1. The lexer now computes column information using UTF16 (which slightly slows down lexing)
2. The `textdoc` infrastructure can now compute byte offsets <-> UTF16 position. Previously, all positions were handled as byte-positions (not even UTF8!).

In addition to the automated tests, can also be tested using the statemachine extension using a comment like `/* 😀 */`. All lsp requests should behave as expected, even in the presence of this comment.