### PR TITLE
First hover and documentation providers implementation

### DIFF
--- a/examples/statemachine/hover_test.go
+++ b/examples/statemachine/hover_test.go
@@ -1,0 +1,224 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+package statemachine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"typefox.dev/fastbelt/server"
+	"typefox.dev/fastbelt/test"
+	"typefox.dev/fastbelt/util/service"
+	"typefox.dev/lsp"
+)
+
+// createHoverServices builds a service container with both the statemachine language
+// and the default server services (DocumentationProvider, HoverProvider, etc.).
+func createHoverServices() *service.Container {
+	sc := service.NewContainer()
+	SetupServices(sc)
+	server.SetupDefaultServices(sc)
+	sc.Seal()
+	return sc
+}
+
+// hoverAt calls the hover provider at the position of the named marker.
+// Accepts both index markers (<|label>) and range markers (<|label:text|>);
+// for range markers the start of the range is used as the cursor position.
+func hoverAt(t *testing.T, f *test.Fixture, doc *test.Doc, label string) *lsp.Hover {
+	t.Helper()
+	offset := -1
+	for _, idx := range doc.Indices {
+		if idx.Label == label {
+			offset = idx.Offset
+			break
+		}
+	}
+	if offset == -1 {
+		for _, r := range doc.Ranges {
+			if r.Label == label {
+				offset = r.Start
+				break
+			}
+		}
+	}
+	if offset == -1 {
+		t.Fatalf("no marker with label %q", label)
+	}
+	pos := doc.Document.TextDoc.PositionAt(offset)
+	provider := service.MustGet[server.HoverProvider](f.Services())
+	result, err := provider.HandleHoverRequest(f.Ctx(), &lsp.HoverParams{
+		TextDocumentPositionParams: lsp.TextDocumentPositionParams{
+			TextDocument: lsp.TextDocumentIdentifier{URI: doc.Document.URI.DocumentURI()},
+			Position:     pos,
+		},
+	})
+	require.NoError(t, err)
+	return result
+}
+
+func TestDocumentationSingleLineComment(t *testing.T) {
+	f := test.New(t, createHoverServices())
+	docProvider := service.MustGet[server.DocumentationProvider](f.Services())
+
+	doc := f.Parse(`
+statemachine Test
+events flick
+initialState off
+
+// The off state
+state off
+  flick => on
+end
+
+state on
+  flick => off
+end
+`).AssertNoErrors()
+
+	off := test.MustFindNamedNode[State](doc, "off")
+	assert.Equal(t, "The off state", docProvider.Documentation(off))
+}
+
+func TestDocumentationMultipleLineComments(t *testing.T) {
+	f := test.New(t, createHoverServices())
+	docProvider := service.MustGet[server.DocumentationProvider](f.Services())
+
+	doc := f.Parse(`
+statemachine Test
+events flick
+initialState off
+
+// line one
+// line two
+state off
+  flick => on
+end
+
+state on
+  flick => off
+end
+`).AssertNoErrors()
+
+	off := test.MustFindNamedNode[State](doc, "off")
+	assert.Equal(t, "line one  \nline two", docProvider.Documentation(off))
+}
+
+func TestDocumentationBlockComment(t *testing.T) {
+	f := test.New(t, createHoverServices())
+	docProvider := service.MustGet[server.DocumentationProvider](f.Services())
+
+	doc := f.Parse(`
+statemachine Test
+events flick
+initialState off
+
+/*
+ * line one
+ * line two
+ */
+state off
+  flick => on
+end
+
+state on
+  flick => off
+end
+`).AssertNoErrors()
+
+	off := test.MustFindNamedNode[State](doc, "off")
+	assert.Equal(t, "line one\nline two", docProvider.Documentation(off))
+}
+
+func TestDocumentationNoComment(t *testing.T) {
+	f := test.New(t, createHoverServices())
+	docProvider := service.MustGet[server.DocumentationProvider](f.Services())
+
+	doc := f.Parse(`
+statemachine Test
+events flick
+initialState off
+
+state off
+  flick => on
+end
+
+state on
+  flick => off
+end
+`).AssertNoErrors()
+
+	off := test.MustFindNamedNode[State](doc, "off")
+	assert.Equal(t, "", docProvider.Documentation(off))
+}
+
+func TestHoverReturnsDocumentationForReference(t *testing.T) {
+	f := test.New(t, createHoverServices())
+
+	doc := f.Parse(`
+statemachine Test
+events flick
+initialState off
+
+state off
+  flick => <|toOn:on|>
+end
+
+// The on state
+state on
+  flick => off
+end
+`).AssertNoErrors()
+
+	result := hoverAt(t, f, doc, "toOn")
+	require.NotNil(t, result)
+	assert.Equal(t, lsp.Markdown, result.Contents.Kind)
+	assert.Equal(t, "The on state", result.Contents.Value)
+
+	expectedRange, err := doc.MarkerRange("toOn")
+	require.NoError(t, err)
+	assert.Equal(t, expectedRange.LspRange(), result.Range)
+}
+
+func TestHoverNilForUndocumentedReference(t *testing.T) {
+	f := test.New(t, createHoverServices())
+
+	doc := f.Parse(`
+statemachine Test
+events flick
+initialState off
+
+state off
+  flick => <|toOn:on|>
+end
+
+state on
+  flick => off
+end
+`).AssertNoErrors()
+
+	assert.Nil(t, hoverAt(t, f, doc, "toOn"))
+}
+
+func TestHoverNilForWhitespace(t *testing.T) {
+	f := test.New(t, createHoverServices())
+
+	doc := f.Parse(`
+statemachine<|ws> Test
+events flick
+initialState off
+
+state off
+  flick => on
+end
+
+state on
+  flick => off
+end
+`).AssertNoErrors()
+
+	assert.Nil(t, hoverAt(t, f, doc, "ws"))
+}

