### PR TITLE
Improve LSP text event handling

### DIFF
--- a/server/diagnostics_publisher.go
+++ b/server/diagnostics_publisher.go
@@ -1,0 +1,85 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+package server
+
+import (
+	"context"
+	"log"
+
+	core "typefox.dev/fastbelt"
+	"typefox.dev/fastbelt/textdoc"
+	"typefox.dev/fastbelt/util/service"
+	"typefox.dev/fastbelt/workspace"
+	"typefox.dev/lsp"
+)
+
+// DiagnosticsPublisher is responsible for publishing diagnostics to the LSP client.
+// The default implementation publishes diagnostics in the following scenarios:
+// Document is opened (reuses diagnostics from build).
+// Document is closed (clears diagnostics).
+// Document is validated by the builder.
+//
+// When registered to a service container, it automatically hooks into the document lifecycle events.
+type DiagnosticsPublisher struct {
+	sc *service.Container
+}
+
+// NewDiagnosticsPublisher creates a new instance of [DiagnosticsPublisher].
+func NewDiagnosticsPublisher(sc *service.Container) *DiagnosticsPublisher {
+	return &DiagnosticsPublisher{sc: sc}
+}
+
+func (d *DiagnosticsPublisher) OnServerInitialize(_ *lsp.ParamInitialize) {
+	store := service.MustGet[textdoc.Store](d.sc)
+	syncher := service.MustGet[DocumentSyncher](d.sc)
+	syncher.OnDidOpen(func(ctx context.Context, event *TextDocumentChangeEvent) {
+		docManager, err := service.Get[workspace.DocumentManager](d.sc)
+		if err != nil {
+			return
+		}
+		uri := core.ParseURI(string(event.Document.URI()))
+		document := docManager.Get(uri)
+		if document != nil {
+			// If the document already exists, publish diagnostics immediately.
+			d.publishDocumentDiagnostics(ctx, document)
+		}
+	})
+	syncher.OnDidClose(func(ctx context.Context, event *TextDocumentChangeEvent) {
+		uri := core.ParseURI(string(event.Document.URI()))
+		handle := store.Get(uri.DocumentURI())
+		if handle != nil {
+			// Clear diagnostics for the closed document.
+			d.publishDiagnostics(ctx, handle, []lsp.Diagnostic{})
+		}
+	})
+	builder := service.MustGet[workspace.Builder](d.sc)
+	builder.AddBuildStepListener(core.DocStateValidated, func(ctx context.Context, doc *core.Document) error {
+		if store.GetOverlay(doc.URI.DocumentURI()) == nil {
+			return nil // Document is not open, skip publishing diagnostics
+		}
+		return d.publishDocumentDiagnostics(ctx, doc)
+	})
+}
+
+func (d *DiagnosticsPublisher) publishDocumentDiagnostics(ctx context.Context, doc *core.Document) error {
+	lspDiags := make([]lsp.Diagnostic, 0, len(doc.Diagnostics))
+	for _, d := range doc.Diagnostics {
+		lspDiags = append(lspDiags, toLspDiagnostic(*d))
+	}
+	return d.publishDiagnostics(ctx, doc.TextDoc, lspDiags)
+}
+
+func (d *DiagnosticsPublisher) publishDiagnostics(ctx context.Context, handle textdoc.Handle, diagnostics []lsp.Diagnostic) error {
+	connection := service.MustGet[*Connection](d.sc)
+	client := lsp.ClientDispatcher(connection.Value)
+	err := client.PublishDiagnostics(ctx, &lsp.PublishDiagnosticsParams{
+		URI:         handle.URI(),
+		Diagnostics: diagnostics,
+	})
+	if err != nil {
+		log.Printf("failed to publish diagnostics: %v", err)
+	}
+	return err
+}

--- a/server/diagnostics_publisher.go
+++ b/server/diagnostics_publisher.go
@@ -59,19 +59,20 @@ func (d *DiagnosticsPublisher) OnServerInitialize(_ *lsp.ParamInitialize) {
 		if store.GetOverlay(doc.URI.DocumentURI()) == nil {
 			return nil // Document is not open, skip publishing diagnostics
 		}
-		return d.publishDocumentDiagnostics(ctx, doc)
+		d.publishDocumentDiagnostics(ctx, doc)
+		return nil
 	})
 }
 
