### PR TITLE
Implement file system abstraction

### DIFF
--- a/examples/statemachine/server/main_wasm.go
+++ b/examples/statemachine/server/main_wasm.go
@@ -13,16 +13,7 @@ import (
 	"typefox.dev/fastbelt/server"
 	"typefox.dev/fastbelt/util/service"
 	"typefox.dev/fastbelt/workspace"
-	"typefox.dev/lsp"
 )
-
-// noopInitializer is used in the browser build, where there is no filesystem to
-// scan. The server only operates on documents delivered over the LSP connection.
-type noopInitializer struct{}
-
-func (noopInitializer) Initialize(ctx context.Context, folders []lsp.WorkspaceFolder) error {
-	return nil
-}
 
 func main() {
 	ctx := context.Background()
@@ -30,7 +21,7 @@ func main() {
 	sc := statemachine.CreateLspServices(func(sc *service.Container) {
 		// Override the default services with browser-compatible implementations.
 		server.SetupWasmServices(sc)
-		service.Override[workspace.Initializer](sc, noopInitializer{})
+		service.Override(sc, workspace.NewNoopInitializer())
 	})
 
 	// StartLanguageServer blocks on the connection until it is closed, which

--- a/uri.go
+++ b/uri.go
@@ -36,6 +36,8 @@ type URI interface {
 	// FilePath returns the URI as a file path, which is the format used by the local file system.
 	FilePath() string
 	// JoinPath joins the given path segments to the URI's path and returns a new URI.
+	// It will automatically attempt to normalize the resulting path by resolving "." and ".." segments,
+	// and by collapsing multiple slashes.
 	JoinPath(segments ...string) URI
 	// DocumentURI converts the URI to a lsp.DocumentURI, which is the format used by the LSP library.
 	DocumentURI() lsp.DocumentURI
@@ -228,7 +230,6 @@ func (u *uri) FilePath() string {
 		// UNC path: \\server\share\file.txt
 		sb.WriteString(`\\`)
 		sb.WriteString(u.Authority())
-		isWindows = true
 	}
 	if isWindows && !withAuthority && strings.HasPrefix(path, "/") {
 		// Omit first slash for normal (non-UNC) windows file paths
@@ -246,13 +247,40 @@ func (u *uri) JoinPath(segments ...string) URI {
 	if len(segments) == 0 {
 		return u
 	}
-	joined := strings.Join(segments, "/")
-	newPath := u.Path()
-	if !strings.HasSuffix(u.Path(), "/") {
-		newPath += "/"
+	// An empty path is treated as the root, so the result stays absolute.
+	absolute := u.Path() == "" || strings.HasPrefix(u.Path(), "/")
+
+	// Resolve "." and ".." against a stack of real segments. Slashes (both
+	// kinds) split segments, so leading/trailing/repeated slashes normalize away.
+	var stack []string
+	splitSlashes := func(r rune) bool { return r == '/' || r == '\\' }
+	handleSegment := func(seg string) {
+		for _, seg := range strings.FieldsFunc(seg, splitSlashes) {
+			switch seg {
+			case "", ".":
+				// no-op
+			case "..":
+				if n := len(stack); n > 0 && stack[n-1] != ".." {
+					stack = stack[:n-1]
+				} else if !absolute {
+					// Can't go above the root of an absolute path; keep ".." only for relative paths.
+					stack = append(stack, "..")
+				}
+			default:
+				stack = append(stack, seg)
+			}
+		}
 	}
-	newPath += joined
-	return u.WithPath(newPath)
+	handleSegment(u.Path())
+	for _, seg := range segments {
+		handleSegment(seg)
+	}
+
+	joined := strings.Join(stack, "/")
+	if absolute {
+		joined = "/" + joined
+	}
+	return u.WithPath(joined)
 }
 
 // NewURI returns a URI from the given components.
@@ -395,7 +423,7 @@ func normalizeDriveLetter(path string) string {
 		// No drive letter found
 		return path
 	}
-	return path[0:offset] + strings.ToUpper(string(path[offset:1+offset])) + path[1+offset:]
+	return path[0:offset] + strings.ToUpper(path[offset:1+offset]) + path[1+offset:]
 }
 
 func windowsDriveLetterOffset(path string) int {
@@ -403,10 +431,16 @@ func windowsDriveLetterOffset(path string) int {
 	if strings.HasPrefix(path, "/") {
 		offset = 1
 	}
-	if len(path) >= 3+offset && path[2+offset] == '/' && path[1+offset] == ':' && ((path[0+offset] >= 'a' && path[0+offset] <= 'z') || (path[0+offset] >= 'A' && path[0+offset] <= 'Z')) {
+	if len(path) >= 3+offset && path[2+offset] == '/' && path[1+offset] == ':' && isLetter(path[0+offset]) {
 		return offset
 	}
 	return -1
+}
+
+func isLetter(c byte) bool {
+	// OR with 0x20 converts uppercase ASCII letters to lowercase
+	// Other characters will be rejected by the range check, so this is safe
+	return ((c|0x20) >= 'a' && (c|0x20) <= 'z')
 }
 
 const upperhex = "0123456789ABCDEF"
@@ -466,11 +500,6 @@ func shouldEscape(c byte, isPath, isAuthority bool) bool {
 		(isAuthority && c == ']') ||
 		(isAuthority && c == ':')
 	return !shouldKeep
-}
-
-// isLetter checks if a byte is an ASCII letter
-func isLetter(c byte) bool {
-	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
 }
 
 // isDigit checks if a byte is an ASCII digit

--- a/uri.go
+++ b/uri.go
@@ -33,6 +33,10 @@ type URI interface {
 	// StringUnencoded returns the URI as a string without percent-encoding.
 	// This is useful for debugging and logging purposes.
 	StringUnencoded() string
+	// FilePath returns the URI as a file path, which is the format used by the local file system.
+	FilePath() string
+	// JoinPath joins the given path segments to the URI's path and returns a new URI.
+	JoinPath(segments ...string) URI
 	// DocumentURI converts the URI to a lsp.DocumentURI, which is the format used by the LSP library.
 	DocumentURI() lsp.DocumentURI
 	// WithScheme returns a new URI with the specified scheme, keeping other components unchanged.
@@ -210,6 +214,47 @@ func (u *uri) DocumentURI() lsp.DocumentURI {
 	return lsp.DocumentURI(u.String())
 }
 
+func (u *uri) FilePath() string {
+	if u.Scheme() != FileScheme {
+		// What to do with a non-file URI?
+		// Simply return an empty string for now
+		return ""
+	}
+	sb := strings.Builder{}
+	path := u.Path()
+	withAuthority := u.Authority() != ""
+	isWindows := withAuthority || windowsDriveLetterOffset(path) != -1
+	if withAuthority {
+		// UNC path: \\server\share\file.txt
+		sb.WriteString(`\\`)
+		sb.WriteString(u.Authority())
+		isWindows = true
+	}
+	if isWindows && !withAuthority && strings.HasPrefix(path, "/") {
+		// Omit first slash for normal (non-UNC) windows file paths
+		path = path[1:]
+	}
+	if isWindows {
+		// Normalize Windows paths by replacing forward slashes with backslashes
+		path = strings.ReplaceAll(path, "/", "\\")
+	}
+	sb.WriteString(path)
+	return sb.String()
+}
+
+func (u *uri) JoinPath(segments ...string) URI {
+	if len(segments) == 0 {
+		return u
+	}
+	joined := strings.Join(segments, "/")
+	newPath := u.Path()
+	if !strings.HasSuffix(u.Path(), "/") {
+		newPath += "/"
+	}
+	newPath += joined
+	return u.WithPath(newPath)
+}
+
 // NewURI returns a URI from the given components.
 // The components are not validated or normalized, so callers must ensure they
 // are valid for their use case.
@@ -316,7 +361,22 @@ func ParseURI(value string) URI {
 // FileURI replaces Windows backslashes with forward slashes, ensures the URI
 // path starts with a slash, and normalizes Windows drive letters to uppercase.
 // This is used when creating document URIs from workspace file paths.
+// It is also capable of handling UNC paths.
 func FileURI(path string) URI {
+	authority := ""
+	if strings.HasPrefix(path, `\\`) {
+		// UNC path: \\server\share\file.txt
+		// Authority is "server" and path is "/share/file.txt"
+		parts := strings.SplitN(path[2:], `\`, 2)
+		if len(parts) == 2 {
+			authority = parts[0]
+			path = `\` + parts[1]
+		} else {
+			// Malformed UNC path, treat entire path as authority
+			authority = path[2:]
+			path = `\`
+		}
+	}
 	// Normalize Windows paths by replacing backslashes with forward slashes
 	normalized := strings.ReplaceAll(path, "\\", "/")
 	// Ensure the path starts with a slash
@@ -325,19 +385,28 @@ func FileURI(path string) URI {
 	}
 	// Further normalize the drive letter
 	normalized = normalizeDriveLetter(normalized)
-	return NewURI("file", "", normalized, "", "")
+	return NewURI("file", authority, normalized, "", "")
 }
 
 // Uppercases the drive letter in Windows file paths to ensure consistent URIs across platforms
 func normalizeDriveLetter(path string) string {
+	offset := windowsDriveLetterOffset(path)
+	if offset == -1 {
+		// No drive letter found
+		return path
+	}
+	return path[0:offset] + strings.ToUpper(string(path[offset:1+offset])) + path[1+offset:]
+}
+
+func windowsDriveLetterOffset(path string) int {
 	offset := 0
 	if strings.HasPrefix(path, "/") {
 		offset = 1
 	}
-	if len(path) >= 3+offset && path[2+offset] == '/' && path[1+offset] == ':' && (path[0+offset] >= 'a' && path[0+offset] <= 'z') {
-		return path[0:offset] + strings.ToUpper(string(path[offset:1+offset])) + path[1+offset:]
+	if len(path) >= 3+offset && path[2+offset] == '/' && path[1+offset] == ':' && ((path[0+offset] >= 'a' && path[0+offset] <= 'z') || (path[0+offset] >= 'A' && path[0+offset] <= 'Z')) {
+		return offset
 	}
-	return path
+	return -1
 }
 
 const upperhex = "0123456789ABCDEF"

--- a/uri_test.go
+++ b/uri_test.go
@@ -69,12 +69,45 @@ func TestParseURI(t *testing.T) {
 			},
 		},
 		{
-			name:  "relative path only",
+			name:  "path only",
 			input: "/path/to/resource",
 			expected: &uri{
 				scheme:    "",
 				authority: "",
 				path:      "/path/to/resource",
+				query:     "",
+				fragment:  "",
+			},
+		},
+		{
+			name:  "relative path",
+			input: "file:path/to/resource",
+			expected: &uri{
+				scheme:    "file",
+				authority: "",
+				path:      "path/to/resource",
+				query:     "",
+				fragment:  "",
+			},
+		},
+		{
+			name:  "relative path with dot",
+			input: "file:./path/to/resource",
+			expected: &uri{
+				scheme:    "file",
+				authority: "",
+				path:      "./path/to/resource",
+				query:     "",
+				fragment:  "",
+			},
+		},
+		{
+			name:  "relative path with double dot",
+			input: "file:../path/to/resource",
+			expected: &uri{
+				scheme:    "file",
+				authority: "",
+				path:      "../path/to/resource",
 				query:     "",
 				fragment:  "",
 			},
@@ -591,6 +624,62 @@ func TestString_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestString_PercentRoundTrip(t *testing.T) {
+	// A literal '%' must survive uri -> String (escaped to %25) -> ParseURI (decoded back to '%').
+	testCases := []*uri{
+		{
+			scheme:    "https",
+			authority: "example.com",
+			path:      "/discount/50%off",
+			query:     "code=SAVE%NOW",
+			fragment:  "terms%conditions",
+		},
+		{
+			scheme:    "https",
+			authority: "example.com",
+			path:      "/100%/done",
+		},
+		{
+			// '%' next to sequences that look like valid percent-encoding must not be misread.
+			scheme:    "https",
+			authority: "example.com",
+			path:      "/a%20b/c%3Ad",
+			query:     "x=%2F&y=%25",
+			fragment:  "%41%42",
+		},
+		{
+			scheme: "file",
+			path:   "/C:/100% complete/file%.txt",
+		},
+	}
+
+	for i, original := range testCases {
+		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
+			parsed := ParseURI(original.String())
+			assert.Equal(t, original.scheme, parsed.Scheme())
+			assert.Equal(t, original.authority, parsed.Authority())
+			assert.Equal(t, original.path, parsed.Path())
+			assert.Equal(t, original.query, parsed.Query())
+			assert.Equal(t, original.fragment, parsed.Fragment())
+		})
+	}
+}
+
+func TestParseUri_PercentEncodedStringRoundTrip(t *testing.T) {
+	// An already-encoded URI string must round-trip unchanged through ParseURI -> String.
+	inputs := []string{
+		"https://example.com/discount/50%25off?code%3DSAVE%25NOW#terms%25conditions",
+		"file:///C%3A/100%25%20complete/file%25.txt",
+		"https://example.com/a%20b/c?x%3D%252F",
+	}
+
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			assert.Equal(t, input, ParseURI(input).String())
+		})
+	}
+}
+
 func TestParseUri_WindowsDriveHandling(t *testing.T) {
 	input := "file:///c%3A/Users/Document/%23source.go"
 	expected := "file:///C:/Users/Document/#source.go"
@@ -715,6 +804,78 @@ func TestURI_JoinPath(t *testing.T) {
 			uri:      &uri{scheme: "file"},
 			segments: []string{"file.txt"},
 			expected: "/file.txt",
+		},
+		{
+			name:     "single dot is dropped",
+			uri:      &uri{scheme: "file", path: "/home/user"},
+			segments: []string{"a", ".", "b"},
+			expected: "/home/user/a/b",
+		},
+		{
+			name:     "consecutive dots are dropped",
+			uri:      &uri{scheme: "file", path: "/home/user"},
+			segments: []string{".", ".", "x"},
+			expected: "/home/user/x",
+		},
+		{
+			name:     "double dot pops the previous segment",
+			uri:      &uri{scheme: "file", path: "/home/user"},
+			segments: []string{"a", "..", "b"},
+			expected: "/home/user/b",
+		},
+		{
+			name:     "double dot pops the base path",
+			uri:      &uri{scheme: "file", path: "/home/user"},
+			segments: []string{".."},
+			expected: "/home",
+		},
+		{
+			name:     "consecutive double dots pop multiple segments",
+			uri:      &uri{scheme: "file", path: "/a/b/c"},
+			segments: []string{"..", ".."},
+			expected: "/a",
+		},
+		{
+			name:     "consecutive double dots then a segment",
+			uri:      &uri{scheme: "file", path: "/a/b/c"},
+			segments: []string{"..", "..", "x"},
+			expected: "/a/x",
+		},
+		{
+			name:     "double dots inside a single segment",
+			uri:      &uri{scheme: "file", path: "/a/b"},
+			segments: []string{"x/../../y"},
+			expected: "/a/y",
+		},
+		{
+			name:     "double dot at root is clamped",
+			uri:      &uri{scheme: "file", path: "/"},
+			segments: []string{".."},
+			expected: "/",
+		},
+		{
+			name:     "consecutive double dots past root are clamped",
+			uri:      &uri{scheme: "file", path: "/a"},
+			segments: []string{"..", "..", ".."},
+			expected: "/",
+		},
+		{
+			name:     "double dot past root then a segment",
+			uri:      &uri{scheme: "file", path: "/a"},
+			segments: []string{"..", "..", "b"},
+			expected: "/b",
+		},
+		{
+			name:     "double dot preserved merged on relative path",
+			uri:      &uri{scheme: "file", path: "a"},
+			segments: []string{"..", "..", "b"},
+			expected: "../b",
+		},
+		{
+			name:     "double dot preserved on relative path",
+			uri:      &uri{scheme: "file", path: "../.."},
+			segments: []string{"..", "b"},
+			expected: "../../../b",
 		},
 	}
 

--- a/uri_test.go
+++ b/uri_test.go
@@ -628,3 +628,100 @@ func TestParseUri_LowerCaseSchemeAndAuthority(t *testing.T) {
 	parsed := ParseURI(input)
 	assert.Equal(t, expected, parsed.StringUnencoded())
 }
+
+func TestURI_FilePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		uri      URI
+		expected string
+	}{
+		{
+			name:     "unix path",
+			uri:      &uri{scheme: "file", path: "/home/user/document.txt"},
+			expected: "/home/user/document.txt",
+		},
+		{
+			name:     "windows drive path",
+			uri:      &uri{scheme: "file", path: "/C:/Users/John Doe/file.txt"},
+			expected: `C:\Users\John Doe\file.txt`,
+		},
+		{
+			name:     "UNC path with authority",
+			uri:      &uri{scheme: "file", authority: "server", path: "/share/file.txt"},
+			expected: `\\server\share\file.txt`,
+		},
+		{
+			name:     "non-file scheme returns empty",
+			uri:      &uri{scheme: "https", authority: "example.com", path: "/path"},
+			expected: "",
+		},
+		{
+			name:     "round trip with FileURI on windows path",
+			uri:      FileURI(`C:\Users\John Doe\Documents\my file.txt`),
+			expected: `C:\Users\John Doe\Documents\my file.txt`,
+		},
+		{
+			name:     "round trip with FileURI on unix path",
+			uri:      FileURI("/home/user/document.txt"),
+			expected: "/home/user/document.txt",
+		},
+		{
+			name:     "round trip with FileURI on UNC path",
+			uri:      FileURI(`\\server\share\file.txt`),
+			expected: `\\server\share\file.txt`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.uri.FilePath())
+		})
+	}
+}
+
+func TestURI_JoinPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		uri      URI
+		segments []string
+		expected string
+	}{
+		{
+			name:     "no segments returns same path",
+			uri:      &uri{scheme: "file", path: "/home/user"},
+			segments: nil,
+			expected: "/home/user",
+		},
+		{
+			name:     "single segment without trailing slash",
+			uri:      &uri{scheme: "file", path: "/home/user"},
+			segments: []string{"file.txt"},
+			expected: "/home/user/file.txt",
+		},
+		{
+			name:     "single segment with trailing slash",
+			uri:      &uri{scheme: "file", path: "/home/user/"},
+			segments: []string{"file.txt"},
+			expected: "/home/user/file.txt",
+		},
+		{
+			name:     "multiple segments",
+			uri:      &uri{scheme: "file", path: "/home/user"},
+			segments: []string{"dir", "sub", "file.txt"},
+			expected: "/home/user/dir/sub/file.txt",
+		},
+		{
+			name:     "empty path",
+			uri:      &uri{scheme: "file"},
+			segments: []string{"file.txt"},
+			expected: "/file.txt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.uri.JoinPath(tt.segments...)
+			assert.Equal(t, tt.expected, result.Path())
+		})
+	}
+}

--- a/workspace/file_system.go
+++ b/workspace/file_system.go
@@ -1,0 +1,328 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+package workspace
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"strings"
+
+	core "typefox.dev/fastbelt"
+)
+
+// DirEntry represents a file system entry, which can be a file, directory, or/and symbolic link.
+type DirEntry struct {
+	// IsFile is true if the entry is a regular file.
+	IsFile bool
+	// IsDir is true if the entry is a directory.
+	IsDir bool
+	// IsSymlink is true if the entry is a symbolic link.
+	IsSymlink bool
+	// URI is the URI of the entry.
+	URI core.URI
+}
+
+// FileSystem defines the interface for reading data from an arbitrary file system.
+type FileSystem interface {
+	// Exists checks if the given URI exists in the file system.
+	Exists(ctx context.Context, uri core.URI) bool
+	// Stat returns the file system entry for the given URI, or an error if it does not exist.
+	Stat(ctx context.Context, uri core.URI) (DirEntry, error)
+	// ReadFile reads the content of the file at the given URI and returns it as a byte slice.
+	ReadFile(ctx context.Context, uri core.URI) ([]byte, error)
+	// ReadDir reads the contents of the directory at the given URI and returns a slice of DirEntry for its entries.
+	ReadDir(ctx context.Context, uri core.URI) ([]DirEntry, error)
+}
+
+// SkipDir indicates that the current directory should be skipped.
+var SkipDir = fs.SkipDir
+
+// SkipAll indicates that the entire file system walk should be aborted.
+var SkipAll = fs.SkipAll
+
+func WalkFileSystem(ctx context.Context, fs FileSystem, uri core.URI, fn func(DirEntry) error) error {
+	entry, err := fs.Stat(ctx, uri)
+	if err != nil {
+		return err
+	} else {
+		err = walkDir(ctx, fs, entry, fn)
+	}
+	if err == SkipAll || err == SkipDir {
+		return nil
+	}
+	return err
+}
+
+func walkDir(ctx context.Context, fs FileSystem, entry DirEntry, fn func(DirEntry) error) error {
+	if ctx.Err() != nil {
+		// Abort the walk if the context is already cancelled.
+		return ctx.Err()
+	}
+	if err := fn(entry); err != nil || !entry.IsDir {
+		if err == SkipDir && entry.IsDir {
+			return nil // Skip this dir's contents, not an error
+		}
+		return err
+	}
+	entries, err := fs.ReadDir(ctx, entry.URI)
+	if err != nil {
+		return err
+	}
+	for _, child := range entries {
+		if err := walkDir(ctx, fs, child, fn); err != nil {
+			if err == SkipDir {
+				break // SkipDir from a child stops the remaining siblings
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+// DiskFileSystem is a FileSystem implementation that reads from the local disk using the os package.
+type DiskFileSystem struct{}
+
+// NewDiskFileSystem creates a new instance of DiskFileSystem.
+func NewDiskFileSystem() FileSystem {
+	return &DiskFileSystem{}
+}
+
+// Exists checks if the given URI exists in the local file system.
+func (s *DiskFileSystem) Exists(ctx context.Context, uri core.URI) bool {
+	_, err := s.Stat(ctx, uri)
+	return err == nil
+}
+
+// Stat returns the file system entry for the given URI, or an error if it does not exist.
+func (s *DiskFileSystem) Stat(ctx context.Context, uri core.URI) (DirEntry, error) {
+	if uri.Scheme() != core.FileScheme {
+		return DirEntry{}, os.ErrNotExist
+	}
+	path := uri.FilePath()
+	info, err := os.Lstat(path)
+	if err != nil {
+		return DirEntry{}, err
+	}
+	return DirEntry{
+		IsFile:    info.Mode().IsRegular(),
+		IsDir:     info.IsDir(),
+		IsSymlink: info.Mode()&os.ModeSymlink != 0,
+		URI:       uri,
+	}, nil
+}
+
+// ReadFile reads the content of the file at the given URI and returns it as a byte slice.
+func (s *DiskFileSystem) ReadFile(ctx context.Context, uri core.URI) ([]byte, error) {
+	if uri.Scheme() != core.FileScheme {
+		return nil, os.ErrNotExist
+	}
+	return os.ReadFile(uri.FilePath())
+}
+
+// ReadDir reads the contents of the directory at the given URI and returns a slice of DirEntry for its entries.
+func (s *DiskFileSystem) ReadDir(ctx context.Context, uri core.URI) ([]DirEntry, error) {
+	if uri.Scheme() != core.FileScheme {
+		return nil, os.ErrNotExist
+	}
+	path := uri.FilePath()
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]DirEntry, len(entries))
+	for i, entry := range entries {
+		result[i] = DirEntry{
+			IsFile:    entry.Type().IsRegular(),
+			IsDir:     entry.IsDir(),
+			IsSymlink: entry.Type()&os.ModeSymlink != 0,
+			URI:       uri.JoinPath(entry.Name()),
+		}
+	}
+	return result, nil
+}
+
+// virtualDirEntry is a single node in the file system trie. A node is either a
+// directory (children != nil) or a file (children == nil, content holds the
+// bytes). The empty string key in the parent's children map is never used;
+// children are keyed by path segment.
+type virtualDirEntry struct {
+	name     string
+	content  []byte                      // non-nil => file
+	children map[string]*virtualDirEntry // non-nil => directory
+}
+
+func (e *virtualDirEntry) isDir() bool { return e.children != nil }
+
+// VirtualFileSystem is an in-memory FileSystem. Each URI scheme has its own
+// directory trie rooted at an implicit root directory.
+//
+// Note: not safe for concurrent use; wrap with a workspace lock if shared.
+type VirtualFileSystem struct {
+	schemeRoots map[string]*virtualDirEntry
+}
+
+func NewVirtualFileSystem() *VirtualFileSystem {
+	return &VirtualFileSystem{
+		schemeRoots: make(map[string]*virtualDirEntry),
+	}
+}
+
+// segments splits a URI path into non-empty path segments.
+func segments(uri core.URI) []string {
+	return strings.FieldsFunc(uri.Path(), func(r rune) bool { return r == '/' })
+}
+
+// find walks the trie for the given URI and returns the node, or nil if any
+// segment is missing or traverses through a file.
+func (s *VirtualFileSystem) find(uri core.URI) *virtualDirEntry {
+	node, ok := s.schemeRoots[uri.Scheme()]
+	if !ok {
+		return nil
+	}
+	for _, seg := range segments(uri) {
+		if !node.isDir() {
+			return nil
+		}
+		next, ok := node.children[seg]
+		if !ok {
+			return nil
+		}
+		node = next
+	}
+	return node
+}
+
+// rootFor returns the root directory for a scheme, creating it on first use.
+func (s *VirtualFileSystem) rootFor(scheme string) *virtualDirEntry {
+	root, ok := s.schemeRoots[scheme]
+	if !ok {
+		root = &virtualDirEntry{children: map[string]*virtualDirEntry{}}
+		s.schemeRoots[scheme] = root
+	}
+	return root
+}
+
+// mkdirAll walks segs from the scheme root, creating missing directories. It
+// returns an error if a segment collides with an existing file.
+func (s *VirtualFileSystem) mkdirAll(scheme string, segs []string) (*virtualDirEntry, error) {
+	node := s.rootFor(scheme)
+	for _, seg := range segs {
+		child, ok := node.children[seg]
+		if !ok {
+			child = &virtualDirEntry{name: seg, children: map[string]*virtualDirEntry{}}
+			node.children[seg] = child
+		} else if !child.isDir() {
+			return nil, os.ErrExist
+		}
+		node = child
+	}
+	return node, nil
+}
+
+func entryFor(node *virtualDirEntry, uri core.URI) DirEntry {
+	return DirEntry{
+		IsFile: !node.isDir(),
+		IsDir:  node.isDir(),
+		URI:    uri,
+	}
+}
+
+func (s *VirtualFileSystem) Exists(ctx context.Context, uri core.URI) bool {
+	return s.find(uri) != nil
+}
+
+func (s *VirtualFileSystem) Stat(ctx context.Context, uri core.URI) (DirEntry, error) {
+	node := s.find(uri)
+	if node == nil {
+		return DirEntry{}, os.ErrNotExist
+	}
+	return entryFor(node, uri), nil
+}
+
+func (s *VirtualFileSystem) ReadFile(ctx context.Context, uri core.URI) ([]byte, error) {
+	node := s.find(uri)
+	if node == nil || node.isDir() {
+		return nil, os.ErrNotExist
+	}
+	return node.content, nil
+}
+
+func (s *VirtualFileSystem) ReadDir(ctx context.Context, uri core.URI) ([]DirEntry, error) {
+	node := s.find(uri)
+	if node == nil || !node.isDir() {
+		return nil, os.ErrNotExist
+	}
+	result := make([]DirEntry, 0, len(node.children))
+	for name, child := range node.children {
+		result = append(result, entryFor(child, uri.JoinPath(name)))
+	}
+	return result, nil
+}
+
+func (s *VirtualFileSystem) Mkdir(uri core.URI) error {
+	segs := segments(uri)
+	if len(segs) == 0 {
+		return os.ErrExist // root always exists
+	}
+	parent, err := s.mkdirAll(uri.Scheme(), segs[:len(segs)-1])
+	if err != nil {
+		return err
+	}
+	last := segs[len(segs)-1]
+	if _, ok := parent.children[last]; ok {
+		return os.ErrExist
+	}
+	parent.children[last] = &virtualDirEntry{name: last, children: map[string]*virtualDirEntry{}}
+	return nil
+}
+
+func (s *VirtualFileSystem) WriteFile(uri core.URI, content []byte) error {
+	segs := segments(uri)
+	if len(segs) == 0 {
+		return os.ErrInvalid // cannot write the root
+	}
+	parent, err := s.mkdirAll(uri.Scheme(), segs[:len(segs)-1])
+	if err != nil {
+		return err
+	}
+	last := segs[len(segs)-1]
+	if existing, ok := parent.children[last]; ok && existing.isDir() {
+		return os.ErrInvalid // target is a directory
+	}
+	if content == nil {
+		content = []byte{}
+	}
+	parent.children[last] = &virtualDirEntry{name: last, content: content}
+	return nil
+}
+
+func (s *VirtualFileSystem) Delete(uri core.URI) error {
+	segs := segments(uri)
+	if len(segs) == 0 {
+		if _, ok := s.schemeRoots[uri.Scheme()]; !ok {
+			return os.ErrNotExist
+		}
+		delete(s.schemeRoots, uri.Scheme())
+		return nil
+	}
+	dir, ok := s.schemeRoots[uri.Scheme()]
+	if !ok {
+		return os.ErrNotExist
+	}
+	for _, seg := range segs[:len(segs)-1] {
+		child, ok := dir.children[seg]
+		if !ok || !child.isDir() {
+			return os.ErrNotExist
+		}
+		dir = child
+	}
+	last := segs[len(segs)-1]
+	if _, ok := dir.children[last]; !ok {
+		return os.ErrNotExist
+	}
+	delete(dir.children, last)
+	return nil
+}

--- a/workspace/file_system.go
+++ b/workspace/file_system.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"io/fs"
 	"os"
+	"sort"
 	"strings"
 
 	core "typefox.dev/fastbelt"
@@ -258,6 +259,10 @@ func (s *VirtualFileSystem) ReadDir(ctx context.Context, uri core.URI) ([]DirEnt
 	for name, child := range node.children {
 		result = append(result, entryFor(child, uri.JoinPath(name)))
 	}
+	// Produce stable order for testing and deterministic behavior
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].URI.String() < result[j].URI.String()
+	})
 	return result, nil
 }
 

--- a/workspace/file_system.go
+++ b/workspace/file_system.go
@@ -47,9 +47,8 @@ func WalkFileSystem(ctx context.Context, fs FileSystem, uri core.URI, fn func(Di
 	entry, err := fs.Stat(ctx, uri)
 	if err != nil {
 		return err
-	} else {
-		err = walkDir(ctx, fs, entry, fn)
 	}
+	err = walkDir(ctx, fs, entry, fn)
 	if err == SkipAll || err == SkipDir {
 		return nil
 	}

--- a/workspace/file_system_test.go
+++ b/workspace/file_system_test.go
@@ -47,6 +47,23 @@ func TestWalkFileSystemVisitsAll(t *testing.T) {
 	}, visited)
 }
 
+func TestWalkFileSystemVisitsAllInAlphabeticalOrder(t *testing.T) {
+	fs := NewVirtualFileSystem()
+	require.NoError(t, fs.WriteFile(core.FileURI("/workspace/a.txt"), []byte("a")))
+	require.NoError(t, fs.WriteFile(core.FileURI("/workspace/d.txt"), []byte("d")))
+	require.NoError(t, fs.WriteFile(core.FileURI("/workspace/c.txt"), []byte("c")))
+	require.NoError(t, fs.WriteFile(core.FileURI("/workspace/b.txt"), []byte("b")))
+
+	visited := walkVisited(t, fs, core.FileURI("/workspace"), nil)
+	assert.Equal(t, []string{
+		"file:///workspace",
+		"file:///workspace/a.txt",
+		"file:///workspace/b.txt",
+		"file:///workspace/c.txt",
+		"file:///workspace/d.txt",
+	}, visited)
+}
+
 func TestWalkFileSystemSingleFile(t *testing.T) {
 	fs := NewVirtualFileSystem()
 	require.NoError(t, fs.WriteFile(core.FileURI("/a/b/c.txt"), []byte("c")))
@@ -70,6 +87,27 @@ func TestWalkFileSystemSkipDir(t *testing.T) {
 	assert.Equal(t, []string{
 		"file:///a",
 		"file:///a/b",
+		"file:///a/d.txt",
+	}, visited)
+}
+
+func TestWalkFileSystemSkipFile(t *testing.T) {
+	fs := NewVirtualFileSystem()
+	require.NoError(t, fs.WriteFile(core.FileURI("/a/b/c.txt"), []byte("c")))
+	require.NoError(t, fs.WriteFile(core.FileURI("/a/d.txt"), []byte("d")))
+	require.NoError(t, fs.WriteFile(core.FileURI("/a/e.txt"), []byte("e")))
+
+	// Skip file d: will prevent further siblings from being visited
+	visited := walkVisited(t, fs, core.FileURI("/a"), func(e DirEntry) error {
+		if e.URI.String() == "file:///a/d.txt" {
+			return SkipDir
+		}
+		return nil
+	})
+	assert.Equal(t, []string{
+		"file:///a",
+		"file:///a/b",
+		"file:///a/b/c.txt",
 		"file:///a/d.txt",
 	}, visited)
 }

--- a/workspace/file_system_test.go
+++ b/workspace/file_system_test.go
@@ -1,0 +1,186 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+package workspace
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	core "typefox.dev/fastbelt"
+)
+
+// walkFS builds a small tree and returns the sorted set of visited URIs,
+// applying fn (may be nil) to control the walk.
+func walkVisited(t *testing.T, fs *VirtualFileSystem, root core.URI, fn func(DirEntry) error) []string {
+	t.Helper()
+	var visited []string
+	err := WalkFileSystem(context.Background(), fs, root, func(e DirEntry) error {
+		visited = append(visited, e.URI.String())
+		if fn != nil {
+			return fn(e)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	sort.Strings(visited)
+	return visited
+}
+
+func TestWalkFileSystemVisitsAll(t *testing.T) {
+	fs := NewVirtualFileSystem()
+	require.NoError(t, fs.WriteFile(core.FileURI("/a/b/c.txt"), []byte("c")))
+	require.NoError(t, fs.WriteFile(core.FileURI("/a/d.txt"), []byte("d")))
+
+	visited := walkVisited(t, fs, core.FileURI("/a"), nil)
+	assert.Equal(t, []string{
+		"file:///a",
+		"file:///a/b",
+		"file:///a/b/c.txt",
+		"file:///a/d.txt",
+	}, visited)
+}
+
+func TestWalkFileSystemSingleFile(t *testing.T) {
+	fs := NewVirtualFileSystem()
+	require.NoError(t, fs.WriteFile(core.FileURI("/a/b/c.txt"), []byte("c")))
+
+	visited := walkVisited(t, fs, core.FileURI("/a/b/c.txt"), nil)
+	assert.Equal(t, []string{"file:///a/b/c.txt"}, visited)
+}
+
+func TestWalkFileSystemSkipDir(t *testing.T) {
+	fs := NewVirtualFileSystem()
+	require.NoError(t, fs.WriteFile(core.FileURI("/a/b/c.txt"), []byte("c")))
+	require.NoError(t, fs.WriteFile(core.FileURI("/a/d.txt"), []byte("d")))
+
+	// Skip directory b: its contents must not be visited, but siblings are.
+	visited := walkVisited(t, fs, core.FileURI("/a"), func(e DirEntry) error {
+		if e.URI.String() == "file:///a/b" {
+			return SkipDir
+		}
+		return nil
+	})
+	assert.Equal(t, []string{
+		"file:///a",
+		"file:///a/b",
+		"file:///a/d.txt",
+	}, visited)
+}
+
+func TestWalkFileSystemSkipAll(t *testing.T) {
+	fs := NewVirtualFileSystem()
+	require.NoError(t, fs.WriteFile(core.FileURI("/a/b/c.txt"), []byte("c")))
+	require.NoError(t, fs.WriteFile(core.FileURI("/a/d.txt"), []byte("d")))
+
+	count := 0
+	err := WalkFileSystem(context.Background(), fs, core.FileURI("/a"), func(e DirEntry) error {
+		count++
+		return SkipAll
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, count) // aborted after the root
+}
+
+func TestWalkFileSystemErrorPropagates(t *testing.T) {
+	fs := NewVirtualFileSystem()
+	require.NoError(t, fs.WriteFile(core.FileURI("/a/b/c.txt"), []byte("c")))
+
+	sentinel := errors.New("boom")
+	err := WalkFileSystem(context.Background(), fs, core.FileURI("/a"), func(e DirEntry) error {
+		return sentinel
+	})
+	assert.ErrorIs(t, err, sentinel)
+}
+
+func TestWalkFileSystemMissingRoot(t *testing.T) {
+	fs := NewVirtualFileSystem()
+	err := WalkFileSystem(context.Background(), fs, core.FileURI("/nope"), func(e DirEntry) error {
+		return nil
+	})
+	assert.Error(t, err)
+}
+
+func TestVirtualFileSystemWriteCreatesParents(t *testing.T) {
+	ctx := context.Background()
+	fs := NewVirtualFileSystem()
+	file := core.FileURI("/a/b/c.txt")
+
+	require.NoError(t, fs.WriteFile(file, []byte("hello")))
+
+	content, err := fs.ReadFile(ctx, file)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("hello"), content)
+
+	// Intermediate parents are real, listable directories.
+	dir := core.FileURI("/a/b")
+	stat, err := fs.Stat(ctx, dir)
+	require.NoError(t, err)
+	assert.True(t, stat.IsDir)
+}
+
+func TestVirtualFileSystemReadDir(t *testing.T) {
+	ctx := context.Background()
+	fs := NewVirtualFileSystem()
+	require.NoError(t, fs.WriteFile(core.FileURI("/a/b/c.txt"), []byte("hello")))
+
+	entries, err := fs.ReadDir(ctx, core.FileURI("/a/b"))
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.True(t, entries[0].IsFile)
+}
+
+func TestVirtualFileSystemOverwrite(t *testing.T) {
+	ctx := context.Background()
+	fs := NewVirtualFileSystem()
+	file := core.FileURI("/a/b/c.txt")
+
+	require.NoError(t, fs.WriteFile(file, []byte("hello")))
+	require.NoError(t, fs.WriteFile(file, []byte("world")))
+
+	content, err := fs.ReadFile(ctx, file)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("world"), content)
+}
+
+func TestVirtualFileSystemMkdirExistingFails(t *testing.T) {
+	fs := NewVirtualFileSystem()
+	require.NoError(t, fs.WriteFile(core.FileURI("/a/b/c.txt"), []byte("hello")))
+
+	assert.Error(t, fs.Mkdir(core.FileURI("/a/b")))
+}
+
+func TestVirtualFileSystemFileDirTypeMismatch(t *testing.T) {
+	ctx := context.Background()
+	fs := NewVirtualFileSystem()
+	require.NoError(t, fs.WriteFile(core.FileURI("/a/b/c.txt"), []byte("hello")))
+	dir := core.FileURI("/a/b")
+
+	// Cannot overwrite a directory with a file.
+	assert.Error(t, fs.WriteFile(dir, []byte("x")))
+	// Cannot read a directory as a file.
+	_, err := fs.ReadFile(ctx, dir)
+	assert.Error(t, err)
+}
+
+func TestVirtualFileSystemDeleteRecursive(t *testing.T) {
+	ctx := context.Background()
+	fs := NewVirtualFileSystem()
+	file := core.FileURI("/a/b/c.txt")
+	require.NoError(t, fs.WriteFile(file, []byte("hello")))
+
+	require.NoError(t, fs.Delete(core.FileURI("/a")))
+	assert.False(t, fs.Exists(ctx, file))
+	assert.False(t, fs.Exists(ctx, core.FileURI("/a/b")))
+}
+
+func TestVirtualFileSystemDeleteMissingFails(t *testing.T) {
+	fs := NewVirtualFileSystem()
+	assert.Error(t, fs.Delete(core.FileURI("/a")))
+}

--- a/workspace/initializer.go
+++ b/workspace/initializer.go
@@ -6,10 +6,9 @@ package workspace
 
 import (
 	"context"
-	"io/fs"
 	"log"
-	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	core "typefox.dev/fastbelt"
@@ -42,6 +41,20 @@ type Initializer interface {
 	Initialize(ctx context.Context, folders []lsp.WorkspaceFolder) error
 }
 
+// NoopInitializer is an [Initializer] that does nothing.
+// It can be used in environments where there is no file system to scan, such as the browser.
+type NoopInitializer struct{}
+
+// NewNoopInitializer creates a new instance of [NoopInitializer].
+func NewNoopInitializer() Initializer {
+	return NoopInitializer{}
+}
+
+// Initialize does nothing and returns nil.
+func (NoopInitializer) Initialize(ctx context.Context, folders []lsp.WorkspaceFolder) error {
+	return nil
+}
+
 // DefaultInitializer is the default implementation of [Initializer].
 type DefaultInitializer struct {
 	sc *service.Container
@@ -54,34 +67,34 @@ func NewDefaultInitializer(sc *service.Container) Initializer {
 }
 
 func (s *DefaultInitializer) Initialize(ctx context.Context, folders []lsp.WorkspaceFolder) error {
-	if !service.Has[LanguageID](s.sc) {
+	fs, err := service.Get[FileSystem](s.sc)
+	if err != nil {
+		return nil
+	}
+	languageID, err := service.Get[LanguageID](s.sc)
+	if err != nil {
 		log.Print("workspace LanguageID is not set")
 	}
-	if !service.Has[FileExtensions](s.sc) {
+	extensions, err := service.Get[FileExtensions](s.sc)
+	if err != nil {
 		log.Print("workspace FileExtensions is not set")
 		return nil
 	}
 	for _, folder := range folders {
-		root := core.ParseURI(folder.URI).Path()
-		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
-			if err != nil {
-				return err
-			}
-			if err := ctx.Err(); err != nil {
-				return err
-			}
-			name := d.Name()
-			if d.IsDir() {
+		root := core.ParseURI(folder.URI)
+		err := WalkFileSystem(ctx, fs, root, func(entry DirEntry) error {
+			name := filepath.Base(entry.URI.Path())
+			if entry.IsDir {
 				if strings.HasPrefix(name, ".") {
 					return filepath.SkipDir
 				}
 				return nil
 			}
 			ext := filepath.Ext(name)
-			if !s.matchesExtension(ext) {
+			if !slices.Contains(extensions, ext) {
 				return nil
 			}
-			s.loadFile(path)
+			s.loadFile(ctx, entry.URI, fs, languageID)
 			return nil
 		})
 		if err != nil {
@@ -91,29 +104,17 @@ func (s *DefaultInitializer) Initialize(ctx context.Context, folders []lsp.Works
 	return nil
 }
 
-func (s *DefaultInitializer) loadFile(path string) {
-	content, err := os.ReadFile(path)
+func (s *DefaultInitializer) loadFile(ctx context.Context, uri core.URI, fs FileSystem, languageID LanguageID) {
+	content, err := fs.ReadFile(ctx, uri)
 	if err != nil {
-		log.Printf("failed to read file %s: %v", path, err)
+		log.Printf("failed to read file %s: %v", uri.String(), err)
 		return
 	}
-	uri := core.FileURI(path)
-	languageID := service.MustGet[LanguageID](s.sc)
 	textDoc, err := textdoc.NewFile(uri.DocumentURI(), string(languageID), 0, string(content))
 	if err != nil {
-		log.Printf("failed to create text document for %s: %v", path, err)
+		log.Printf("failed to create text document for %s: %v", uri.String(), err)
 		return
 	}
 	doc := core.NewDocument(textDoc)
 	service.MustGet[DocumentManager](s.sc).Set(doc)
-}
-
-func (s *DefaultInitializer) matchesExtension(ext string) bool {
-	extensions := service.MustGet[FileExtensions](s.sc)
-	for _, e := range extensions {
-		if e == ext {
-			return true
-		}
-	}
-	return false
 }

--- a/workspace/initializer.go
+++ b/workspace/initializer.go
@@ -74,6 +74,7 @@ func (s *DefaultInitializer) Initialize(ctx context.Context, folders []lsp.Works
 	languageID, err := service.Get[LanguageID](s.sc)
 	if err != nil {
 		log.Print("workspace LanguageID is not set")
+		return nil
 	}
 	extensions, err := service.Get[FileExtensions](s.sc)
 	if err != nil {
@@ -86,7 +87,7 @@ func (s *DefaultInitializer) Initialize(ctx context.Context, folders []lsp.Works
 			name := filepath.Base(entry.URI.Path())
 			if entry.IsDir {
 				if strings.HasPrefix(name, ".") {
-					return filepath.SkipDir
+					return SkipDir
 				}
 				return nil
 			}

--- a/workspace/initializer.go
+++ b/workspace/initializer.go
@@ -41,6 +41,45 @@ type Initializer interface {
 	Initialize(ctx context.Context, folders []lsp.WorkspaceFolder) error
 }
 
+// IncludeFilter determines whether a file system entry should be included
+// in the workspace initialization process. It is used by [DefaultInitializer]
+// to filter files and directories.
+type IncludeFilter interface {
+	// Include returns true if the given file system entry should be included.
+	Include(entry DirEntry) bool
+}
+
+// DefaultIncludeFilter is the default implementation of [IncludeFilter].
+// It includes files whose extension matches [FileExtensions] and skips hidden
+// directories (names starting with ".").
+type DefaultIncludeFilter struct {
+	sc *service.Container
+}
+
+// Include returns true if the given file system entry should be included.
+// See [DefaultIncludeFilter] for more info.
+func (s *DefaultIncludeFilter) Include(entry DirEntry) bool {
+	if entry.IsDir {
+		name := filepath.Base(entry.URI.Path())
+		// Don't include hidden directories
+		return !strings.HasPrefix(name, ".")
+	}
+	extensions, err := service.Get[FileExtensions](s.sc)
+	ext := filepath.Ext(entry.URI.Path())
+	if err != nil {
+		// No file extensions are configured
+		// Only include files without an extension
+		return ext == ""
+	}
+	// Include files whose extension matches the configured file extensions
+	return slices.Contains(extensions, ext)
+}
+
+// NewDefaultIncludeFilter returns a new instance of [DefaultIncludeFilter].
+func NewDefaultIncludeFilter(sc *service.Container) IncludeFilter {
+	return &DefaultIncludeFilter{sc: sc}
+}
+
 // NoopInitializer is an [Initializer] that does nothing.
 // It can be used in environments where there is no file system to scan, such as the browser.
 type NoopInitializer struct{}
@@ -56,12 +95,14 @@ func (NoopInitializer) Initialize(ctx context.Context, folders []lsp.WorkspaceFo
 }
 
 // DefaultInitializer is the default implementation of [Initializer].
+// It scans the given workspace folders for files and matches them
+// against the configured [IncludeFilter].
 type DefaultInitializer struct {
 	sc *service.Container
 }
 
 // NewDefaultInitializer returns an [Initializer] that scans workspace folders
-// for files matching [FileExtensions].
+// for files matching [FileExtensions]. Will skip hidden directories (names starting with ".").
 func NewDefaultInitializer(sc *service.Container) Initializer {
 	return &DefaultInitializer{sc: sc}
 }
@@ -76,23 +117,24 @@ func (s *DefaultInitializer) Initialize(ctx context.Context, folders []lsp.Works
 		log.Print("workspace LanguageID is not set")
 		return nil
 	}
-	extensions, err := service.Get[FileExtensions](s.sc)
+	filter, err := service.Get[IncludeFilter](s.sc)
 	if err != nil {
-		log.Print("workspace FileExtensions is not set")
+		log.Print("workspace IncludeFilter is not set")
 		return nil
 	}
 	for _, folder := range folders {
 		root := core.ParseURI(folder.URI)
 		err := WalkFileSystem(ctx, fs, root, func(entry DirEntry) error {
-			name := filepath.Base(entry.URI.Path())
+			included := filter.Include(entry)
 			if entry.IsDir {
-				if strings.HasPrefix(name, ".") {
+				if !included {
+					// Skip this directory and its contents
 					return SkipDir
+				} else {
+					return nil
 				}
-				return nil
-			}
-			ext := filepath.Ext(name)
-			if !slices.Contains(extensions, ext) {
+			} else if !included {
+				// Just skip this file
 				return nil
 			}
 			s.loadFile(ctx, entry.URI, fs, languageID)

--- a/workspace/services.go
+++ b/workspace/services.go
@@ -28,6 +28,9 @@ func SetupDefaultServices(sc *service.Container) {
 	if !service.Has[DocumentManager](sc) {
 		service.Put(sc, NewDefaultDocumentManager(sc))
 	}
+	if !service.Has[FileSystem](sc) {
+		service.Put(sc, NewDiskFileSystem())
+	}
 	if !service.Has[Initializer](sc) {
 		service.Put(sc, NewDefaultInitializer(sc))
 	}

--- a/workspace/services.go
+++ b/workspace/services.go
@@ -34,6 +34,9 @@ func SetupDefaultServices(sc *service.Container) {
 	if !service.Has[Initializer](sc) {
 		service.Put(sc, NewDefaultInitializer(sc))
 	}
+	if !service.Has[IncludeFilter](sc) {
+		service.Put(sc, NewDefaultIncludeFilter(sc))
+	}
 	if !service.Has[Lock](sc) {
 		service.Put(sc, NewDefaultLock())
 	}


### PR DESCRIPTION
Adds a file system abstraction that can be used to implement different kinds of file system (for example - via the vscode API for web extensions).

The default implementation uses the disk as its source of data. Also adds a virtual file system implementation that can be used for testing.