### PR TITLE
Do not create file content copy

### DIFF
--- a/textdoc/file.go
+++ b/textdoc/file.go
@@ -57,7 +57,9 @@ func (f *File) Version() int32 {
 	return f.version
 }
 
-// Content returns a copy of the document content as a byte slice.
+// Content returns the byte slice that represents the document content.
+// This is not a copy. Do not modify the returned slice, as it may lead
+// to unexpected behavior.
 func (f *File) Content() []byte {
 	return f.content
 }

--- a/textdoc/file.go
+++ b/textdoc/file.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"unicode/utf16"
 	"unicode/utf8"
+	"unsafe"
 
 	"typefox.dev/lsp"
 )
@@ -63,13 +64,19 @@ func (f *File) Content() []byte {
 
 // Text returns the text content or a substring if range is provided.
 // This is a convenience method that returns a string instead of []byte.
+//
+// Note: This string is not a copy, and holding onto it will prevent
+// the underlying byte slice from being garbage collected.
 func (f *File) Text(r *lsp.Range) string {
+	content := f.content
 	if r != nil {
 		start := f.offsetAt(r.Start)
 		end := f.offsetAt(r.End)
-		return string(f.content[start:end])
+		content = f.content[start:end]
 	}
-	return string(f.content)
+	// We are creating an "unsafe" view on the byte slice to avoid copying it.
+	// This is safe, since the content is never actually modified after creation.
+	return unsafe.String(unsafe.SliceData(content), len(content))
 }
 
 // PositionAt converts a zero-based byte-offset to a UTF16 position.

--- a/textdoc/overlay.go
+++ b/textdoc/overlay.go
@@ -201,6 +201,9 @@ func (o *Overlay) applyChangeLocked(change lsp.TextDocumentContentChangeEvent) e
 		endOffset := o.offsetAtLocked(wellFormedRange.End)
 
 		// Update content using []byte operations for efficiency
+		// Note: never modify the original content slice in-place:
+		// The byte array is returned directly by Text() so in-place modifications
+		// would affect all existing string views.
 		newContent := make([]byte, 0, startOffset+len(change.Text)+(len(o.content)-endOffset))
 		newContent = append(newContent, o.content[:startOffset]...)
 		newContent = append(newContent, change.Text...)

--- a/textdoc/overlay.go
+++ b/textdoc/overlay.go
@@ -118,9 +118,9 @@ func (o *Overlay) Version() int32 {
 	return o.version
 }
 
-// Content returns a copy of the document content as a byte slice.
-// Returning bytes enables efficient manipulation; a copy is returned to prevent
-// external modification of internal state. This method is thread-safe.
+// Content returns the byte slice that represents the document content.
+// This is not a copy. Do not modify the returned slice, as it may lead
+// to unexpected behavior. This method is thread-safe.
 func (o *Overlay) Content() []byte {
 	o.mu.RLock()
 	defer o.mu.RUnlock()

--- a/textdoc/textdoc.go
+++ b/textdoc/textdoc.go
@@ -15,6 +15,7 @@ type Handle interface {
 	// Version returns the version number of this document.
 	Version() int32
 	// Content returns the document content as a byte slice.
+	// Do not modify the returned slice, as it may lead to unexpected behavior.
 	Content() []byte
 	// Text returns the text content or a substring if range is provided.
 	Text(r *lsp.Range) string


### PR DESCRIPTION
Resolves an issue identified in https://github.com/TypeFox/fastbelt/discussions/111. `string([]byte)` creates a copy of the byte array (as an immutable string value) which is quite wasteful on the memory side of things.

Since we never modify the byte slice anyway (we only ever reassign the pointer), creating a pointer to the byte slice as a string is a "safe" option to prevent this from happening. The only issue is that the byte slice will not be garbage collected if an adopter holds onto a value - but we already had the same problem with the string copy as well.

The following test script can be used on this branch and main (in the `benchmark_test.go` file) to confirm the improved memory consumption behavior:

<details>

```go
const resourceCount = 2000

func TestWorkspaceCycle(t *testing.T) {
	length := 0
	contents := make([]string, resourceCount)
	for i := range contents {
		contents[i], _ = generateStatemachineContent(i)
		length += len(contents[i])
	}
	srv := CreateServices()
	docManager := service.MustGet[workspace.DocumentManager](srv)
	lock := service.MustGet[workspace.Lock](srv)
	builder := service.MustGet[workspace.Builder](srv)

	docs := make([]*fastbelt.Document, resourceCount)
	for i, content := range contents {
		uri := fmt.Sprintf("file:///workspace/statemachine_%d.statemachine", i)
		doc, err := fastbelt.NewDocumentFromString(uri, "statemachine", content)
		if err != nil {
			t.Fatal(err)
		}
		docs[i] = doc
		docManager.Set(doc)
	}

	lock.Write(context.Background(), func(ctx context.Context, downgrade func()) {
		if err := builder.Build(ctx, docs, downgrade); err != nil {
			t.Errorf("build failed: %v", err)
		}
	})

	runtime.GC()
	var mem runtime.MemStats
	runtime.ReadMemStats(&mem)
	t.Errorf("heap after GC: alloc=%.1f MiB sys=%.1f MiB for %.1f MiB of code", float64(mem.HeapAlloc)/1e6, float64(mem.HeapSys)/1e6, float64(length)/1e6)

}
```

</details>

In my tests, it roughly reduces the amount of memory consumed by 10%.