### PR TITLE
Improve offset computation for LSP services

### DIFF
--- a/examples/statemachine/statemachine_definition_test.go
+++ b/examples/statemachine/statemachine_definition_test.go
@@ -51,3 +51,24 @@ func TestDefinitionOnReference(t *testing.T) {
 
 	doc.AssertDefinition("flick")
 }
+
+func TestDefinitionBetweenReferenceAndKeyword(t *testing.T) {
+	f := test.New(t, CreateLspServices(nil))
+	doc := f.Parse(`
+		statemachine Toggle
+
+		events <|flick|>
+
+		initialState a
+
+		state a
+		  flick<|flick>=>b
+		end
+
+		state b
+		  flick => a
+		end
+	`).AssertNoErrors()
+
+	doc.AssertDefinition("flick")
+}

--- a/examples/statemachine/statemachine_references_test.go
+++ b/examples/statemachine/statemachine_references_test.go
@@ -51,3 +51,24 @@ func TestReferencesOnReference(t *testing.T) {
 
 	doc.AssertReferences("flick")
 }
+
+func TestReferencesBetweenReferenceAndKeyword(t *testing.T) {
+	f := test.New(t, CreateLspServices(nil))
+	doc := f.Parse(`
+		statemachine Toggle
+
+		events <|flick|>
+
+		initialState a
+
+		state a
+		  <|flick|><|flick>=> b
+		end
+
+		state b
+		  <|flick|> => a
+		end
+	`).AssertNoErrors()
+
+	doc.AssertReferences("flick")
+}

--- a/server/definition_provider.go
+++ b/server/definition_provider.go
@@ -38,12 +38,12 @@ func (s *DefaultDefinitionProvider) HandleDefinitionRequest(ctx context.Context,
 	}
 	offset := doc.TextDoc.OffsetAt(params.Position)
 	tokens := doc.Tokens