--- a/examples/statemachine/lexer_gen.go
+++ b/examples/statemachine/lexer_gen.go
@@ -478,7 +478,7 @@ var Token_SL_COMMENT = core.NewTokenType(
 	Token_SL_COMMENT_Idx,
 	"SL_COMMENT",
 	"SL_COMMENT",
-	core.SkippedGroup,
+	core.CommentGroup,
 	core.TokenKindToken,
 	0,
 	false,

--- a/examples/statemachine/statemachine.fb
+++ b/examples/statemachine/statemachine.fb
@@ -58,4 +58,4 @@ token ID: /[_a-zA-Z][\w_]*/;
 
 hidden token WS: /\s+/;
 comment token ML_COMMENT: /\/\*[\s\S]*?\*\//;
-hidden token SL_COMMENT: /\/\/[^\n\r]*/;
+comment token SL_COMMENT: /\/\/[^\n\r]*/;

--- a/examples/statemachine/statemachine_hover_test.go
+++ b/examples/statemachine/statemachine_hover_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestDocumentationSingleLineComment(t *testing.T) {
-	f := test.New(t, CreateLspServices())
+	f := test.New(t, CreateLspServices(nil))
 	docProvider := service.MustGet[server.DocumentationProvider](f.Services())
 
 	doc := f.Parse(`
@@ -37,7 +37,7 @@ end
 }
 
 func TestDocumentationMultipleLineComments(t *testing.T) {
-	f := test.New(t, CreateLspServices())
+	f := test.New(t, CreateLspServices(nil))
 	docProvider := service.MustGet[server.DocumentationProvider](f.Services())
 
 	doc := f.Parse(`
@@ -61,7 +61,7 @@ end
 }
 
 func TestDocumentationBlankLinePreserved(t *testing.T) {
-	f := test.New(t, CreateLspServices())
+	f := test.New(t, CreateLspServices(nil))
 	docProvider := service.MustGet[server.DocumentationProvider](f.Services())
 
 	doc := f.Parse(`
@@ -86,7 +86,7 @@ end
 }
 
 func TestDocumentationBlockComment(t *testing.T) {
-	f := test.New(t, CreateLspServices())
+	f := test.New(t, CreateLspServices(nil))
 	docProvider := service.MustGet[server.DocumentationProvider](f.Services())
 
 	doc := f.Parse(`
@@ -112,7 +112,7 @@ end
 }
 
 func TestDocumentationIgnoresCommentsSeparatedByBlankLine(t *testing.T) {
-	f := test.New(t, CreateLspServices())
+	f := test.New(t, CreateLspServices(nil))
 	docProvider := service.MustGet[server.DocumentationProvider](f.Services())
 
 	doc := f.Parse(`
@@ -137,7 +137,7 @@ end
 }
 
 func TestDocumentationNoComment(t *testing.T) {
-	f := test.New(t, CreateLspServices())
+	f := test.New(t, CreateLspServices(nil))
 	docProvider := service.MustGet[server.DocumentationProvider](f.Services())
 
 	doc := f.Parse(`
@@ -159,7 +159,7 @@ end
 }
 
 func TestHoverReturnsDocumentationForReference(t *testing.T) {
-	f := test.New(t, CreateLspServices())
+	f := test.New(t, CreateLspServices(nil))
 
 	f.Parse(`
 statemachine Test
@@ -178,7 +178,7 @@ end
 }
 
 func TestHoverNilForUndocumentedReference(t *testing.T) {
-	f := test.New(t, CreateLspServices())
+	f := test.New(t, CreateLspServices(nil))
 
 	f.Parse(`
 statemachine Test
@@ -196,7 +196,7 @@ end
 }
 
 func TestHoverNilForWhitespace(t *testing.T) {
-	f := test.New(t, CreateLspServices())
+	f := test.New(t, CreateLspServices(nil))
 
 	f.Parse(`
 statemachine<|ws> Test

--- a/examples/statemachine/statemachine_hover_test.go
+++ b/examples/statemachine/statemachine_hover_test.go
@@ -13,19 +13,8 @@ import (
 	"typefox.dev/fastbelt/util/service"
 )
 
-// createHoverServices builds a service container with both the statemachine language
-// and the default server services (DocumentationProvider, HoverProvider, etc.).
-func createHoverServices() *service.Container {
-	sc := service.NewContainer()
-	SetupServices(sc)
-	server.SetupDefaultServices(sc)
-	sc.Seal()
-	return sc
-}
-
-
 func TestDocumentationSingleLineComment(t *testing.T) {
-	f := test.New(t, createHoverServices())
+	f := test.New(t, CreateLspServices())
 	docProvider := service.MustGet[server.DocumentationProvider](f.Services())
 
 	doc := f.Parse(`
@@ -48,7 +37,7 @@ end
 }
 
 func TestDocumentationMultipleLineComments(t *testing.T) {
-	f := test.New(t, createHoverServices())
+	f := test.New(t, CreateLspServices())
 	docProvider := service.MustGet[server.DocumentationProvider](f.Services())
 
 	doc := f.Parse(`
@@ -72,7 +61,7 @@ end
 }
 
 func TestDocumentationBlankLinePreserved(t *testing.T) {
-	f := test.New(t, createHoverServices())
+	f := test.New(t, CreateLspServices())
 	docProvider := service.MustGet[server.DocumentationProvider](f.Services())
 
 	doc := f.Parse(`
@@ -97,7 +86,7 @@ end
 }
 
 func TestDocumentationBlockComment(t *testing.T) {
-	f := test.New(t, createHoverServices())
+	f := test.New(t, CreateLspServices())
 	docProvider := service.MustGet[server.DocumentationProvider](f.Services())
 
 	doc := f.Parse(`
@@ -123,7 +112,7 @@ end
 }
 
 func TestDocumentationIgnoresCommentsSeparatedByBlankLine(t *testing.T) {
-	f := test.New(t, createHoverServices())
+	f := test.New(t, CreateLspServices())
 	docProvider := service.MustGet[server.DocumentationProvider](f.Services())
 
 	doc := f.Parse(`
@@ -148,7 +137,7 @@ end
 }
 
 func TestDocumentationNoComment(t *testing.T) {
-	f := test.New(t, createHoverServices())
+	f := test.New(t, CreateLspServices())
 	docProvider := service.MustGet[server.DocumentationProvider](f.Services())
 
 	doc := f.Parse(`
@@ -170,7 +159,7 @@ end
 }
 
 func TestHoverReturnsDocumentationForReference(t *testing.T) {
-	f := test.New(t, createHoverServices())
+	f := test.New(t, CreateLspServices())
 
 	f.Parse(`
 statemachine Test
@@ -189,7 +178,7 @@ end
 }
 
 func TestHoverNilForUndocumentedReference(t *testing.T) {
-	f := test.New(t, createHoverServices())
+	f := test.New(t, CreateLspServices())
 
 	f.Parse(`
 statemachine Test
@@ -207,7 +196,7 @@ end
 }
 
 func TestHoverNilForWhitespace(t *testing.T) {
-	f := test.New(t, createHoverServices())
+	f := test.New(t, CreateLspServices())
 
 	f.Parse(`
 statemachine<|ws> Test

--- a/examples/statemachine/statemachine_hover_test.go
+++ b/examples/statemachine/statemachine_hover_test.go
@@ -122,6 +122,31 @@ end
 	assert.Equal(t, "line one\nline two", docProvider.Documentation(off))
 }
 
+func TestDocumentationIgnoresCommentsSeparatedByBlankLine(t *testing.T) {
+	f := test.New(t, createHoverServices())
+	docProvider := service.MustGet[server.DocumentationProvider](f.Services())
+
+	doc := f.Parse(`
+statemachine Test
+events flick
+initialState off
+
+/* Section header */
+
+// The off state
+state off
+  flick => on
+end
+
+state on
+  flick => off
+end
+`).AssertNoErrors()
+
+	off := test.MustFindNamedNode[State](doc, "off")
+	assert.Equal(t, "The off state", docProvider.Documentation(off))
+}
+
 func TestDocumentationNoComment(t *testing.T) {
 	f := test.New(t, createHoverServices())
 	docProvider := service.MustGet[server.DocumentationProvider](f.Services())

--- a/examples/statemachine/statemachine_hover_test.go
+++ b/examples/statemachine/statemachine_hover_test.go
@@ -8,11 +8,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"typefox.dev/fastbelt/server"
 	"typefox.dev/fastbelt/test"
 	"typefox.dev/fastbelt/util/service"
-	"typefox.dev/lsp"
 )
 
 // createHoverServices builds a service container with both the statemachine language
@@ -25,40 +23,6 @@ func createHoverServices() *service.Container {
 	return sc
 }
 
-// hoverAt calls the hover provider at the position of the named marker.
-// Accepts both index markers (<|label>) and range markers (<|label:text|>);
-// for range markers the start of the range is used as the cursor position.
-func hoverAt(t *testing.T, f *test.Fixture, doc *test.Doc, label string) *lsp.Hover {
-	t.Helper()
-	offset := -1
-	for _, idx := range doc.Indices {
-		if idx.Label == label {
-			offset = idx.Offset
-			break
-		}
-	}
-	if offset == -1 {
-		for _, r := range doc.Ranges {
-			if r.Label == label {
-				offset = r.Start
-				break
-			}
-		}
-	}
-	if offset == -1 {
-		t.Fatalf("no marker with label %q", label)
-	}
-	pos := doc.Document.TextDoc.PositionAt(offset)
-	provider := service.MustGet[server.HoverProvider](f.Services())
-	result, err := provider.HandleHoverRequest(f.Ctx(), &lsp.HoverParams{
-		TextDocumentPositionParams: lsp.TextDocumentPositionParams{
-			TextDocument: lsp.TextDocumentIdentifier{URI: doc.Document.URI.DocumentURI()},
-			Position:     pos,
-		},
-	})
-	require.NoError(t, err)
-	return result
-}
 
 func TestDocumentationSingleLineComment(t *testing.T) {
 	f := test.New(t, createHoverServices())
@@ -105,6 +69,31 @@ end
 
 	off := test.MustFindNamedNode[State](doc, "off")
 	assert.Equal(t, "line one  \nline two", docProvider.Documentation(off))
+}
+
+func TestDocumentationBlankLinePreserved(t *testing.T) {
+	f := test.New(t, createHoverServices())
+	docProvider := service.MustGet[server.DocumentationProvider](f.Services())
+
+	doc := f.Parse(`
+statemachine Test
+events flick
+initialState off
+
+// line one
+//
+// line two
+state off
+  flick => on
+end
+
+state on
+  flick => off
+end
+`).AssertNoErrors()
+
+	off := test.MustFindNamedNode[State](doc, "off")
+	assert.Equal(t, "line one  \n  \nline two", docProvider.Documentation(off))
 }
 
 func TestDocumentationBlockComment(t *testing.T) {
@@ -158,7 +147,7 @@ end
 func TestHoverReturnsDocumentationForReference(t *testing.T) {
 	f := test.New(t, createHoverServices())
 
-	doc := f.Parse(`
+	f.Parse(`
 statemachine Test
 events flick
 initialState off
@@ -171,22 +160,13 @@ end
 state on
   flick => off
 end
-`).AssertNoErrors()
-
-	result := hoverAt(t, f, doc, "toOn")
-	require.NotNil(t, result)
-	assert.Equal(t, lsp.Markdown, result.Contents.Kind)
-	assert.Equal(t, "The on state", result.Contents.Value)
-
-	expectedRange, err := doc.MarkerRange("toOn")
-	require.NoError(t, err)
-	assert.Equal(t, expectedRange.LspRange(), result.Range)
+`).AssertNoErrors().ExpectHoverAt("toOn", "The on state")
 }
 
 func TestHoverNilForUndocumentedReference(t *testing.T) {
 	f := test.New(t, createHoverServices())
 
-	doc := f.Parse(`
+	f.Parse(`
 statemachine Test
 events flick
 initialState off
@@ -198,15 +178,13 @@ end
 state on
   flick => off
 end
-`).AssertNoErrors()
-
-	assert.Nil(t, hoverAt(t, f, doc, "toOn"))
+`).AssertNoErrors().ExpectNoHoverAt("toOn")
 }
 
 func TestHoverNilForWhitespace(t *testing.T) {
 	f := test.New(t, createHoverServices())
 
-	doc := f.Parse(`
+	f.Parse(`
 statemachine<|ws> Test
 events flick
 initialState off
@@ -218,7 +196,5 @@ end
 state on
   flick => off
 end
-`).AssertNoErrors()
-
-	assert.Nil(t, hoverAt(t, f, doc, "ws"))
+`).AssertNoErrors().ExpectNoHoverAt("ws")
 }

--- a/internal/vscode-extensions/statemachine/package.json
+++ b/internal/vscode-extensions/statemachine/package.json
@@ -17,7 +17,7 @@
     "languages": [{
       "id": "statemachine",
       "aliases": ["Statemachine", "statemachine"],
-      "extensions": ["statemachine"],
+      "extensions": [".statemachine"],
       "configuration": "./language-configuration.json"
     }],
     "grammars": [{

--- a/server/documentation_provider.go
+++ b/server/documentation_provider.go
@@ -1,0 +1,100 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+package server
+
+import (
+	"strings"
+	"unicode"
+
+	core "typefox.dev/fastbelt"
+)
+
+// DocumentationProvider extracts and formats documentation comments for AST nodes.
+type DocumentationProvider interface {
+	Documentation(node core.AstNode) string
+}
+
+// DefaultDocumentationProvider is the default implementation of [DocumentationProvider].
+type DefaultDocumentationProvider struct{}
+
+func NewDefaultDocumentationProvider() DocumentationProvider {
+	return &DefaultDocumentationProvider{}
+}
+
+// Documentation returns the documentation comment block immediately preceding node,
+// with comment markers stripped. Returns an empty string when no attached comment exists.
+func (s *DefaultDocumentationProvider) Documentation(node core.AstNode) string {
+	doc := node.Document()
+	if doc == nil {
+		return ""
+	}
+
+	targetStart := int(node.Segment().Indices.Start)
+
+	var block []core.Token
+	prevEnd := targetStart
+	for i := len(doc.Comments) - 1; i >= 0; i-- {
+		c := doc.Comments[i]
+		commentEnd := int(c.TextSegment.Indices.End)
+		if commentEnd > prevEnd {
+			continue
+		}
+		if hasTokenInRange(doc.Tokens, commentEnd, prevEnd) {
+			break
+		}
+		block = append(block, c)
+		prevEnd = int(c.TextSegment.Indices.Start)
+	}
+
+	if len(block) == 0 {
+		return ""
+	}
+
+	// Reverse to restore chronological order.
+	for i, j := 0, len(block)-1; i < j; i, j = i+1, j-1 {
+		block[i], block[j] = block[j], block[i]
+	}
+
+	var lines []string
+	for _, c := range block {
+		if line := stripCommentMarkers(c.Image); line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return strings.Join(lines, "  \n")
+}
+
+// hasTokenInRange reports whether any token in ts starts in the half-open range [lo, hi).
+// lo is the end of the preceding comment; hi is the start of the target node.
+func hasTokenInRange(ts core.TokenSlice, lo, hi int) bool {
+	left, right := 0, len(ts)-1
+	for left <= right {
+		mid := (left + right) / 2
+		if int(ts[mid].TextSegment.Indices.Start) < lo {
+			left = mid + 1
+		} else {
+			right = mid - 1
+		}
+	}
+	return left < len(ts) && int(ts[left].TextSegment.Indices.Start) < hi
+}
+
+// stripCommentMarkers removes comment markers from a raw comment token image.
+// Leading and trailing non-alphanumeric runes are trimmed from the whole image
+// and then again from each individual line, stripping interior markers (e.g. the
+// * in /* */ blocks). Works for any comment style (// # -- /* */ etc.).
+func stripCommentMarkers(raw string) string {
+	isMarker := func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	}
+	raw = strings.TrimFunc(strings.TrimSpace(raw), isMarker)
+	var lines []string
+	for _, line := range strings.Split(raw, "\n") {
+		if line = strings.TrimFunc(line, isMarker); line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return strings.Join(lines, "\n")
+}

--- a/server/documentation_provider.go
+++ b/server/documentation_provider.go
@@ -91,21 +91,31 @@ func (s *DefaultDocumentationProvider) Documentation(node core.AstNode) string {
 		lowerBound = int(doc.Tokens[i-1].TextSegment.Indices.End)
 	}
 
-	// Collect comments in [lowerBound, nodeStart) — doc.Comments is sorted by offset,
-	// so results are already in chronological order; no reversal needed.
+	// Collect comments in [lowerBound, nodeStart).
 	first := sort.Search(len(doc.Comments), func(j int) bool {
 		return int(doc.Comments[j].TextSegment.Indices.Start) >= lowerBound
 	})
-	var parts []string
-	for j := first; j < len(doc.Comments); j++ {
-		c := doc.Comments[j]
-		if int(c.TextSegment.Indices.Start) >= nodeStart {
+	last := sort.Search(len(doc.Comments), func(j int) bool {
+		return int(doc.Comments[j].TextSegment.Indices.Start) >= nodeStart
+	}) - 1
+	if last < first {
+		return ""
+	}
+
+	// Only include the last contiguous block — stop at any blank line between comments.
+	blockStart := last
+	for blockStart > first {
+		prev := doc.Comments[blockStart-1]
+		curr := doc.Comments[blockStart]
+		if int(curr.TextSegment.Range.Start.Line)-int(prev.TextSegment.Range.End.Line) > 1 {
 			break
 		}
-		parts = append(parts, s.trimmer.TrimComment(c.Image))
+		blockStart--
 	}
-	if len(parts) == 0 {
-		return ""
+
+	var parts []string
+	for k := blockStart; k <= last; k++ {
+		parts = append(parts, s.trimmer.TrimComment(doc.Comments[k].Image))
 	}
 	return strings.Join(parts, "  \n")
 }

--- a/server/documentation_provider.go
+++ b/server/documentation_provider.go
@@ -5,8 +5,8 @@
 package server
 
 import (
+	"sort"
 	"strings"
-	"unicode"
 
 	core "typefox.dev/fastbelt"
 )
@@ -16,11 +16,55 @@ type DocumentationProvider interface {
 	Documentation(node core.AstNode) string
 }
 
-// DefaultDocumentationProvider is the default implementation of [DocumentationProvider].
-type DefaultDocumentationProvider struct{}
+// DocumentationTrimmer strips comment markers from a raw comment token image.
+// Implement this interface to support comment styles beyond the defaults (// and /* */).
+type DocumentationTrimmer interface {
+	TrimComment(content string) string
+}
 
+// DefaultDocumentationTrimmer strips // single-line and /* */ block comment markers.
+type DefaultDocumentationTrimmer struct{}
+
+// TrimComment removes comment markers from a raw comment token image.
+// For // single-line comments the prefix is stripped and surrounding whitespace trimmed.
+// For /* */ block comments the delimiters and leading * prefixes are removed per line.
+func (t *DefaultDocumentationTrimmer) TrimComment(content string) string {
+	trimmed := strings.TrimSpace(content)
+	if strings.HasPrefix(trimmed, "/*") {
+		inner := strings.TrimSuffix(strings.TrimPrefix(trimmed, "/*"), "*/")
+		lines := strings.Split(inner, "\n")
+		result := make([]string, 0, len(lines))
+		for _, line := range lines {
+			line = strings.TrimSpace(line)
+			line = strings.TrimPrefix(line, "*")
+			line = strings.TrimSpace(line)
+			result = append(result, line)
+		}
+		for len(result) > 0 && result[0] == "" {
+			result = result[1:]
+		}
+		for len(result) > 0 && result[len(result)-1] == "" {
+			result = result[:len(result)-1]
+		}
+		return strings.Join(result, "\n")
+	}
+	// Single-line // comment: strip prefix and trim surrounding whitespace.
+	return strings.TrimSpace(strings.TrimPrefix(trimmed, "//"))
+}
+
+// DefaultDocumentationProvider is the default implementation of [DocumentationProvider].
+type DefaultDocumentationProvider struct {
+	trimmer DocumentationTrimmer
+}
+
+// NewDefaultDocumentationProvider creates a DocumentationProvider with the default trimmer.
 func NewDefaultDocumentationProvider() DocumentationProvider {
-	return &DefaultDocumentationProvider{}
+	return &DefaultDocumentationProvider{trimmer: &DefaultDocumentationTrimmer{}}
+}
+
+// NewDocumentationProviderWithTrimmer creates a DocumentationProvider with a custom trimmer.
+func NewDocumentationProviderWithTrimmer(trimmer DocumentationTrimmer) DocumentationProvider {
+	return &DefaultDocumentationProvider{trimmer: trimmer}
 }
 
 // Documentation returns the documentation comment block immediately preceding node,
@@ -31,70 +75,37 @@ func (s *DefaultDocumentationProvider) Documentation(node core.AstNode) string {
 		return ""
 	}
 
-	targetStart := int(node.Segment().Indices.Start)
-
-	var block []core.Token
-	prevEnd := targetStart
-	for i := len(doc.Comments) - 1; i >= 0; i-- {
-		c := doc.Comments[i]
-		commentEnd := int(c.TextSegment.Indices.End)
-		if commentEnd > prevEnd {
-			continue
-		}
-		if hasTokenInRange(doc.Tokens, commentEnd, prevEnd) {
-			break
-		}
-		block = append(block, c)
-		prevEnd = int(c.TextSegment.Indices.Start)
-	}
-
-	if len(block) == 0 {
+	nodeTokens := node.Tokens()
+	if len(nodeTokens) == 0 {
 		return ""
 	}
+	nodeStart := int(nodeTokens[0].TextSegment.Indices.Start)
 
-	// Reverse to restore chronological order.
-	for i, j := 0, len(block)-1; i < j; i, j = i+1, j-1 {
-		block[i], block[j] = block[j], block[i]
+	// Find the lower bound: end of the code token immediately before this node.
+	// doc.Tokens is sorted by offset; comments live in doc.Comments, not doc.Tokens.
+	lowerBound := 0
+	i := sort.Search(len(doc.Tokens), func(k int) bool {
+		return int(doc.Tokens[k].TextSegment.Indices.Start) >= nodeStart
+	})
+	if i > 0 {
+		lowerBound = int(doc.Tokens[i-1].TextSegment.Indices.End)
 	}
 
-	var lines []string
-	for _, c := range block {
-		if line := stripCommentMarkers(c.Image); line != "" {
-			lines = append(lines, line)
+	// Collect comments in [lowerBound, nodeStart) — doc.Comments is sorted by offset,
+	// so results are already in chronological order; no reversal needed.
+	first := sort.Search(len(doc.Comments), func(j int) bool {
+		return int(doc.Comments[j].TextSegment.Indices.Start) >= lowerBound
+	})
+	var parts []string
+	for j := first; j < len(doc.Comments); j++ {
+		c := doc.Comments[j]
+		if int(c.TextSegment.Indices.Start) >= nodeStart {
+			break
 		}
+		parts = append(parts, s.trimmer.TrimComment(c.Image))
 	}
-	return strings.Join(lines, "  \n")
-}
-
-// hasTokenInRange reports whether any token in ts starts in the half-open range [lo, hi).
-// lo is the end of the preceding comment; hi is the start of the target node.
-func hasTokenInRange(ts core.TokenSlice, lo, hi int) bool {
-	left, right := 0, len(ts)-1
-	for left <= right {
-		mid := (left + right) / 2
-		if int(ts[mid].TextSegment.Indices.Start) < lo {
-			left = mid + 1
-		} else {
-			right = mid - 1
-		}
+	if len(parts) == 0 {
+		return ""
 	}
-	return left < len(ts) && int(ts[left].TextSegment.Indices.Start) < hi
-}
-
-// stripCommentMarkers removes comment markers from a raw comment token image.
-// Leading and trailing non-alphanumeric runes are trimmed from the whole image
-// and then again from each individual line, stripping interior markers (e.g. the
-// * in /* */ blocks). Works for any comment style (// # -- /* */ etc.).
-func stripCommentMarkers(raw string) string {
-	isMarker := func(r rune) bool {
-		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
-	}
-	raw = strings.TrimFunc(strings.TrimSpace(raw), isMarker)
-	var lines []string
-	for _, line := range strings.Split(raw, "\n") {
-		if line = strings.TrimFunc(line, isMarker); line != "" {
-			lines = append(lines, line)
-		}
-	}
-	return strings.Join(lines, "\n")
+	return strings.Join(parts, "  \n")
 }

--- a/server/documentation_provider_test.go
+++ b/server/documentation_provider_test.go
@@ -10,29 +10,26 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestStripCommentMarkersLineComment(t *testing.T) {
-	assert.Equal(t, "foo bar", stripCommentMarkers("// foo bar"))
+func TestTrimCommentLineComment(t *testing.T) {
+	assert.Equal(t, "foo bar", (&DefaultDocumentationTrimmer{}).TrimComment("// foo bar"))
 }
 
-func TestStripCommentMarkersHashComment(t *testing.T) {
-	assert.Equal(t, "foo bar", stripCommentMarkers("# foo bar"))
+func TestTrimCommentBlockComment(t *testing.T) {
+	assert.Equal(t, "foo bar", (&DefaultDocumentationTrimmer{}).TrimComment("/* foo bar */"))
 }
 
-func TestStripCommentMarkersDoubleDashComment(t *testing.T) {
-	assert.Equal(t, "foo bar", stripCommentMarkers("-- foo bar"))
-}
-
-func TestStripCommentMarkersBlockComment(t *testing.T) {
-	assert.Equal(t, "foo bar", stripCommentMarkers("/* foo bar */"))
-}
-
-func TestStripCommentMarkersMultilineBlockComment(t *testing.T) {
+func TestTrimCommentMultilineBlockComment(t *testing.T) {
 	input := "/*\n * line one\n * line two\n */"
-	assert.Equal(t, "line one\nline two", stripCommentMarkers(input))
+	assert.Equal(t, "line one\nline two", (&DefaultDocumentationTrimmer{}).TrimComment(input))
 }
 
-func TestStripCommentMarkersEmpty(t *testing.T) {
-	assert.Equal(t, "", stripCommentMarkers("//"))
-	assert.Equal(t, "", stripCommentMarkers("/* */"))
-	assert.Equal(t, "", stripCommentMarkers("//   "))
+func TestTrimCommentEmpty(t *testing.T) {
+	trimmer := &DefaultDocumentationTrimmer{}
+	assert.Equal(t, "", trimmer.TrimComment("//"))
+	assert.Equal(t, "", trimmer.TrimComment("/* */"))
+	assert.Equal(t, "", trimmer.TrimComment("//   "))
+}
+
+func TestTrimCommentPreservesTrailingPeriod(t *testing.T) {
+	assert.Equal(t, "foo bar.", (&DefaultDocumentationTrimmer{}).TrimComment("// foo bar."))
 }

--- a/server/documentation_provider_test.go
+++ b/server/documentation_provider_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStripCommentMarkersLineComment(t *testing.T) {
+	assert.Equal(t, "foo bar", stripCommentMarkers("// foo bar"))
+}
+
+func TestStripCommentMarkersHashComment(t *testing.T) {
+	assert.Equal(t, "foo bar", stripCommentMarkers("# foo bar"))
+}
+
+func TestStripCommentMarkersDoubleDashComment(t *testing.T) {
+	assert.Equal(t, "foo bar", stripCommentMarkers("-- foo bar"))
+}
+
+func TestStripCommentMarkersBlockComment(t *testing.T) {
+	assert.Equal(t, "foo bar", stripCommentMarkers("/* foo bar */"))
+}
+
+func TestStripCommentMarkersMultilineBlockComment(t *testing.T) {
+	input := "/*\n * line one\n * line two\n */"
+	assert.Equal(t, "line one\nline two", stripCommentMarkers(input))
+}
+
+func TestStripCommentMarkersEmpty(t *testing.T) {
+	assert.Equal(t, "", stripCommentMarkers("//"))
+	assert.Equal(t, "", stripCommentMarkers("/* */"))
+	assert.Equal(t, "", stripCommentMarkers("//   "))
+}

--- a/server/documentation_provider_test.go
+++ b/server/documentation_provider_test.go
@@ -10,26 +10,27 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var trimmer = &DefaultDocumentationTrimmer{}
+
 func TestTrimCommentLineComment(t *testing.T) {
-	assert.Equal(t, "foo bar", (&DefaultDocumentationTrimmer{}).TrimComment("// foo bar"))
+	assert.Equal(t, "foo bar", trimmer.TrimComment("// foo bar"))
 }
 
 func TestTrimCommentBlockComment(t *testing.T) {
-	assert.Equal(t, "foo bar", (&DefaultDocumentationTrimmer{}).TrimComment("/* foo bar */"))
+	assert.Equal(t, "foo bar", trimmer.TrimComment("/* foo bar */"))
 }
 
 func TestTrimCommentMultilineBlockComment(t *testing.T) {
 	input := "/*\n * line one\n * line two\n */"
-	assert.Equal(t, "line one\nline two", (&DefaultDocumentationTrimmer{}).TrimComment(input))
+	assert.Equal(t, "line one\nline two", trimmer.TrimComment(input))
 }
 
 func TestTrimCommentEmpty(t *testing.T) {
-	trimmer := &DefaultDocumentationTrimmer{}
 	assert.Equal(t, "", trimmer.TrimComment("//"))
 	assert.Equal(t, "", trimmer.TrimComment("/* */"))
 	assert.Equal(t, "", trimmer.TrimComment("//   "))
 }
 
 func TestTrimCommentPreservesTrailingPeriod(t *testing.T) {
-	assert.Equal(t, "foo bar.", (&DefaultDocumentationTrimmer{}).TrimComment("// foo bar."))
+	assert.Equal(t, "foo bar.", trimmer.TrimComment("// foo bar."))
 }

--- a/server/hover_provider.go
+++ b/server/hover_provider.go
@@ -1,0 +1,65 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+package server
+
+import (
+	"context"
+
+	core "typefox.dev/fastbelt"
+	"typefox.dev/fastbelt/util/service"
+	"typefox.dev/fastbelt/workspace"
+	"typefox.dev/lsp"
+)
+
+// HoverProvider is a service for handling LSP hover requests.
+type HoverProvider interface {
+	HandleHoverRequest(ctx context.Context, params *lsp.HoverParams) (*lsp.Hover, error)
+}
+
+// DefaultHoverProvider is the default implementation of [HoverProvider].
+type DefaultHoverProvider struct {
+	sc *service.Container
+}
+
+func NewDefaultHoverProvider(sc *service.Container) HoverProvider {
+	return &DefaultHoverProvider{sc: sc}
+}
+
+func (s *DefaultHoverProvider) HandleHoverRequest(ctx context.Context, params *lsp.HoverParams) (*lsp.Hover, error) {
+	documentManager := service.MustGet[workspace.DocumentManager](s.sc)
+	uri := core.ParseURI(string(params.TextDocument.URI))
+	doc := documentManager.Get(uri)
+	if doc == nil {
+		return nil, nil
+	}
+
+	offset := doc.TextDoc.OffsetAt(params.Position)
+	sourceToken := doc.Tokens.SearchOffset(offset)
+	if sourceToken == nil {
+		return nil, nil
+	}
+
+	nameFinder := service.MustGet[NameFinder](s.sc)
+	foundName := nameFinder.Find(ctx, sourceToken)
+	if foundName.Target == nil {
+		return nil, nil
+	}
+
+	targetNode := foundName.Target.Owner()
+	docProvider := service.MustGet[DocumentationProvider](s.sc)
+	content := docProvider.Documentation(targetNode)
+	if content == "" {
+		return nil, nil
+	}
+
+	sourceRange := foundName.Source.Segment().Range.LspRange()
+	return &lsp.Hover{
+		Contents: lsp.MarkupContent{
+			Kind:  lsp.Markdown,
+			Value: content,
+		},
+		Range: sourceRange,
+	}, nil
+}

--- a/server/hover_provider.go
+++ b/server/hover_provider.go
@@ -43,12 +43,15 @@ func (s *DefaultHoverProvider) HandleHoverRequest(ctx context.Context, params *l
 
 	nameFinder := service.MustGet[NameFinder](s.sc)
 	foundName := nameFinder.Find(ctx, sourceToken)
-	if foundName.Target == nil {
+	if foundName.Target == nil || foundName.Source == nil {
 		return nil, nil
 	}
 
 	targetNode := foundName.Target.Owner()
-	docProvider := service.MustGet[DocumentationProvider](s.sc)
+	docProvider, err := service.Get[DocumentationProvider](s.sc)
+	if err != nil {
+		return nil, nil
+	}
 	content := docProvider.Documentation(targetNode)
 	if content == "" {
 		return nil, nil

--- a/server/hover_provider.go
+++ b/server/hover_provider.go
@@ -36,13 +36,13 @@ func (s *DefaultHoverProvider) HandleHoverRequest(ctx context.Context, params *l
 	}
 
 	offset := doc.TextDoc.OffsetAt(params.Position)
-	sourceToken := doc.Tokens.SearchOffset(offset)
-	if sourceToken == nil {
+	first, second := doc.Tokens.SearchOffset2(offset)
+	if first == nil {
 		return nil, nil
 	}
 
 	nameFinder := service.MustGet[NameFinder](s.sc)
-	foundName := nameFinder.Find(ctx, sourceToken)
+	foundName := nameFinder.Find(ctx, first, second)
 	if foundName.Target == nil || foundName.Source == nil {
 		return nil, nil
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -53,10 +53,6 @@ func (s *DefaultLanguageServer) Initialize(ctx context.Context, params *lsp.Para
 			DefinitionProvider: &lsp.Or_ServerCapabilities_definitionProvider{
 				Value: service.Has[DefinitionProvider](s.sc),
 			},
-			ReferencesProvider: &lsp.Or_ServerCapabilities_referencesProvider{
-				Value: service.Has[ReferencesProvider](s.sc),
-			},
-			RenameProvider: service.Has[RenameProvider](s.sc),
 			DocumentSymbolProvider: &lsp.Or_ServerCapabilities_documentSymbolProvider{
 				Value: service.Has[DocumentSymbolProvider](s.sc),
 			},
@@ -69,6 +65,13 @@ func (s *DefaultLanguageServer) Initialize(ctx context.Context, params *lsp.Para
 			WorkspaceSymbolProvider: &lsp.Or_ServerCapabilities_workspaceSymbolProvider{
 				Value: service.Has[WorkspaceSymbolProvider](s.sc),
 			},
+			HoverProvider: &lsp.Or_ServerCapabilities_hoverProvider{
+				Value: service.Has[HoverProvider](s.sc),
+			},
+			ReferencesProvider: &lsp.Or_ServerCapabilities_referencesProvider{
+				Value: service.Has[ReferencesProvider](s.sc),
+			},
+			RenameProvider: service.Has[RenameProvider](s.sc),
 		},
 	}, nil
 }
@@ -312,7 +315,22 @@ func (s *DefaultLanguageServer) Formatting(ctx context.Context, params *lsp.Docu
 	return nil, nil
 }
 func (s *DefaultLanguageServer) Hover(ctx context.Context, params *lsp.HoverParams) (*lsp.Hover, error) {
-	return nil, nil
+	var result *lsp.Hover
+	var providerErr error
+	lock, err := service.Get[workspace.Lock](s.sc)
+	if err != nil {
+		return nil, err
+	}
+	provider, err := service.Get[HoverProvider](s.sc)
+	if err != nil {
+		return nil, err
+	}
+	if err := lock.Read(ctx, func(ctx context.Context) {
+		result, providerErr = provider.HandleHoverRequest(ctx, params)
+	}); err != nil {
+		return nil, err
+	}
+	return result, providerErr
 }
 func (s *DefaultLanguageServer) Implementation(ctx context.Context, params *lsp.ImplementationParams) ([]lsp.DefinitionLink, error) {
 	return nil, nil

--- a/server/services.go
+++ b/server/services.go
@@ -78,10 +78,11 @@ func SetupDefaultServices(sc *service.Container) {
 	}
 	if !service.Has[WorkspaceSymbolProvider](sc) {
 		service.Put(sc, NewDefaultWorkspaceSymbolProvider(sc))
-	if !service.Has[DocumentationProvider](sc) {
-		service.Put(sc, NewDefaultDocumentationProvider())
-	}
-	if !service.Has[HoverProvider](sc) {
-		service.Put(sc, NewDefaultHoverProvider(sc))
+		if !service.Has[DocumentationProvider](sc) {
+			service.Put(sc, NewDefaultDocumentationProvider())
+		}
+		if !service.Has[HoverProvider](sc) {
+			service.Put(sc, NewDefaultHoverProvider(sc))
+		}
 	}
 }

--- a/server/services.go
+++ b/server/services.go
@@ -78,5 +78,10 @@ func SetupDefaultServices(sc *service.Container) {
 	}
 	if !service.Has[WorkspaceSymbolProvider](sc) {
 		service.Put(sc, NewDefaultWorkspaceSymbolProvider(sc))
+	if !service.Has[DocumentationProvider](sc) {
+		service.Put(sc, NewDefaultDocumentationProvider())
+	}
+	if !service.Has[HoverProvider](sc) {
+		service.Put(sc, NewDefaultHoverProvider(sc))
 	}
 }

--- a/test/doc_fixture_lsp.go
+++ b/test/doc_fixture_lsp.go
@@ -272,6 +272,7 @@ func (d *Doc) ExpectHoverAt(label, markup string) *Doc {
 	}
 	if result == nil {
 		d.fixture.t.Fatalf("fbtest: expected hover result at %q, got nil", label)
+		return d
 	}
 	if result.Contents.Kind != lsp.Markdown {
 		d.fixture.t.Errorf("fbtest: expected Markdown content kind at %q, got %v", label, result.Contents.Kind)

--- a/test/doc_fixture_lsp.go
+++ b/test/doc_fixture_lsp.go
@@ -248,6 +248,75 @@ func (d *Doc) AssertFoldingRanges(labels ...string) *Doc {
 	return d
 }
 
+// ExpectHoverAt asserts that a hover at the named marker returns Markdown content equal to markup.
+// For range markers the start of the range is used as the cursor position.
+// Returns the Doc for chaining.
+func (d *Doc) ExpectHoverAt(label, markup string) *Doc {
+	d.fixture.t.Helper()
+	location, err := d.markerLocation(label, true)
+	if err != nil {
+		d.fixture.t.Fatalf("fbtest: %v", err)
+	}
+	hoverProvider, err := service.Get[server.HoverProvider](d.fixture.sc)
+	if err != nil {
+		d.fixture.t.Fatalf("fbtest: no hover provider available: %v", err)
+	}
+	result, err := hoverProvider.HandleHoverRequest(d.fixture.ctx, &lsp.HoverParams{
+		TextDocumentPositionParams: lsp.TextDocumentPositionParams{
+			TextDocument: lsp.TextDocumentIdentifier{URI: d.Document.URI.DocumentURI()},
+			Position:     location.LspPosition(),
+		},
+	})
+	if err != nil {
+		d.fixture.t.Fatalf("fbtest: hover request failed: %v", err)
+	}
+	if result == nil {
+		d.fixture.t.Fatalf("fbtest: expected hover result at %q, got nil", label)
+	}
+	if result.Contents.Kind != lsp.Markdown {
+		d.fixture.t.Errorf("fbtest: expected Markdown content kind at %q, got %v", label, result.Contents.Kind)
+	}
+	if result.Contents.Value != markup {
+		d.fixture.t.Errorf("fbtest: expected hover value %q at %q, got %q", markup, label, result.Contents.Value)
+	}
+	expectedRange, err := d.MarkerRange(label)
+	if err != nil {
+		d.fixture.t.Fatalf("fbtest: %v", err)
+	}
+	if result.Range != expectedRange.LspRange() {
+		d.fixture.t.Errorf("fbtest: expected hover range %v at %q, got %v", expectedRange.LspRange(), label, result.Range)
+	}
+	return d
+}
+
+// ExpectNoHoverAt asserts that a hover at the named marker returns nil.
+// For range markers the start of the range is used as the cursor position.
+// Returns the Doc for chaining.
+func (d *Doc) ExpectNoHoverAt(label string) *Doc {
+	d.fixture.t.Helper()
+	location, err := d.markerLocation(label, true)
+	if err != nil {
+		d.fixture.t.Fatalf("fbtest: %v", err)
+	}
+	hoverProvider, err := service.Get[server.HoverProvider](d.fixture.sc)
+	if err != nil {
+		d.fixture.t.Fatalf("fbtest: no hover provider available: %v", err)
+	}
+	result, err := hoverProvider.HandleHoverRequest(d.fixture.ctx, &lsp.HoverParams{
+		TextDocumentPositionParams: lsp.TextDocumentPositionParams{
+			TextDocument: lsp.TextDocumentIdentifier{URI: d.Document.URI.DocumentURI()},
+			Position:     location.LspPosition(),
+		},
+	})
+	if err != nil {
+		d.fixture.t.Fatalf("fbtest: hover request failed: %v", err)
+	}
+	if result != nil {
+		d.fixture.t.Errorf("fbtest: expected nil hover at %q, got non-nil result", label)
+	}
+	return d
+}
+
 func (d *Doc) CompletionItems(label string) []lsp.CompletionItem {
 	d.fixture.t.Helper()
 	location, err := d.markerLocation(label, true)


### PR DESCRIPTION
Closes #52 

First attempt at implementing a default hover and documentation provider.

The Hover provider responds to a Hover Request by calling the Documentation Provider to get the content of the associated comment if it exists.

The Documentation Provider finds the comment and strips the comment tokens and returns a cleaned-up string.

I did not find how to get the exact tokens used for comments so I defaulted to removing and leading and trailing non-alphanumerical character. Open for suggestions on how to improve.