-func (d *DiagnosticsPublisher) publishDocumentDiagnostics(ctx context.Context, doc *core.Document) error {
+func (d *DiagnosticsPublisher) publishDocumentDiagnostics(ctx context.Context, doc *core.Document) {
 	lspDiags := make([]lsp.Diagnostic, 0, len(doc.Diagnostics))
 	for _, d := range doc.Diagnostics {
 		lspDiags = append(lspDiags, toLspDiagnostic(*d))
 	}
-	return d.publishDiagnostics(ctx, doc.TextDoc, lspDiags)
+	d.publishDiagnostics(ctx, doc.TextDoc, lspDiags)
 }
 
-func (d *DiagnosticsPublisher) publishDiagnostics(ctx context.Context, handle textdoc.Handle, diagnostics []lsp.Diagnostic) error {
+func (d *DiagnosticsPublisher) publishDiagnostics(ctx context.Context, handle textdoc.Handle, diagnostics []lsp.Diagnostic) {
 	connection := service.MustGet[*Connection](d.sc)
 	client := lsp.ClientDispatcher(connection.Value)
 	err := client.PublishDiagnostics(ctx, &lsp.PublishDiagnosticsParams{
@@ -81,5 +82,4 @@ func (d *DiagnosticsPublisher) publishDiagnostics(ctx context.Context, handle te
 	if err != nil {
 		log.Printf("failed to publish diagnostics: %v", err)
 	}
-	return err
 }

--- a/server/diagnostics_publisher.go
+++ b/server/diagnostics_publisher.go
@@ -53,12 +53,9 @@ func (d *DiagnosticsPublisher) OnServerInitialize(_ *lsp.ParamInitialize) {
 		}
 	})
 	syncher.OnDidClose(func(ctx context.Context, event *TextDocumentChangeEvent) {
-		uri := core.ParseURI(string(event.Document.URI()))
-		handle := store.Get(uri.DocumentURI())
-		if handle != nil {
-			// Clear diagnostics for the closed document.
-			d.publishDiagnostics(ctx, handle, []lsp.Diagnostic{})
-		}
+		uri := core.NormalizeURI(event.Document.URI())
+		// Clear diagnostics for the closed document.
+		d.publishDiagnostics(ctx, uri, []lsp.Diagnostic{})
 	})
 	builder, err := service.Get[workspace.Builder](d.sc)
 	if err != nil {
@@ -78,17 +75,17 @@ func (d *DiagnosticsPublisher) publishDocumentDiagnostics(ctx context.Context, d
 	for _, d := range doc.Diagnostics {
 		lspDiags = append(lspDiags, toLspDiagnostic(*d))
 	}
-	d.publishDiagnostics(ctx, doc.TextDoc, lspDiags)
+	d.publishDiagnostics(ctx, doc.TextDoc.URI(), lspDiags)
 }
 
-func (d *DiagnosticsPublisher) publishDiagnostics(ctx context.Context, handle textdoc.Handle, diagnostics []lsp.Diagnostic) {
+func (d *DiagnosticsPublisher) publishDiagnostics(ctx context.Context, uri lsp.DocumentURI, diagnostics []lsp.Diagnostic) {
 	connection, err := service.Get[*Connection](d.sc)
 	if err != nil {
 		return
 	}
 	client := lsp.ClientDispatcher(connection.Value)
 	err = client.PublishDiagnostics(ctx, &lsp.PublishDiagnosticsParams{
-		URI:         handle.URI(),
+		URI:         uri,
 		Diagnostics: diagnostics,
 	})
 	if err != nil {

--- a/server/diagnostics_publisher.go
+++ b/server/diagnostics_publisher.go
@@ -32,8 +32,14 @@ func NewDiagnosticsPublisher(sc *service.Container) *DiagnosticsPublisher {
 }
 
 func (d *DiagnosticsPublisher) OnServerInitialize(_ *lsp.ParamInitialize) {
-	store := service.MustGet[textdoc.Store](d.sc)
-	syncher := service.MustGet[DocumentSyncher](d.sc)
+	store, err := service.Get[textdoc.Store](d.sc)
+	if err != nil {
+		return
+	}
+	syncher, err := service.Get[DocumentSyncher](d.sc)
+	if err != nil {
+		return
+	}
 	syncher.OnDidOpen(func(ctx context.Context, event *TextDocumentChangeEvent) {
 		docManager, err := service.Get[workspace.DocumentManager](d.sc)
 		if err != nil {
@@ -54,7 +60,10 @@ func (d *DiagnosticsPublisher) OnServerInitialize(_ *lsp.ParamInitialize) {
 			d.publishDiagnostics(ctx, handle, []lsp.Diagnostic{})
 		}
 	})
-	builder := service.MustGet[workspace.Builder](d.sc)
+	builder, err := service.Get[workspace.Builder](d.sc)
+	if err != nil {
+		return
+	}
 	builder.AddBuildStepListener(core.DocStateValidated, func(ctx context.Context, doc *core.Document) error {
 		if store.GetOverlay(doc.URI.DocumentURI()) == nil {
 			return nil // Document is not open, skip publishing diagnostics
@@ -73,9 +82,12 @@ func (d *DiagnosticsPublisher) publishDocumentDiagnostics(ctx context.Context, d
 }
 
 func (d *DiagnosticsPublisher) publishDiagnostics(ctx context.Context, handle textdoc.Handle, diagnostics []lsp.Diagnostic) {
-	connection := service.MustGet[*Connection](d.sc)
+	connection, err := service.Get[*Connection](d.sc)
+	if err != nil {
+		return
+	}
 	client := lsp.ClientDispatcher(connection.Value)
-	err := client.PublishDiagnostics(ctx, &lsp.PublishDiagnosticsParams{
+	err = client.PublishDiagnostics(ctx, &lsp.PublishDiagnosticsParams{
 		URI:         handle.URI(),
 		Diagnostics: diagnostics,
 	})

--- a/server/document_sync.go
+++ b/server/document_sync.go
@@ -78,7 +78,7 @@ func NewDefaultDocumentSyncher(sc *service.Container) DocumentSyncher {
 
 func (s *DefaultDocumentSyncher) DidOpen(ctx context.Context, params *lsp.DidOpenTextDocumentParams) {
 	textdocStore := service.MustGet[textdoc.Store](s.sc)
-	uri := core.ParseURI(string(params.TextDocument.URI)).DocumentURI()
+	uri := core.NormalizeURI(params.TextDocument.URI)
 	existing := textdocStore.Get(uri)
 
 	doc, err := textdoc.NewOverlay(
@@ -119,7 +119,7 @@ func (s *DefaultDocumentSyncher) DidChange(ctx context.Context, params *lsp.DidC
 	}
 
 	textdocStore := service.MustGet[textdoc.Store](s.sc)
-	uri := core.ParseURI(string(params.TextDocument.URI)).DocumentURI()
+	uri := core.NormalizeURI(params.TextDocument.URI)
 	doc := textdocStore.GetOverlay(uri)
 	if doc == nil {
 		return
@@ -154,8 +154,8 @@ func (s *DefaultDocumentSyncher) OnDidChange(handler TextDocumentChangeHandler) 
 
 func (s *DefaultDocumentSyncher) DidClose(ctx context.Context, params *lsp.DidCloseTextDocumentParams) {
 	textdocStore := service.MustGet[textdoc.Store](s.sc)
-	uri := core.ParseURI(string(params.TextDocument.URI))
-	existing := textdocStore.GetOverlay(uri.DocumentURI())
+	uri := core.NormalizeURI(params.TextDocument.URI)
+	existing := textdocStore.GetOverlay(uri)
 	if existing != nil {
 		s.mu.Lock()
 		for _, handler := range s.didCloseHandlers {
@@ -163,7 +163,7 @@ func (s *DefaultDocumentSyncher) DidClose(ctx context.Context, params *lsp.DidCl
 		}
 		s.mu.Unlock()
 	}
-	textdocStore.RemoveOverlay(uri.DocumentURI())
+	textdocStore.RemoveOverlay(uri)
 }
 
 func (s *DefaultDocumentSyncher) OnDidClose(handler TextDocumentChangeHandler) {
@@ -175,7 +175,7 @@ func (s *DefaultDocumentSyncher) OnDidClose(handler TextDocumentChangeHandler) {
 // WillSave does nothing by default.
 func (s *DefaultDocumentSyncher) WillSave(ctx context.Context, params *lsp.WillSaveTextDocumentParams) {
 	store := service.MustGet[textdoc.Store](s.sc)
-	uri := core.ParseURI(string(params.TextDocument.URI)).DocumentURI()
+	uri := core.NormalizeURI(params.TextDocument.URI)
 	doc := store.GetOverlay(uri)
 	if doc != nil {
 		s.mu.RLock()
@@ -196,7 +196,7 @@ func (s *DefaultDocumentSyncher) OnWillSave(handler TextDocumentWillSaveHandler)
 func (s *DefaultDocumentSyncher) WillSaveWaitUntil(ctx context.Context, params *lsp.WillSaveTextDocumentParams) ([]lsp.TextEdit, error) {
 	edits := []lsp.TextEdit{}
 	store := service.MustGet[textdoc.Store](s.sc)
-	uri := core.ParseURI(string(params.TextDocument.URI)).DocumentURI()
+	uri := core.NormalizeURI(params.TextDocument.URI)
 	doc := store.GetOverlay(uri)
 	if doc == nil {
 		return edits, nil
@@ -222,7 +222,7 @@ func (s *DefaultDocumentSyncher) OnWillSaveWaitUntil(handler TextDocumentWillSav
 // DidSave does nothing by default.
 func (s *DefaultDocumentSyncher) DidSave(ctx context.Context, params *lsp.DidSaveTextDocumentParams) {
 	store := service.MustGet[textdoc.Store](s.sc)
-	uri := core.ParseURI(string(params.TextDocument.URI)).DocumentURI()
+	uri := core.NormalizeURI(params.TextDocument.URI)
 	doc := store.GetOverlay(uri)
 	if doc != nil {
 		s.mu.RLock()

--- a/server/document_sync.go
+++ b/server/document_sync.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	"context"
 	"log"
-	"os"
+	"sync"
 
 	core "typefox.dev/fastbelt"
 	"typefox.dev/fastbelt/textdoc"
@@ -51,11 +51,25 @@ type DocumentSyncher interface {
 	WillSave(ctx context.Context, params *lsp.WillSaveTextDocumentParams)
 	WillSaveWaitUntil(ctx context.Context, params *lsp.WillSaveTextDocumentParams) ([]lsp.TextEdit, error)
 	DidSave(ctx context.Context, params *lsp.DidSaveTextDocumentParams)
+
+	OnDidOpen(handler TextDocumentChangeHandler)
+	OnDidChange(handler TextDocumentChangeHandler)
+	OnDidClose(handler TextDocumentChangeHandler)
+	OnWillSave(handler TextDocumentWillSaveHandler)
+	OnWillSaveWaitUntil(handler TextDocumentWillSaveWaitUntilHandler)
+	OnDidSave(handler TextDocumentChangeHandler)
 }
 
 // DefaultDocumentSyncher is the default implementation of DocumentSyncher.
 type DefaultDocumentSyncher struct {
-	sc *service.Container
+	sc                        *service.Container
+	didOpenHandlers           []TextDocumentChangeHandler
+	didChangeHandlers         []TextDocumentChangeHandler
+	didCloseHandlers          []TextDocumentChangeHandler
+	willSaveHandlers          []TextDocumentWillSaveHandler
+	willSaveWaitUntilHandlers []TextDocumentWillSaveWaitUntilHandler
+	didSaveHandlers           []TextDocumentChangeHandler
+	mu                        sync.RWMutex
 }
 
 func NewDefaultDocumentSyncher(sc *service.Container) DocumentSyncher {
@@ -64,10 +78,11 @@ func NewDefaultDocumentSyncher(sc *service.Container) DocumentSyncher {
 
 func (s *DefaultDocumentSyncher) DidOpen(ctx context.Context, params *lsp.DidOpenTextDocumentParams) {
 	textdocStore := service.MustGet[textdoc.Store](s.sc)
-	existing := textdocStore.Get(params.TextDocument.URI)
+	uri := core.ParseURI(string(params.TextDocument.URI)).DocumentURI()
+	existing := textdocStore.Get(uri)
 
 	doc, err := textdoc.NewOverlay(
-		params.TextDocument.URI,
+		uri,
 		string(params.TextDocument.LanguageID),
 		params.TextDocument.Version,
 		params.TextDocument.Text,
@@ -79,6 +94,11 @@ func (s *DefaultDocumentSyncher) DidOpen(ctx context.Context, params *lsp.DidOpe
 	}
 
 	textdocStore.AddOverlay(doc)
+	s.mu.RLock()
+	for _, handler := range s.didOpenHandlers {
+		handler(ctx, &TextDocumentChangeEvent{Document: doc})
+	}
+	s.mu.RUnlock()
 	if existing != nil && existing.Text(nil) == params.TextDocument.Text {
 		// The text editor content is the same as the file content
 		return
@@ -87,13 +107,20 @@ func (s *DefaultDocumentSyncher) DidOpen(ctx context.Context, params *lsp.DidOpe
 	updater.Update(ctx, []textdoc.Handle{doc}, nil)
 }
 
+func (s *DefaultDocumentSyncher) OnDidOpen(handler TextDocumentChangeHandler) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.didOpenHandlers = append(s.didOpenHandlers, handler)
+}
+
 func (s *DefaultDocumentSyncher) DidChange(ctx context.Context, params *lsp.DidChangeTextDocumentParams) {
 	if len(params.ContentChanges) == 0 {
 		return
 	}
 
 	textdocStore := service.MustGet[textdoc.Store](s.sc)
-	doc := textdocStore.GetOverlay(params.TextDocument.URI)
+	uri := core.ParseURI(string(params.TextDocument.URI)).DocumentURI()
+	doc := textdocStore.GetOverlay(uri)
 	if doc == nil {
 		return
 	}
@@ -107,56 +134,107 @@ func (s *DefaultDocumentSyncher) DidChange(ctx context.Context, params *lsp.DidC
 	}
 
 	if bytes.Equal(oldContent, doc.Content()) {
+		// Document hasn't actually changed, no need to notify handlers or update the workspace
 		return
 	}
+	s.mu.RLock()
+	for _, handler := range s.didChangeHandlers {
+		handler(ctx, &TextDocumentChangeEvent{Document: doc})
+	}
+	s.mu.RUnlock()
 	updater := service.MustGet[workspace.DocumentUpdater](s.sc)
 	updater.Update(ctx, []textdoc.Handle{doc}, nil)
 }
 
+func (s *DefaultDocumentSyncher) OnDidChange(handler TextDocumentChangeHandler) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.didChangeHandlers = append(s.didChangeHandlers, handler)
+}
+
 func (s *DefaultDocumentSyncher) DidClose(ctx context.Context, params *lsp.DidCloseTextDocumentParams) {
 	textdocStore := service.MustGet[textdoc.Store](s.sc)
-	textdocStore.RemoveOverlay(params.TextDocument.URI)
 	uri := core.ParseURI(string(params.TextDocument.URI))
-
-	var file *textdoc.File
-	if uri.Scheme() == core.FileScheme {
-		if content, err := os.ReadFile(uri.Path()); err == nil {
-			languageID := service.MustGet[workspace.LanguageID](s.sc)
-			file, _ = textdoc.NewFile(params.TextDocument.URI, string(languageID), 0, string(content))
+	existing := textdocStore.GetOverlay(uri.DocumentURI())
+	if existing != nil {
+		s.mu.Lock()
+		for _, handler := range s.didCloseHandlers {
+			handler(ctx, &TextDocumentChangeEvent{Document: existing})
 		}
+		s.mu.Unlock()
 	}
-	updater := service.MustGet[workspace.DocumentUpdater](s.sc)
-	if file != nil {
-		// Revert to the original file content
-		updater.Update(ctx, []textdoc.Handle{file}, nil)
-	} else {
-		// We don't find the document in the file system, so delete it from our workspace
-		updater.Update(ctx, nil, []core.URI{uri})
-	}
+	textdocStore.RemoveOverlay(uri.DocumentURI())
+}
 
-	if connection := service.MustGet[*Connection](s.sc); connection.Value != nil {
-		// Ensure we clear diagnostics on close
-		// TODO: Make this configurable - some adopters might want to keep diagnostics for closed documents
-		client := lsp.ClientDispatcher(connection.Value)
-		err := client.PublishDiagnostics(ctx, &lsp.PublishDiagnosticsParams{
-			URI:         params.TextDocument.URI,
-			Diagnostics: []lsp.Diagnostic{},
-		})
-		if err != nil {
-			log.Printf("failed to publish diagnostics after document close: %v", err)
-		}
-	}
+func (s *DefaultDocumentSyncher) OnDidClose(handler TextDocumentChangeHandler) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.didCloseHandlers = append(s.didCloseHandlers, handler)
 }
 
 // WillSave does nothing by default.
 func (s *DefaultDocumentSyncher) WillSave(ctx context.Context, params *lsp.WillSaveTextDocumentParams) {
+	store := service.MustGet[textdoc.Store](s.sc)
+	uri := core.ParseURI(string(params.TextDocument.URI)).DocumentURI()
+	doc := store.GetOverlay(uri)
+	if doc != nil {
+		s.mu.RLock()
+		for _, handler := range s.willSaveHandlers {
+			handler(ctx, &TextDocumentWillSaveEvent{Document: doc, Reason: params.Reason})
+		}
+		s.mu.RUnlock()
+	}
+}
+
+func (s *DefaultDocumentSyncher) OnWillSave(handler TextDocumentWillSaveHandler) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.willSaveHandlers = append(s.willSaveHandlers, handler)
 }
 
 // WillSaveWaitUntil does nothing by default.
 func (s *DefaultDocumentSyncher) WillSaveWaitUntil(ctx context.Context, params *lsp.WillSaveTextDocumentParams) ([]lsp.TextEdit, error) {
-	return []lsp.TextEdit{}, nil
+	edits := []lsp.TextEdit{}
+	store := service.MustGet[textdoc.Store](s.sc)
+	uri := core.ParseURI(string(params.TextDocument.URI)).DocumentURI()
+	doc := store.GetOverlay(uri)
+	if doc == nil {
+		return edits, nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, handler := range s.willSaveWaitUntilHandlers {
+		handlerEdits, err := handler(ctx, &TextDocumentWillSaveEvent{Document: doc, Reason: params.Reason})
+		if err != nil {
+			return nil, err
+		}
+		edits = append(edits, handlerEdits...)
+	}
+	return edits, nil
+}
+
+func (s *DefaultDocumentSyncher) OnWillSaveWaitUntil(handler TextDocumentWillSaveWaitUntilHandler) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.willSaveWaitUntilHandlers = append(s.willSaveWaitUntilHandlers, handler)
 }
 
 // DidSave does nothing by default.
 func (s *DefaultDocumentSyncher) DidSave(ctx context.Context, params *lsp.DidSaveTextDocumentParams) {
+	store := service.MustGet[textdoc.Store](s.sc)
+	uri := core.ParseURI(string(params.TextDocument.URI)).DocumentURI()
+	doc := store.GetOverlay(uri)
+	if doc != nil {
+		s.mu.RLock()
+		for _, handler := range s.didSaveHandlers {
+			handler(ctx, &TextDocumentChangeEvent{Document: doc})
+		}
+		s.mu.RUnlock()
+	}
+}
+
+func (s *DefaultDocumentSyncher) OnDidSave(handler TextDocumentChangeHandler) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.didSaveHandlers = append(s.didSaveHandlers, handler)
 }

--- a/server/document_sync_test.go
+++ b/server/document_sync_test.go
@@ -135,15 +135,6 @@ func TestTextDocuments_Lifecycle(t *testing.T) {
 	if textdocStore.GetOverlay(uri) != nil {
 		t.Error("document should have been removed from collection")
 	}
-
-	// Verify DocumentUpdater.Update was called with deleted URI
-	updateCalls = updater.getUpdateCalls()
-	if len(updateCalls) != 1 {
-		t.Fatalf("expected 1 update call after close, got %d", len(updateCalls))
-	}
-	if len(updateCalls[0].deleted) != 1 {
-		t.Fatalf("expected 1 deleted URI in update call, got %d", len(updateCalls[0].deleted))
-	}
 }
 
 func TestTextDocuments_MultipleDocuments(t *testing.T) {

--- a/server/server.go
+++ b/server/server.go
@@ -12,10 +12,21 @@ import (
 
 	"golang.org/x/exp/jsonrpc2"
 	core "typefox.dev/fastbelt"
+	"typefox.dev/fastbelt/textdoc"
 	"typefox.dev/fastbelt/util/service"
 	"typefox.dev/fastbelt/workspace"
 	"typefox.dev/lsp"
 )
+
+// ServerInitializeParticipant is an interface for services that want to
+// participate in the LSP server initialization process.
+//
+// All services implementing this interface and registered in the [service.Container]
+// instance will have their [ServerInitializeParticipant.OnServerInitialize]
+// method called during the [lsp.Server.Initialize] request.
+type ServerInitializeParticipant interface {
+	OnServerInitialize(params *lsp.ParamInitialize)
+}
 
 // DefaultLanguageServer implements the [lsp.Server] interface
 type DefaultLanguageServer struct {
@@ -28,10 +39,11 @@ func NewDefaultLanguageServer(sc *service.Container) lsp.Server {
 }
 
 func (s *DefaultLanguageServer) Initialize(ctx context.Context, params *lsp.ParamInitialize) (*lsp.InitializeResult, error) {
-	if slogHandler, _ := service.Get[slog.Handler](s.sc); slogHandler != nil {
-		// Set the default logger to use the configured slog handler
-		// It will send logs to the client via the LSP connection
-		slog.SetDefault(slog.New(slogHandler))
+	// Initialize all participants first
+	for service := range s.sc.All() {
+		if initializer, ok := service.(ServerInitializeParticipant); ok {
+			initializer.OnServerInitialize(params)
+		}
 	}
 	workspaceFolders, err := service.Get[*WorkspaceFolders](s.sc)
 	if err != nil {
@@ -516,7 +528,14 @@ func StartLanguageServer(ctx context.Context, sc *service.Container) error {
 	if err != nil {
 		return err
 	}
+	store, err := service.Get[textdoc.Store](sc)
+	if err != nil {
+		return err
+	}
 	builder.AddBuildStepListener(core.DocStateValidated, func(ctx context.Context, doc *core.Document) error {
+		if store.GetOverlay(doc.URI.DocumentURI()) == nil {
+			return nil // Document is not open, skip publishing diagnostics
+		}
 		lspDiags := make([]lsp.Diagnostic, 0, len(doc.Diagnostics))
 		for _, d := range doc.Diagnostics {
 			lspDiags = append(lspDiags, toLspDiagnostic(*d))

--- a/server/server.go
+++ b/server/server.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"log"
-	"log/slog"
 
 	"golang.org/x/exp/jsonrpc2"
 	core "typefox.dev/fastbelt"

--- a/server/server.go
+++ b/server/server.go
@@ -11,19 +11,18 @@ import (
 
 	"golang.org/x/exp/jsonrpc2"
 	core "typefox.dev/fastbelt"
-	"typefox.dev/fastbelt/textdoc"
 	"typefox.dev/fastbelt/util/service"
 	"typefox.dev/fastbelt/workspace"
 	"typefox.dev/lsp"
 )
 
-// ServerInitializeParticipant is an interface for services that want to
+// InitializeParticipant is an interface for services that want to
 // participate in the LSP server initialization process.
 //
 // All services implementing this interface and registered in the [service.Container]
-// instance will have their [ServerInitializeParticipant.OnServerInitialize]
+// instance will have their [InitializeParticipant.OnServerInitialize]
 // method called during the [lsp.Server.Initialize] request.
-type ServerInitializeParticipant interface {
+type InitializeParticipant interface {
 	OnServerInitialize(params *lsp.ParamInitialize)
 }
 
@@ -39,10 +38,8 @@ func NewDefaultLanguageServer(sc *service.Container) lsp.Server {
 
 func (s *DefaultLanguageServer) Initialize(ctx context.Context, params *lsp.ParamInitialize) (*lsp.InitializeResult, error) {
 	// Initialize all participants first
-	for service := range s.sc.All() {
-		if initializer, ok := service.(ServerInitializeParticipant); ok {
-			initializer.OnServerInitialize(params)
-		}
+	for service := range service.GetAll[InitializeParticipant](s.sc) {
+		service.OnServerInitialize(params)
 	}
 	workspaceFolders, err := service.Get[*WorkspaceFolders](s.sc)
 	if err != nil {
@@ -520,32 +517,6 @@ func StartLanguageServer(ctx context.Context, sc *service.Container) error {
 	defer func() {
 		_ = conn.Close() // Ignore error in defer
 	}()
-
-	// Register build step listener to publish diagnostics after validation
-	client := lsp.ClientDispatcher(conn)
-	builder, err := service.Get[workspace.Builder](sc)
-	if err != nil {
-		return err
-	}
-	store, err := service.Get[textdoc.Store](sc)
-	if err != nil {
-		return err
-	}
-	builder.AddBuildStepListener(core.DocStateValidated, func(ctx context.Context, doc *core.Document) error {
-		if store.GetOverlay(doc.URI.DocumentURI()) == nil {
-			return nil // Document is not open, skip publishing diagnostics
-		}
-		lspDiags := make([]lsp.Diagnostic, 0, len(doc.Diagnostics))
-		for _, d := range doc.Diagnostics {
-			lspDiags = append(lspDiags, toLspDiagnostic(*d))
-		}
-		params := &lsp.PublishDiagnosticsParams{
-			URI:         doc.URI.DocumentURI(),
-			Version:     doc.TextDoc.Version(),
-			Diagnostics: lspDiags,
-		}
-		return client.PublishDiagnostics(ctx, params)
-	})
 
 	// Wait for the connection to close
 	return conn.Wait()

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"testing"
 
+	"typefox.dev/fastbelt/textdoc"
 	"typefox.dev/fastbelt/util/service"
 	"typefox.dev/fastbelt/workspace"
 	"typefox.dev/lsp"
@@ -17,6 +18,7 @@ import (
 func TestLanguageServerBasicLifecycle(t *testing.T) {
 	sc := service.NewContainer()
 	workspace.SetupDefaultServices(sc)
+	textdoc.SetupDefaultServices(sc)
 	SetupDefaultServices(sc)
 	service.Put[workspace.LanguageID](sc, "plaintext")
 	service.Put[workspace.FileExtensions](sc, []string{".txt"})

--- a/server/services.go
+++ b/server/services.go
@@ -31,6 +31,9 @@ func SetupDefaultServices(sc *service.Container) {
 	if !service.Has[slog.Handler](sc) {
 		service.Put(sc, NewSlogHandler(sc))
 	}
+	if !service.Has[DiagnosticsPublisher](sc) {
+		service.Put(sc, NewDiagnosticsPublisher(sc))
+	}
 	if !service.Has[lsp.Server](sc) {
 		service.Put(sc, NewDefaultLanguageServer(sc))
 	}

--- a/server/slog_handler.go
+++ b/server/slog_handler.go
@@ -25,6 +25,11 @@ func NewSlogHandler(sc *service.Container) slog.Handler {
 	return &SlogHandler{sc: sc}
 }
 
+// Initializes the default slog handler to send log messages to the LSP client.
+func (h *SlogHandler) OnServerInitialize(_ *lsp.ParamInitialize) {
+	slog.SetDefault(slog.New(h))
+}
+
 func (h *SlogHandler) Enabled(ctx context.Context, level slog.Level) bool {
 	// Enable all log levels. You can customize this to filter based on level or context.
 	return true

--- a/uri.go
+++ b/uri.go
@@ -328,6 +328,17 @@ func (u *uri) With(scheme, authority, path, query, fragment *string) URI {
 	return &result
 }
 
+// NormalizeURI normalizes a [lsp.DocumentURI] by parsing it and re-serializing it.
+// Ensures consistent formatting for reliable comparisons and storage.
+//
+// Different LSP clients use different formats for URIs. For example:
+// VS Code uses "file:///c%3A/path/to/file.txt".
+// Eclipse (LSP4E) uses "file:/C:/path/to/file.txt".
+// Normalization ensures that these variations are treated as equivalent.
+func NormalizeURI(value lsp.DocumentURI) lsp.DocumentURI {
+	return ParseURI(string(value)).DocumentURI()
+}
+
 var parseRegexp = regexp.MustCompile(`^(([^:/?#]+?):)?(\/\/([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?`)
 
 // ParseURI parses value into URI components.

--- a/util/service/service.go
+++ b/util/service/service.go
@@ -9,6 +9,8 @@ import (
 	"iter"
 	"maps"
 	"reflect"
+
+	"typefox.dev/fastbelt/util/extiter"
 )
 
 // A Container holds a collection of services keyed by Go type.
@@ -58,6 +60,23 @@ func Get[T any](container *Container) (T, error) {
 		return zero, fmt.Errorf("service %s not found", t.Name())
 	}
 	return service.(T), nil
+}
+
+// GetAll retrieves all services of type T from the container.
+// Will return an empty sequence if the container is not sealed.
+//
+// TODO make this a method once generic methods are supported in Go.
+func GetAll[T any](container *Container) iter.Seq[T] {
+	if !container.sealed {
+		return extiter.Empty[T]()
+	}
+	return func(yield func(T) bool) {
+		for service := range container.All() {
+			if t, ok := service.(T); ok && !yield(t) {
+				return
+			}
+		}
+	}
 }
 
 // MustGet retrieves a service from the container.


### PR DESCRIPTION
Our current LSP text event handling infrastructure has a few issues:

1. It will trigger a rebuild on file close - this is not necessary, as the change event should be triggered by the client if the file changes during the close event (for example, if it resets the state of the file to the disk state).
2. When building a file, the language server always sent all diagnostics for all files included in the build to the client. It disregarded closed files.

This change addresses these two issues by improving our general LSP infrastructure to support `ServerInitializeParticipant` services that can use callbacks to properly participate in the initialization of the language server. The new `DiagnosticsPublisher` properly takes care of the state of open/closed files and updates diagnostics for all open files included in a build.