### PR TITLE
Remove root node folding range

### DIFF
--- a/server/folding_range_provider.go
+++ b/server/folding_range_provider.go
@@ -96,7 +96,7 @@ func (p *DefaultFoldingRangeProvider) collectFolding(document *core.Document) []
 
 	foldings := []lsp.FoldingRange{}
 
-	for node := range core.AllNodes(document.Root) {
+	for node := range core.AllChildren(document.Root) {
 		if p.filter.ShouldProcess(node) {
 			includeLastLine := p.filter.IncludeLastFoldingLine(node)
 			if foldingRange := p.toFoldingRange(node.Segment(), "", includeLastLine); foldingRange != nil {


### PR DESCRIPTION
I've noticed that our root node currently also receives a folding range that effectively covers the whole document. This doesn't really make too much sense. This change simply excludes the root node from the folding ranges.

Can be tested using the statemachine or fastbelt grammar extension - writing dedicated tests for the absence of a folding range doesn't work too well, but manual testing should cover this well enough.