### PR TITLE
Proposal: Eager output channel setup in VS Code extensions & server initialization heartbeat log msgs

### DIFF
--- a/internal/scaffold/template_params.go
+++ b/internal/scaffold/template_params.go
@@ -56,7 +56,6 @@ type templateParams struct {
 
 func newTemplateParams(s *Scaffolder) (templateParams, error) {
 	modulePath := s.ImportPath
-	languageLabel := s.Language
 	modulePath = strings.TrimSpace(modulePath)
 	if modulePath == "" {
 		return templateParams{}, fmt.Errorf("module path is empty")
@@ -66,7 +65,9 @@ func newTemplateParams(s *Scaffolder) (templateParams, error) {
 	if base == "." || base == "/" {
 		return templateParams{}, fmt.Errorf("invalid module path %q", modulePath)
 	}
+	languageLabel := s.Language
 	languageLabel = strings.TrimSpace(languageLabel)
+	languageLabel = strings.ToUpper(languageLabel[0:1]) + languageLabel[1:]
 	if languageLabel == "" {
 		return templateParams{}, fmt.Errorf("language name is empty")
 	}

--- a/internal/scaffold/templates/vscode-extension/src/extension.ts.tmpl
+++ b/internal/scaffold/templates/vscode-extension/src/extension.ts.tmpl
@@ -2,7 +2,7 @@
 // This program and the accompanying materials are made available under the
 // terms of the MIT License, which is available in the project root.
 
-import type * as vscode from 'vscode';
+import * as vscode from 'vscode';
 import type { LanguageClientOptions, ServerOptions } from 'vscode-languageclient/node.js';
 import * as path from 'node:path';
 import { LanguageClient, TransportKind } from 'vscode-languageclient/node.js';
@@ -28,7 +28,12 @@ async function startLanguageClient(context: vscode.ExtensionContext): Promise<La
     };
 
     const clientOptions: LanguageClientOptions = {
-        documentSelector: [{ scheme: 'file', language: '{{.LanguageID}}' }]
+        documentSelector: [{ scheme: 'file', language: '{{.LanguageID}}' }],
+        // explicitly create an output channel enabling monitoring the LS logs from the beginning in vs code's 'output' view
+        // (by default vs code creates such channels lazily on the first message)
+        outputChannel: vscode.window.createOutputChannel(
+            '{{.LanguageLabel}} Language Server'
+        )
     };
     const lc = new LanguageClient(
         '{{.LanguageID}}',

--- a/internal/vscode-extensions/arithmetics/src/extension.ts
+++ b/internal/vscode-extensions/arithmetics/src/extension.ts
@@ -2,7 +2,7 @@
 // This program and the accompanying materials are made available under the
 // terms of the MIT License, which is available in the project root.
 
-import type * as vscode from 'vscode';
+import * as vscode from 'vscode';
 import type { LanguageClientOptions, ServerOptions } from 'vscode-languageclient/node.js';
 import * as path from 'node:path';
 import { LanguageClient, TransportKind } from 'vscode-languageclient/node.js';
@@ -28,7 +28,10 @@ async function startLanguageClient(context: vscode.ExtensionContext): Promise<La
     };
 
     const clientOptions: LanguageClientOptions = {
-        documentSelector: [{ scheme: 'file', language: 'arithmetics' }]
+        documentSelector: [{ scheme: 'file', language: 'arithmetics' }],
+        outputChannel: vscode.window.createOutputChannel(
+            'Arithmetics Language Server'
+        )
     };
     const lc = new LanguageClient(
         'arithmetics',

--- a/internal/vscode-extensions/fastbelt/src/extension.ts
+++ b/internal/vscode-extensions/fastbelt/src/extension.ts
@@ -2,7 +2,7 @@
 // This program and the accompanying materials are made available under the
 // terms of the MIT License, which is available in the project root.
 
-import type * as vscode from 'vscode';
+import * as vscode from 'vscode';
 import type { LanguageClientOptions, ServerOptions } from 'vscode-languageclient/node.js';
 import * as path from 'node:path';
 import { LanguageClient, TransportKind } from 'vscode-languageclient/node.js';
@@ -32,7 +32,10 @@ async function startLanguageClient(context: vscode.ExtensionContext): Promise<La
 
     // Options to control the language client
     const clientOptions: LanguageClientOptions = {
-        documentSelector: [{ scheme: 'file', language: 'fastbelt' }]
+        documentSelector: [{ scheme: 'file', language: 'fastbelt' }],
+        outputChannel: vscode.window.createOutputChannel(
+            'Fastbelt Grammar Language Server'
+        )
     };
     const client = new LanguageClient(
         'fastbelt',

--- a/internal/vscode-extensions/statemachine/src/extension.ts
+++ b/internal/vscode-extensions/statemachine/src/extension.ts
@@ -2,7 +2,7 @@
 // This program and the accompanying materials are made available under the
 // terms of the MIT License, which is available in the project root.
 
-import type * as vscode from 'vscode';
+import * as vscode from 'vscode';
 import type { LanguageClientOptions, ServerOptions } from 'vscode-languageclient/node.js';
 import * as path from 'node:path';
 import { LanguageClient, TransportKind } from 'vscode-languageclient/node.js';
@@ -32,7 +32,10 @@ async function startLanguageClient(context: vscode.ExtensionContext): Promise<La
 
     // Options to control the language client
     const clientOptions: LanguageClientOptions = {
-        documentSelector: [{ scheme: 'file', language: 'statemachine' }]
+        documentSelector: [{ scheme: 'file', language: 'statemachine' }],
+        outputChannel: vscode.window.createOutputChannel(
+            'Statemachine Language Server'
+        )
     };
     const client = new LanguageClient(
         'statemachine',

--- a/internal/vscode-extensions/statemachine/src/extension.web.ts
+++ b/internal/vscode-extensions/statemachine/src/extension.web.ts
@@ -36,7 +36,10 @@ async function startLanguageClient(context: vscode.ExtensionContext): Promise<La
     worker.postMessage({ __init: true, wasm }, [wasm.buffer]);
 
     const clientOptions: LanguageClientOptions = {
-        documentSelector: [{ language: 'statemachine' }]
+        documentSelector: [{ language: 'statemachine' }],
+        outputChannel: vscode.window.createOutputChannel(
+            'Statemachine Language Server'
+        )
     };
     const client = new LanguageClient(
         'statemachine',

--- a/server/server.go
+++ b/server/server.go
@@ -7,6 +7,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"log"
 	"log/slog"
 
 	"golang.org/x/exp/jsonrpc2"
@@ -78,6 +79,8 @@ func (s *DefaultLanguageServer) Initialize(ctx context.Context, params *lsp.Para
 
 func (s *DefaultLanguageServer) Initialized(ctx context.Context, params *lsp.InitializedParams) error {
 	if initializer, err := service.Get[workspace.Initializer](s.sc); err == nil {
+		log.Print("LS Initializer running...")
+		defer log.Println("done.")
 		workspaceFolders := service.MustGet[*WorkspaceFolders](s.sc).Value
 		return initializer.Initialize(ctx, workspaceFolders)
 	}


### PR DESCRIPTION
For the sake of having LS output channels in VS Code's output view while firing up the VSC extension, see screenshot,
this change adds explicit channel creations to the existing VSC extensions + the extension template.
(By default VS Code creates them lazily on the first output.)

Proposal: This change adds some heartbeat log messages before and after the LS initialization.
We might make that configurable, but (in development) it's often nice to see it's alive and properly initialized.

<img width="555" height="633" alt="image" src="https://github.com/user-attachments/assets/656c32e0-2b34-403f-a7f4-0f5886b1ccd4" />