-	sourceToken := tokens.SearchOffset(offset)
-	if sourceToken == nil {
+	first, second := tokens.SearchOffset2(offset)
+	if first == nil {
 		return nil, nil // No token at the given position
 	}
 	nameFinder := service.MustGet[NameFinder](s.sc)
-	foundName := nameFinder.Find(ctx, sourceToken)
+	foundName := nameFinder.Find(ctx, first, second)
 	if foundName.Target == nil || foundName.Source == nil {
 		return nil, nil // Could not find a name
 	}

--- a/server/document_highlight_provider.go
+++ b/server/document_highlight_provider.go
@@ -34,12 +34,12 @@ func (s *DefaultDocumentHighlightProvider) HandleDocumentHighlightRequest(ctx co
 	}
 	offset := targetDoc.TextDoc.OffsetAt(params.Position)
 	tokens := targetDoc.Tokens
-	sourceToken := tokens.SearchOffset(offset)
-	if sourceToken == nil {
+	first, second := tokens.SearchOffset2(offset)
+	if first == nil {
 		return nil, nil // No token at the given position
 	}
 	nameFinder := service.MustGet[NameFinder](s.sc)
-	foundName := nameFinder.Find(ctx, sourceToken)
+	foundName := nameFinder.Find(ctx, first, second)
 	if foundName.Target == nil || foundName.Source == nil {
 		return nil, nil // Could not find a name
 	}

--- a/server/name_finder.go
+++ b/server/name_finder.go
@@ -24,7 +24,11 @@ type FoundName struct {
 // Adopters should customize this service if they want to change how names are found in LSP services.
 // Downstream LSP services will automatically use the new implementation.
 type NameFinder interface {
-	Find(ctx context.Context, token *core.Token) FoundName
+	// Find returns the source and target [core.StringUnit] for the given tokens.
+	// This method accepts two tokens, as in some cases (i.e. if the cursor is between two tokens),
+	// there may be two relevant tokens that could be used to find a name.
+	// Use [core.TokenSlice.SearchOffset2] to get the tokens at a given offset.
+	Find(ctx context.Context, first, second *core.Token) FoundName
 }
 
 type DefaultNameFinder struct {
@@ -35,7 +39,32 @@ func NewDefaultNameFinder(sc *service.Container) NameFinder {
 	return &DefaultNameFinder{sc: sc}
 }
 
-func (nf *DefaultNameFinder) Find(ctx context.Context, token *core.Token) FoundName {
+func (nf *DefaultNameFinder) Find(ctx context.Context, first, second *core.Token) FoundName {
+	firstResult := nf.forToken(ctx, first)
+	// Early guard: if the first token already resolves to a name, return it immediately
+	if firstResult.Target != nil {
+		return firstResult
+	}
+	// Try the second token now
+	secondResult := nf.forToken(ctx, second)
+	if secondResult.Target != nil {
+		return secondResult
+	}
+	// Neither token could be resolved to a name.
+	// Try to return the one that has a source unit.
+	if firstResult.Source != nil {
+		return firstResult
+	} else if secondResult.Source != nil {
+		return secondResult
+	}
+	// Found nothing, return empty result
+	return FoundName{}
+}
+
+func (nf *DefaultNameFinder) forToken(ctx context.Context, token *core.Token) FoundName {
+	if token == nil {
+		return FoundName{}
+	}
 	ref := core.ReferenceOfToken(token)
 	if ref != nil {
 		// The token is a reference, try to resolve it and return the target name unit

--- a/server/references_provider.go
+++ b/server/references_provider.go
@@ -36,12 +36,12 @@ func (s *DefaultReferencesProvider) HandleReferencesRequest(ctx context.Context,
 	}
 	offset := targetDoc.TextDoc.OffsetAt(params.Position)
 	tokens := targetDoc.Tokens
-	sourceToken := tokens.SearchOffset(offset)
-	if sourceToken == nil {
+	first, second := tokens.SearchOffset2(offset)
+	if first == nil {
 		return nil, nil // No token at the given position
 	}
 	nameFinder := service.MustGet[NameFinder](s.sc)
-	foundName := nameFinder.Find(ctx, sourceToken)
+	foundName := nameFinder.Find(ctx, first, second)
 	if foundName.Target == nil || foundName.Source == nil {
 		return nil, nil // Could not find a name
 	}

--- a/server/rename_provider.go
+++ b/server/rename_provider.go
@@ -70,11 +70,11 @@ func (rp *DefaultRenameProvider) findTargetNode(ctx context.Context, params *lsp
 	}
 	offset := targetDoc.TextDoc.OffsetAt(params.Position)
 	tokens := targetDoc.Tokens
-	sourceToken := tokens.SearchOffset(offset)
-	if sourceToken == nil {
+	first, second := tokens.SearchOffset2(offset)
+	if first == nil {
 		return FoundName{} // No token at the given position
 	}
 	nameFinder := service.MustGet[NameFinder](rp.sc)
-	foundName := nameFinder.Find(ctx, sourceToken)
+	foundName := nameFinder.Find(ctx, first, second)
 	return foundName
 }

--- a/token.go
+++ b/token.go
@@ -252,21 +252,45 @@ func (t *Token) Owner() AstNode {
 // TokenSlice is a token sequence sorted by source offsets.
 type TokenSlice []Token
 
-// SearchOffset returns the token that contains offset.
+// SearchOffset returns the token that contains the given offset. If the
+// offset is exactly between two tokens, it returns the token after the
+// offset (i.e. the one that starts at that offset). If no token contains
+// the offset, it returns nil.
 //
-// It expects ts to be sorted by token offsets and uses binary search.
+// It expects the tokens to be sorted by token offsets and uses binary search.
 func (ts TokenSlice) SearchOffset(offset int) *Token {
+	prev, next := ts.SearchOffset2(offset)
+	if next != nil {
+		return next
+	}
+	return prev
+}
+
+// SearchOffset2 returns the tokens at the given offset. If the offset is
+// inside of a token, the first return value is that token and the second
+// is nil. If the offset is exactly between two tokens, the first return
+// value is the previous token and the second is the next token.
+//
+// It expects the tokens to be sorted by token offsets and uses binary search.
+func (ts TokenSlice) SearchOffset2(offset int) (*Token, *Token) {
 	low, high := 0, len(ts)-1
 	for low <= high {
 		mid := (low + high) / 2
-		token := ts[mid]
+		token := &ts[mid]
 		if offset < int(token.TextSegment.Indices.Start) {
 			high = mid - 1
 		} else if offset >= int(token.TextSegment.Indices.End) {
 			low = mid + 1
 		} else {
-			return &token
+			// Offset sits exactly on the boundary between this token and the
+			// previous one (prev.End == offset == token.Start): return both.
+			if offset == int(token.TextSegment.Indices.Start) && mid > 0 {
+				if prev := &ts[mid-1]; int(prev.TextSegment.Indices.End) == offset {
+					return prev, token
+				}
+			}
+			return token, nil
 		}
 	}
-	return nil
+	return nil, nil
 }


### PR DESCRIPTION
Fixes an issue in the LSP services: If you were running an LSP operation at the end of a token, it would attempt to compute the result for the next token (if that tokens starts at the position where the previous token ends).

Since we don't know which token is really semantically relevant, we actually need to adjust our `NameFinder#Find` method to accept both tokens in such a case. It will then try to identify which one is more relevant for the request. As the `FoundName` type already returns the `Source` range, callers will always know whether the `first` or `second` token is the revelant one.

In Langium we solved this issue by taking the first token, if it ends on a unicode letter. While this works fairly well, it's not 100% sound.

We could change the name of `SearchOffset2` to something else - but it's in line with Go convention, see `iter.Seq2` which is `iter.Seq`, but with a tuple.