### PR TITLE
Fix completion after grammar action

### DIFF
--- a/examples/arithmetics/atn_gen.go
+++ b/examples/arithmetics/atn_gen.go
@@ -542,7 +542,7 @@ func BuildATN() *parser.RuntimeATN {
 		parser.NewEpsilonTransition(states[PrimaryExpression__BlockEnd]),
 	)
 	states[PrimaryExpression_Callable_ID].AppendTransitions(
-		parser.NewAtomTransition(states[PrimaryExpression__Basic_7], Token_ID, &parser.CompletionHint{Field: "Expression.Callable", PrecedingAction: &parser.ActionInfo{TargetType: "FunctionCall", Property: ""}}),
+		parser.NewAtomTransition(states[PrimaryExpression__Basic_7], Token_ID, &parser.CompletionHint{Field: "FunctionCall.Callable", PrecedingAction: &parser.ActionInfo{TargetType: "FunctionCall", Property: ""}}),
 	)
 	states[PrimaryExpression_LeftParen_1].AppendTransitions(
 		parser.NewAtomTransition(states[PrimaryExpression__Basic_3], Keyword_LeftParen, nil),

--- a/examples/arithmetics/completion_gen.go
+++ b/examples/arithmetics/completion_gen.go
@@ -27,20 +27,6 @@ func (*DefaultArithmeticsCompletionFilter) FilterFunctionCallCallable(_ context.
 	return in
 }
 
-var ArithmeticsSyntheticFactories = map[string]func() core.AstNode{
-	"Addition":          func() core.AstNode { return NewExpression() },
-	"DeclaredParameter": func() core.AstNode { return NewDeclaredParameter() },
-	"Definition":        func() core.AstNode { return NewDefinition() },
-	"Evaluation":        func() core.AstNode { return NewEvaluation() },
-	"Exponentiation":    func() core.AstNode { return NewExpression() },
-	"Expression":        func() core.AstNode { return NewExpression() },
-	"Module":            func() core.AstNode { return NewModule() },
-	"Modulo":            func() core.AstNode { return NewExpression() },
-	"Multiplication":    func() core.AstNode { return NewExpression() },
-	"PrimaryExpression": func() core.AstNode { return NewExpression() },
-	"Statement":         func() core.AstNode { return NewStatement() },
-}
-
 type ArithmeticsCompletionDispatchFunc func(
 	ctx context.Context,
 	sc *service.Container,

--- a/examples/arithmetics/parser_gen.go
+++ b/examples/arithmetics/parser_gen.go
@@ -36,26 +36,28 @@ func (p *Parser) ParseModule() Module {
 	current := NewModule()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_module)
-		core.AssignToken(current, token, Module_module)
-	}
-	{
-		token := p.state.Consume(Token_ID)
-		core.AssignToken(current, token, Module_Name_ID)
-		if token != nil {
-			current.SetName(token)
+		{
+			token := p.state.Consume(Keyword_module)
+			core.AssignToken(current, token, Module_module)
 		}
-	}
-	{
-		p.state.Sync(Module__LoopEntry)
-		for p.lookahead.ModuleStatementsLoop(p.state) {
-			p.state.EnterRule(Module__Basic_1)
-			result := p.ParseStatement()
-			p.state.ExitRule()
-			if result != nil {
-				current.SetStatementsItem(result)
+		{
+			token := p.state.Consume(Token_ID)
+			core.AssignToken(current, token, Module_Name_ID)
+			if token != nil {
+				current.SetName(token)
 			}
+		}
+		{
 			p.state.Sync(Module__LoopEntry)
+			for p.lookahead.ModuleStatementsLoop(p.state) {
+				p.state.EnterRule(Module__Basic_1)
+				result := p.ParseStatement()
+				p.state.ExitRule()
+				if result != nil {
+					current.SetStatementsItem(result)
+				}
+				p.state.Sync(Module__LoopEntry)
+			}
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
@@ -65,25 +67,27 @@ func (p *Parser) ParseModule() Module {
 func (p *Parser) ParseStatement() Statement {
 	current := NewStatement()
 	current.SetSegmentStartToken(p.state.LA(1))
-	switch prediction, failure := p.lookahead.StatementAlternatives(p.state); prediction {
-	case 0:
-		{
-			p.state.EnterRule(Statement__Basic_1)
-			result := p.ParseDefinition()
-			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
-			current = result
+	{
+		switch prediction, failure := p.lookahead.StatementAlternatives(p.state); prediction {
+		case 0:
+			{
+				p.state.EnterRule(Statement__Basic_1)
+				result := p.ParseDefinition()
+				p.state.ExitRule()
+				core.MergeTokens(result, current.Tokens())
+				current = result
+			}
+		case 1:
+			{
+				p.state.EnterRule(Statement__Basic_3)
+				result := p.ParseEvaluation()
+				p.state.ExitRule()
+				core.MergeTokens(result, current.Tokens())
+				current = result
+			}
+		default:
+			p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 		}
-	case 1:
-		{
-			p.state.EnterRule(Statement__Basic_3)
-			result := p.ParseEvaluation()
-			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
-			current = result
-		}
-	default:
-		p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -93,38 +97,25 @@ func (p *Parser) ParseDefinition() Definition {
 	current := NewDefinition()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_def)
-		core.AssignToken(current, token, Definition_def)
-	}
-	{
-		token := p.state.Consume(Token_ID)
-		core.AssignToken(current, token, Definition_Name_ID)
-		if token != nil {
-			current.SetName(token)
-		}
-	}
-	p.state.Sync(Definition__Basic_4)
-	if p.lookahead.DefinitionOptional(p.state) {
 		{
-			token := p.state.Consume(Keyword_LeftParen)
-			core.AssignToken(current, token, Definition_LeftParen)
+			token := p.state.Consume(Keyword_def)
+			core.AssignToken(current, token, Definition_def)
 		}
 		{
-			p.state.EnterRule(Definition__LoopEntry)
-			result := p.ParseDeclaredParameter()
-			p.state.ExitRule()
-			if result != nil {
-				current.SetArgsItem(result)
+			token := p.state.Consume(Token_ID)
+			core.AssignToken(current, token, Definition_Name_ID)
+			if token != nil {
+				current.SetName(token)
 			}
 		}
-		p.state.Sync(Definition__LoopEntry)
-		for p.lookahead.DefinitionLoop(p.state) {
+		p.state.Sync(Definition__Basic_4)
+		if p.lookahead.DefinitionOptional(p.state) {
 			{
-				token := p.state.Consume(Keyword_Comma)
-				core.AssignToken(current, token, Definition_Comma)
+				token := p.state.Consume(Keyword_LeftParen)
+				core.AssignToken(current, token, Definition_LeftParen)
 			}
 			{
-				p.state.EnterRule(Definition__Basic_2)
+				p.state.EnterRule(Definition__LoopEntry)
 				result := p.ParseDeclaredParameter()
 				p.state.ExitRule()
 				if result != nil {
@@ -132,27 +123,42 @@ func (p *Parser) ParseDefinition() Definition {
 				}
 			}
 			p.state.Sync(Definition__LoopEntry)
+			for p.lookahead.DefinitionLoop(p.state) {
+				{
+					token := p.state.Consume(Keyword_Comma)
+					core.AssignToken(current, token, Definition_Comma)
+				}
+				{
+					p.state.EnterRule(Definition__Basic_2)
+					result := p.ParseDeclaredParameter()
+					p.state.ExitRule()
+					if result != nil {
+						current.SetArgsItem(result)
+					}
+				}
+				p.state.Sync(Definition__LoopEntry)
+			}
+			{
+				token := p.state.Consume(Keyword_RightParen)
+				core.AssignToken(current, token, Definition_RightParen)
+			}
 		}
 		{
-			token := p.state.Consume(Keyword_RightParen)
-			core.AssignToken(current, token, Definition_RightParen)
+			token := p.state.Consume(Keyword_Colon)
+			core.AssignToken(current, token, Definition_Colon)
 		}
-	}
-	{
-		token := p.state.Consume(Keyword_Colon)
-		core.AssignToken(current, token, Definition_Colon)
-	}
-	{
-		p.state.EnterRule(Definition_Semicolon)
-		result := p.ParseExpression()
-		p.state.ExitRule()
-		if result != nil {
-			current.SetExpression(result)
+		{
+			p.state.EnterRule(Definition_Semicolon)
+			result := p.ParseExpression()
+			p.state.ExitRule()
+			if result != nil {
+				current.SetExpression(result)
+			}
 		}
-	}
-	{
-		token := p.state.Consume(Keyword_Semicolon)
-		core.AssignToken(current, token, Definition_Semicolon)
+		{
+			token := p.state.Consume(Keyword_Semicolon)
+			core.AssignToken(current, token, Definition_Semicolon)
+		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -162,10 +168,12 @@ func (p *Parser) ParseDeclaredParameter() DeclaredParameter {
 	current := NewDeclaredParameter()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Token_ID)
-		core.AssignToken(current, token, DeclaredParameter_Name_ID)
-		if token != nil {
-			current.SetName(token)
+		{
+			token := p.state.Consume(Token_ID)
+			core.AssignToken(current, token, DeclaredParameter_Name_ID)
+			if token != nil {
+				current.SetName(token)
+			}
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
@@ -176,16 +184,18 @@ func (p *Parser) ParseEvaluation() Evaluation {
 	current := NewEvaluation()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		p.state.EnterRule(Evaluation_Semicolon)
-		result := p.ParseExpression()
-		p.state.ExitRule()
-		if result != nil {
-			current.SetExpression(result)
+		{
+			p.state.EnterRule(Evaluation_Semicolon)
+			result := p.ParseExpression()
+			p.state.ExitRule()
+			if result != nil {
+				current.SetExpression(result)
+			}
 		}
-	}
-	{
-		token := p.state.Consume(Keyword_Semicolon)
-		core.AssignToken(current, token, Evaluation_Semicolon)
+		{
+			token := p.state.Consume(Keyword_Semicolon)
+			core.AssignToken(current, token, Evaluation_Semicolon)
+		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -195,11 +205,13 @@ func (p *Parser) ParseExpression() Expression {
 	current := NewExpression()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		p.state.EnterRule(Expression__Basic_1)
-		result := p.ParseAddition()
-		p.state.ExitRule()
-		core.MergeTokens(result, current.Tokens())
-		current = result
+		{
+			p.state.EnterRule(Expression__Basic_1)
+			result := p.ParseAddition()
+			p.state.ExitRule()
+			core.MergeTokens(result, current.Tokens())
+			current = result
+		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -209,47 +221,49 @@ func (p *Parser) ParseAddition() Expression {
 	current := NewExpression()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		p.state.EnterRule(Addition__LoopEntry)
-		result := p.ParseMultiplication()
-		p.state.ExitRule()
-		core.MergeTokens(result, current.Tokens())
-		current = result
-	}
-	p.state.Sync(Addition__LoopEntry)
-	for p.lookahead.AdditionLoop(p.state) {
 		{
-			result := NewBinaryExpression()
-			result.SetSegment(current.Segment())
-			result.SetLeft(current)
-			current.SetSegmentEndToken(p.state.LA(0))
-			current = result
-		}
-		current := current.(BinaryExpression)
-		{
-			switch prediction, _ := p.lookahead.AdditionOperatorAlternatives(p.state); prediction {
-			case 0:
-				token := p.state.Consume(Keyword_Plus)
-				core.AssignToken(current, token, Addition_Operator_Plus)
-				if token != nil {
-					current.SetOperator(token)
-				}
-			case 1:
-				token := p.state.Consume(Keyword_Dash)
-				core.AssignToken(current, token, Addition_Operator_Dash)
-				if token != nil {
-					current.SetOperator(token)
-				}
-			}
-		}
-		{
-			p.state.EnterRule(Addition__Basic_5)
+			p.state.EnterRule(Addition__LoopEntry)
 			result := p.ParseMultiplication()
 			p.state.ExitRule()
-			if result != nil {
-				current.SetRight(result)
-			}
+			core.MergeTokens(result, current.Tokens())
+			current = result
 		}
 		p.state.Sync(Addition__LoopEntry)
+		for p.lookahead.AdditionLoop(p.state) {
+			{
+				result := NewBinaryExpression()
+				result.SetSegment(current.Segment())
+				result.SetLeft(current)
+				current.SetSegmentEndToken(p.state.LA(0))
+				current = result
+			}
+			current := current.(BinaryExpression)
+			{
+				switch prediction, _ := p.lookahead.AdditionOperatorAlternatives(p.state); prediction {
+				case 0:
+					token := p.state.Consume(Keyword_Plus)
+					core.AssignToken(current, token, Addition_Operator_Plus)
+					if token != nil {
+						current.SetOperator(token)
+					}
+				case 1:
+					token := p.state.Consume(Keyword_Dash)
+					core.AssignToken(current, token, Addition_Operator_Dash)
+					if token != nil {
+						current.SetOperator(token)
+					}
+				}
+			}
+			{
+				p.state.EnterRule(Addition__Basic_5)
+				result := p.ParseMultiplication()
+				p.state.ExitRule()
+				if result != nil {
+					current.SetRight(result)
+				}
+			}
+			p.state.Sync(Addition__LoopEntry)
+		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -259,47 +273,49 @@ func (p *Parser) ParseMultiplication() Expression {
 	current := NewExpression()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		p.state.EnterRule(Multiplication__LoopEntry)
-		result := p.ParseExponentiation()
-		p.state.ExitRule()
-		core.MergeTokens(result, current.Tokens())
-		current = result
-	}
-	p.state.Sync(Multiplication__LoopEntry)
-	for p.lookahead.MultiplicationLoop(p.state) {
 		{
-			result := NewBinaryExpression()
-			result.SetSegment(current.Segment())
-			result.SetLeft(current)
-			current.SetSegmentEndToken(p.state.LA(0))
-			current = result
-		}
-		current := current.(BinaryExpression)
-		{
-			switch prediction, _ := p.lookahead.MultiplicationOperatorAlternatives(p.state); prediction {
-			case 0:
-				token := p.state.Consume(Keyword_Asterisk)
-				core.AssignToken(current, token, Multiplication_Operator_Asterisk)
-				if token != nil {
-					current.SetOperator(token)
-				}
-			case 1:
-				token := p.state.Consume(Keyword_Slash)
-				core.AssignToken(current, token, Multiplication_Operator_Slash)
-				if token != nil {
-					current.SetOperator(token)
-				}
-			}
-		}
-		{
-			p.state.EnterRule(Multiplication__Basic_5)
+			p.state.EnterRule(Multiplication__LoopEntry)
 			result := p.ParseExponentiation()
 			p.state.ExitRule()
-			if result != nil {
-				current.SetRight(result)
-			}
+			core.MergeTokens(result, current.Tokens())
+			current = result
 		}
 		p.state.Sync(Multiplication__LoopEntry)
+		for p.lookahead.MultiplicationLoop(p.state) {
+			{
+				result := NewBinaryExpression()
+				result.SetSegment(current.Segment())
+				result.SetLeft(current)
+				current.SetSegmentEndToken(p.state.LA(0))
+				current = result
+			}
+			current := current.(BinaryExpression)
+			{
+				switch prediction, _ := p.lookahead.MultiplicationOperatorAlternatives(p.state); prediction {
+				case 0:
+					token := p.state.Consume(Keyword_Asterisk)
+					core.AssignToken(current, token, Multiplication_Operator_Asterisk)
+					if token != nil {
+						current.SetOperator(token)
+					}
+				case 1:
+					token := p.state.Consume(Keyword_Slash)
+					core.AssignToken(current, token, Multiplication_Operator_Slash)
+					if token != nil {
+						current.SetOperator(token)
+					}
+				}
+			}
+			{
+				p.state.EnterRule(Multiplication__Basic_5)
+				result := p.ParseExponentiation()
+				p.state.ExitRule()
+				if result != nil {
+					current.SetRight(result)
+				}
+			}
+			p.state.Sync(Multiplication__LoopEntry)
+		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -309,38 +325,40 @@ func (p *Parser) ParseExponentiation() Expression {
 	current := NewExpression()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		p.state.EnterRule(Exponentiation__LoopEntry)
-		result := p.ParseModulo()
-		p.state.ExitRule()
-		core.MergeTokens(result, current.Tokens())
-		current = result
-	}
-	p.state.Sync(Exponentiation__LoopEntry)
-	for p.lookahead.ExponentiationLoop(p.state) {
 		{
-			result := NewBinaryExpression()
-			result.SetSegment(current.Segment())
-			result.SetLeft(current)
-			current.SetSegmentEndToken(p.state.LA(0))
-			current = result
-		}
-		current := current.(BinaryExpression)
-		{
-			token := p.state.Consume(Keyword_Caret)
-			core.AssignToken(current, token, Exponentiation_Operator_Caret)
-			if token != nil {
-				current.SetOperator(token)
-			}
-		}
-		{
-			p.state.EnterRule(Exponentiation__Basic_2)
+			p.state.EnterRule(Exponentiation__LoopEntry)
 			result := p.ParseModulo()
 			p.state.ExitRule()
-			if result != nil {
-				current.SetRight(result)
-			}
+			core.MergeTokens(result, current.Tokens())
+			current = result
 		}
 		p.state.Sync(Exponentiation__LoopEntry)
+		for p.lookahead.ExponentiationLoop(p.state) {
+			{
+				result := NewBinaryExpression()
+				result.SetSegment(current.Segment())
+				result.SetLeft(current)
+				current.SetSegmentEndToken(p.state.LA(0))
+				current = result
+			}
+			current := current.(BinaryExpression)
+			{
+				token := p.state.Consume(Keyword_Caret)
+				core.AssignToken(current, token, Exponentiation_Operator_Caret)
+				if token != nil {
+					current.SetOperator(token)
+				}
+			}
+			{
+				p.state.EnterRule(Exponentiation__Basic_2)
+				result := p.ParseModulo()
+				p.state.ExitRule()
+				if result != nil {
+					current.SetRight(result)
+				}
+			}
+			p.state.Sync(Exponentiation__LoopEntry)
+		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -350,38 +368,40 @@ func (p *Parser) ParseModulo() Expression {
 	current := NewExpression()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		p.state.EnterRule(Modulo__LoopEntry)
-		result := p.ParsePrimaryExpression()
-		p.state.ExitRule()
-		core.MergeTokens(result, current.Tokens())
-		current = result
-	}
-	p.state.Sync(Modulo__LoopEntry)
-	for p.lookahead.ModuloLoop(p.state) {
 		{
-			result := NewBinaryExpression()
-			result.SetSegment(current.Segment())
-			result.SetLeft(current)
-			current.SetSegmentEndToken(p.state.LA(0))
-			current = result
-		}
-		current := current.(BinaryExpression)
-		{
-			token := p.state.Consume(Keyword_Percent)
-			core.AssignToken(current, token, Modulo_Operator_Percent)
-			if token != nil {
-				current.SetOperator(token)
-			}
-		}
-		{
-			p.state.EnterRule(Modulo__Basic_2)
+			p.state.EnterRule(Modulo__LoopEntry)
 			result := p.ParsePrimaryExpression()
 			p.state.ExitRule()
-			if result != nil {
-				current.SetRight(result)
-			}
+			core.MergeTokens(result, current.Tokens())
+			current = result
 		}
 		p.state.Sync(Modulo__LoopEntry)
+		for p.lookahead.ModuloLoop(p.state) {
+			{
+				result := NewBinaryExpression()
+				result.SetSegment(current.Segment())
+				result.SetLeft(current)
+				current.SetSegmentEndToken(p.state.LA(0))
+				current = result
+			}
+			current := current.(BinaryExpression)
+			{
+				token := p.state.Consume(Keyword_Percent)
+				core.AssignToken(current, token, Modulo_Operator_Percent)
+				if token != nil {
+					current.SetOperator(token)
+				}
+			}
+			{
+				p.state.EnterRule(Modulo__Basic_2)
+				result := p.ParsePrimaryExpression()
+				p.state.ExitRule()
+				if result != nil {
+					current.SetRight(result)
+				}
+			}
+			p.state.Sync(Modulo__LoopEntry)
+		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -390,75 +410,62 @@ func (p *Parser) ParseModulo() Expression {
 func (p *Parser) ParsePrimaryExpression() Expression {
 	current := NewExpression()
 	current.SetSegmentStartToken(p.state.LA(1))
-	switch prediction, failure := p.lookahead.PrimaryExpressionAlternatives(p.state); prediction {
-	case 0:
-		{
-			token := p.state.Consume(Keyword_LeftParen)
-			core.AssignToken(current, token, PrimaryExpression_LeftParen_0)
-		}
-		{
-			p.state.EnterRule(PrimaryExpression_RightParen_0)
-			result := p.ParseExpression()
-			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
-			current = result
-		}
-		{
-			token := p.state.Consume(Keyword_RightParen)
-			core.AssignToken(current, token, PrimaryExpression_RightParen_0)
-		}
-	case 1:
-		{
-			result := NewNumberLiteral()
-			result.SetSegment(current.Segment())
-			core.AssignTokens(result, current.Tokens())
-			current = result
-		}
-		current := current.(NumberLiteral)
-		{
-			token := p.state.Consume(Token_NUMBER)
-			core.AssignToken(current, token, PrimaryExpression_Value_NUMBER)
-			if token != nil {
-				current.SetValue(token)
-			}
-		}
-	case 2:
-		{
-			result := NewFunctionCall()
-			result.SetSegment(current.Segment())
-			core.AssignTokens(result, current.Tokens())
-			current = result
-		}
-		current := current.(FunctionCall)
-		{
-			token := p.state.Consume(Token_ID)
-			core.AssignToken(current, token, PrimaryExpression_Callable_ID)
-			if token != nil {
-				current.SetCallable(p.referencesConstructor.FunctionCallCallable(current, token))
-			}
-		}
-		p.state.Sync(PrimaryExpression__Basic_7)
-		if p.lookahead.PrimaryExpressionOptional(p.state) {
+	{
+		switch prediction, failure := p.lookahead.PrimaryExpressionAlternatives(p.state); prediction {
+		case 0:
 			{
 				token := p.state.Consume(Keyword_LeftParen)
-				core.AssignToken(current, token, PrimaryExpression_LeftParen_1)
+				core.AssignToken(current, token, PrimaryExpression_LeftParen_0)
 			}
 			{
-				p.state.EnterRule(PrimaryExpression__LoopEntry)
+				p.state.EnterRule(PrimaryExpression_RightParen_0)
 				result := p.ParseExpression()
 				p.state.ExitRule()
-				if result != nil {
-					current.SetArgsItem(result)
+				core.MergeTokens(result, current.Tokens())
+				current = result
+			}
+			{
+				token := p.state.Consume(Keyword_RightParen)
+				core.AssignToken(current, token, PrimaryExpression_RightParen_0)
+			}
+		case 1:
+			{
+				result := NewNumberLiteral()
+				result.SetSegment(current.Segment())
+				core.AssignTokens(result, current.Tokens())
+				current = result
+			}
+			current := current.(NumberLiteral)
+			{
+				token := p.state.Consume(Token_NUMBER)
+				core.AssignToken(current, token, PrimaryExpression_Value_NUMBER)
+				if token != nil {
+					current.SetValue(token)
 				}
 			}
-			p.state.Sync(PrimaryExpression__LoopEntry)
-			for p.lookahead.PrimaryExpressionLoop(p.state) {
+		case 2:
+			{
+				result := NewFunctionCall()
+				result.SetSegment(current.Segment())
+				core.AssignTokens(result, current.Tokens())
+				current = result
+			}
+			current := current.(FunctionCall)
+			{
+				token := p.state.Consume(Token_ID)
+				core.AssignToken(current, token, PrimaryExpression_Callable_ID)
+				if token != nil {
+					current.SetCallable(p.referencesConstructor.FunctionCallCallable(current, token))
+				}
+			}
+			p.state.Sync(PrimaryExpression__Basic_7)
+			if p.lookahead.PrimaryExpressionOptional(p.state) {
 				{
-					token := p.state.Consume(Keyword_Comma)
-					core.AssignToken(current, token, PrimaryExpression_Comma)
+					token := p.state.Consume(Keyword_LeftParen)
+					core.AssignToken(current, token, PrimaryExpression_LeftParen_1)
 				}
 				{
-					p.state.EnterRule(PrimaryExpression__Basic_5)
+					p.state.EnterRule(PrimaryExpression__LoopEntry)
 					result := p.ParseExpression()
 					p.state.ExitRule()
 					if result != nil {
@@ -466,14 +473,29 @@ func (p *Parser) ParsePrimaryExpression() Expression {
 					}
 				}
 				p.state.Sync(PrimaryExpression__LoopEntry)
+				for p.lookahead.PrimaryExpressionLoop(p.state) {
+					{
+						token := p.state.Consume(Keyword_Comma)
+						core.AssignToken(current, token, PrimaryExpression_Comma)
+					}
+					{
+						p.state.EnterRule(PrimaryExpression__Basic_5)
+						result := p.ParseExpression()
+						p.state.ExitRule()
+						if result != nil {
+							current.SetArgsItem(result)
+						}
+					}
+					p.state.Sync(PrimaryExpression__LoopEntry)
+				}
+				{
+					token := p.state.Consume(Keyword_RightParen)
+					core.AssignToken(current, token, PrimaryExpression_RightParen_1)
+				}
 			}
-			{
-				token := p.state.Consume(Keyword_RightParen)
-				core.AssignToken(current, token, PrimaryExpression_RightParen_1)
-			}
+		default:
+			p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 		}
-	default:
-		p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current

--- a/examples/arithmetics/types_gen.go
+++ b/examples/arithmetics/types_gen.go
@@ -668,3 +668,16 @@ func (i *NumberLiteralImpl) ForEachReference(fn func(core.UntypedReference)) {
 	i.ExpressionData.ForEachReference(fn)
 	i.NumberLiteralData.ForEachReference(fn)
 }
+
+var ArithmeticsSyntheticFactories = map[string]func() core.AstNode{
+	"AbstractDefinition": func() core.AstNode { return NewAbstractDefinition() },
+	"BinaryExpression":   func() core.AstNode { return NewBinaryExpression() },
+	"DeclaredParameter":  func() core.AstNode { return NewDeclaredParameter() },
+	"Definition":         func() core.AstNode { return NewDefinition() },
+	"Evaluation":         func() core.AstNode { return NewEvaluation() },
+	"Expression":         func() core.AstNode { return NewExpression() },
+	"FunctionCall":       func() core.AstNode { return NewFunctionCall() },
+	"Module":             func() core.AstNode { return NewModule() },
+	"NumberLiteral":      func() core.AstNode { return NewNumberLiteral() },
+	"Statement":          func() core.AstNode { return NewStatement() },
+}

--- a/examples/statemachine/completion_gen.go
+++ b/examples/statemachine/completion_gen.go
@@ -42,14 +42,6 @@ func (*DefaultStatemachineModelCompletionFilter) FilterTransitionState(_ context
 	return in
 }
 
-var StatemachineModelSyntheticFactories = map[string]func() core.AstNode{
-	"Command":      func() core.AstNode { return NewCommand() },
-	"Event":        func() core.AstNode { return NewEvent() },
-	"State":        func() core.AstNode { return NewState() },
-	"Statemachine": func() core.AstNode { return NewStatemachine() },
-	"Transition":   func() core.AstNode { return NewTransition() },
-}
-
 type StatemachineModelCompletionDispatchFunc func(
 	ctx context.Context,
 	sc *service.Container,

--- a/examples/statemachine/parser_gen.go
+++ b/examples/statemachine/parser_gen.go
@@ -36,73 +36,75 @@ func (p *Parser) ParseStatemachine() Statemachine {
 	current := NewStatemachine()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_statemachine)
-		core.AssignToken(current, token, Statemachine_statemachine)
-	}
-	{
-		token := p.state.Consume(Token_ID)
-		core.AssignToken(current, token, Statemachine_Name_ID)
-		if token != nil {
-			current.SetName(token)
-		}
-	}
-	p.state.Sync(Statemachine__Basic_2)
-	if p.lookahead.StatemachineOptional_0(p.state) {
 		{
-			token := p.state.Consume(Keyword_events)
-			core.AssignToken(current, token, Statemachine_events)
+			token := p.state.Consume(Keyword_statemachine)
+			core.AssignToken(current, token, Statemachine_statemachine)
 		}
 		{
-			for ok := true; ok; ok = p.lookahead.StatemachineEventsLoop(p.state) {
-				p.state.EnterRule(Statemachine__Basic_1)
-				result := p.ParseEvent()
-				p.state.ExitRule()
-				if result != nil {
-					current.SetEventsItem(result)
+			token := p.state.Consume(Token_ID)
+			core.AssignToken(current, token, Statemachine_Name_ID)
+			if token != nil {
+				current.SetName(token)
+			}
+		}
+		p.state.Sync(Statemachine__Basic_2)
+		if p.lookahead.StatemachineOptional_0(p.state) {
+			{
+				token := p.state.Consume(Keyword_events)
+				core.AssignToken(current, token, Statemachine_events)
+			}
+			{
+				for ok := true; ok; ok = p.lookahead.StatemachineEventsLoop(p.state) {
+					p.state.EnterRule(Statemachine__Basic_1)
+					result := p.ParseEvent()
+					p.state.ExitRule()
+					if result != nil {
+						current.SetEventsItem(result)
+					}
+					p.state.Sync(Statemachine__LoopBack_0)
 				}
-				p.state.Sync(Statemachine__LoopBack_0)
 			}
 		}
-	}
-	p.state.Sync(Statemachine__Basic_5)
-	if p.lookahead.StatemachineOptional_1(p.state) {
-		{
-			token := p.state.Consume(Keyword_commands)
-			core.AssignToken(current, token, Statemachine_commands)
-		}
-		{
-			for ok := true; ok; ok = p.lookahead.StatemachineCommandsLoop(p.state) {
-				p.state.EnterRule(Statemachine__Basic_4)
-				result := p.ParseCommand()
-				p.state.ExitRule()
-				if result != nil {
-					current.SetCommandsItem(result)
+		p.state.Sync(Statemachine__Basic_5)
+		if p.lookahead.StatemachineOptional_1(p.state) {
+			{
+				token := p.state.Consume(Keyword_commands)
+				core.AssignToken(current, token, Statemachine_commands)
+			}
+			{
+				for ok := true; ok; ok = p.lookahead.StatemachineCommandsLoop(p.state) {
+					p.state.EnterRule(Statemachine__Basic_4)
+					result := p.ParseCommand()
+					p.state.ExitRule()
+					if result != nil {
+						current.SetCommandsItem(result)
+					}
+					p.state.Sync(Statemachine__LoopBack_1)
 				}
-				p.state.Sync(Statemachine__LoopBack_1)
 			}
 		}
-	}
-	{
-		token := p.state.Consume(Keyword_initialState)
-		core.AssignToken(current, token, Statemachine_initialState)
-	}
-	{
-		token := p.state.Consume(Token_ID)
-		core.AssignToken(current, token, Statemachine_Init_ID)
-		if token != nil {
-			current.SetInit(p.referencesConstructor.StatemachineInit(current, token))
+		{
+			token := p.state.Consume(Keyword_initialState)
+			core.AssignToken(current, token, Statemachine_initialState)
 		}
-	}
-	{
-		p.state.Sync(Statemachine__LoopEntry)
-		for p.lookahead.StatemachineStatesLoop(p.state) {
-			p.state.EnterRule(Statemachine__Basic_7)
-			result := p.ParseState()
-			p.state.ExitRule()
-			if result != nil {
-				current.SetStatesItem(result)
+		{
+			token := p.state.Consume(Token_ID)
+			core.AssignToken(current, token, Statemachine_Init_ID)
+			if token != nil {
+				current.SetInit(p.referencesConstructor.StatemachineInit(current, token))
 			}
+		}
+		{
 			p.state.Sync(Statemachine__LoopEntry)
+			for p.lookahead.StatemachineStatesLoop(p.state) {
+				p.state.EnterRule(Statemachine__Basic_7)
+				result := p.ParseState()
+				p.state.ExitRule()
+				if result != nil {
+					current.SetStatesItem(result)
+				}
+				p.state.Sync(Statemachine__LoopEntry)
+			}
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
@@ -113,10 +115,12 @@ func (p *Parser) ParseEvent() Event {
 	current := NewEvent()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Token_ID)
-		core.AssignToken(current, token, Event_Name_ID)
-		if token != nil {
-			current.SetName(token)
+		{
+			token := p.state.Consume(Token_ID)
+			core.AssignToken(current, token, Event_Name_ID)
+			if token != nil {
+				current.SetName(token)
+			}
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
@@ -127,10 +131,12 @@ func (p *Parser) ParseCommand() Command {
 	current := NewCommand()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Token_ID)
-		core.AssignToken(current, token, Command_Name_ID)
-		if token != nil {
-			current.SetName(token)
+		{
+			token := p.state.Consume(Token_ID)
+			core.AssignToken(current, token, Command_Name_ID)
+			if token != nil {
+				current.SetName(token)
+			}
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
@@ -141,56 +147,58 @@ func (p *Parser) ParseState() State {
 	current := NewState()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_state)
-		core.AssignToken(current, token, State_state)
-	}
-	{
-		token := p.state.Consume(Token_ID)
-		core.AssignToken(current, token, State_Name_ID)
-		if token != nil {
-			current.SetName(token)
-		}
-	}
-	p.state.Sync(State__Basic_2)
-	if p.lookahead.StateOptional(p.state) {
 		{
-			token := p.state.Consume(Keyword_actions)
-			core.AssignToken(current, token, State_actions)
+			token := p.state.Consume(Keyword_state)
+			core.AssignToken(current, token, State_state)
 		}
 		{
-			token := p.state.Consume(Keyword_LeftBrace)
-			core.AssignToken(current, token, State_LeftBrace)
+			token := p.state.Consume(Token_ID)
+			core.AssignToken(current, token, State_Name_ID)
+			if token != nil {
+				current.SetName(token)
+			}
 		}
-		{
-			for ok := true; ok; ok = p.lookahead.StateActionsLoop(p.state) {
-				token := p.state.Consume(Token_ID)
-				core.AssignToken(current, token, State_Actions_ID)
-				if token != nil {
-					current.SetActionsItem(p.referencesConstructor.StateActions(current, token))
+		p.state.Sync(State__Basic_2)
+		if p.lookahead.StateOptional(p.state) {
+			{
+				token := p.state.Consume(Keyword_actions)
+				core.AssignToken(current, token, State_actions)
+			}
+			{
+				token := p.state.Consume(Keyword_LeftBrace)
+				core.AssignToken(current, token, State_LeftBrace)
+			}
+			{
+				for ok := true; ok; ok = p.lookahead.StateActionsLoop(p.state) {
+					token := p.state.Consume(Token_ID)
+					core.AssignToken(current, token, State_Actions_ID)
+					if token != nil {
+						current.SetActionsItem(p.referencesConstructor.StateActions(current, token))
+					}
+					p.state.Sync(State__LoopBack_0)
 				}
-				p.state.Sync(State__LoopBack_0)
+			}
+			{
+				token := p.state.Consume(Keyword_RightBrace)
+				core.AssignToken(current, token, State_RightBrace)
 			}
 		}
 		{
-			token := p.state.Consume(Keyword_RightBrace)
-			core.AssignToken(current, token, State_RightBrace)
-		}
-	}
-	{
-		p.state.Sync(State__LoopEntry)
-		for p.lookahead.StateTransitionsLoop(p.state) {
-			p.state.EnterRule(State__Basic_4)
-			result := p.ParseTransition()
-			p.state.ExitRule()
-			if result != nil {
-				current.SetTransitionsItem(result)
-			}
 			p.state.Sync(State__LoopEntry)
+			for p.lookahead.StateTransitionsLoop(p.state) {
+				p.state.EnterRule(State__Basic_4)
+				result := p.ParseTransition()
+				p.state.ExitRule()
+				if result != nil {
+					current.SetTransitionsItem(result)
+				}
+				p.state.Sync(State__LoopEntry)
+			}
 		}
-	}
-	{
-		token := p.state.Consume(Keyword_end)
-		core.AssignToken(current, token, State_end)
+		{
+			token := p.state.Consume(Keyword_end)
+			core.AssignToken(current, token, State_end)
+		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -200,21 +208,23 @@ func (p *Parser) ParseTransition() Transition {
 	current := NewTransition()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Token_ID)
-		core.AssignToken(current, token, Transition_Event_ID)
-		if token != nil {
-			current.SetEvent(p.referencesConstructor.TransitionEvent(current, token))
+		{
+			token := p.state.Consume(Token_ID)
+			core.AssignToken(current, token, Transition_Event_ID)
+			if token != nil {
+				current.SetEvent(p.referencesConstructor.TransitionEvent(current, token))
+			}
 		}
-	}
-	{
-		token := p.state.Consume(Keyword_EqualsGreaterThan)
-		core.AssignToken(current, token, Transition_EqualsGreaterThan)
-	}
-	{
-		token := p.state.Consume(Token_ID)
-		core.AssignToken(current, token, Transition_State_ID)
-		if token != nil {
-			current.SetState(p.referencesConstructor.TransitionState(current, token))
+		{
+			token := p.state.Consume(Keyword_EqualsGreaterThan)
+			core.AssignToken(current, token, Transition_EqualsGreaterThan)
+		}
+		{
+			token := p.state.Consume(Token_ID)
+			core.AssignToken(current, token, Transition_State_ID)
+			if token != nil {
+				current.SetState(p.referencesConstructor.TransitionState(current, token))
+			}
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))

--- a/examples/statemachine/types_gen.go
+++ b/examples/statemachine/types_gen.go
@@ -421,3 +421,11 @@ func (i *TransitionImpl) ForEachNode(fn func(core.AstNode)) {
 func (i *TransitionImpl) ForEachReference(fn func(core.UntypedReference)) {
 	i.TransitionData.ForEachReference(fn)
 }
+
+var StatemachineModelSyntheticFactories = map[string]func() core.AstNode{
+	"Command":      func() core.AstNode { return NewCommand() },
+	"Event":        func() core.AstNode { return NewEvent() },
+	"State":        func() core.AstNode { return NewState() },
+	"Statemachine": func() core.AstNode { return NewStatemachine() },
+	"Transition":   func() core.AstNode { return NewTransition() },
+}

--- a/internal/atn/atn.go
+++ b/internal/atn/atn.go
@@ -17,6 +17,9 @@ import (
 // completionHintFor returns the per-field CompletionHint for a CrossRef whose
 // container is an Assignment in the given rule. Returns nil if the CrossRef is
 // not nested inside an Assignment (bare cross-references contribute no hint).
+// completionHintFor returns the per-field CompletionHint for a CrossRef whose
+// container is an Assignment in the given rule. Returns nil if the CrossRef is
+// not nested inside an Assignment (bare cross-references contribute no hint).
 func completionHintFor(rule grammar.AbstractRuleWithBody, cr grammar.CrossRef) *parser.CompletionHint {
 	if rule == nil {
 		return nil
@@ -29,11 +32,16 @@ func completionHintFor(rule grammar.AbstractRuleWithBody, cr grammar.CrossRef) *
 	if prop == nil {
 		return nil
 	}
-	propName := prop.Text()
-	if propName == "" {
+	field := prop.Ref(context.Background())
+	if field == nil {
 		return nil
 	}
-	hint := &parser.CompletionHint{Field: ruleTypeName(rule) + "." + propName}
+	fieldName := field.Name()
+	if fieldName == "" {
+		return nil
+	}
+	iface := field.Container().(grammar.Interface)
+	hint := &parser.CompletionHint{Field: iface.Name() + "." + fieldName}
 	if action := findPrecedingAction(assignment); action != nil {
 		typeName := ""
 		if t := action.Type(); t != nil {
@@ -49,22 +57,6 @@ func completionHintFor(rule grammar.AbstractRuleWithBody, cr grammar.CrossRef) *
 		}
 	}
 	return hint
-}
-
-// ruleTypeName returns the name of the interface a rule produces. For a rule
-// like `Foo returns Bar: ...` it returns "Bar"; for `Foo: ...` it returns
-// "Foo" (the rule name doubles as the produced interface). The completion
-// dispatch tables are keyed by interface name, so the hint must use this
-// name and not the rule name.
-func ruleTypeName(rule grammar.AbstractRuleWithBody) string {
-	if pr, ok := rule.(grammar.ParserRule); ok {
-		if rt := pr.ReturnType(); rt != nil {
-			if name := rt.Text(); name != "" {
-				return name
-			}
-		}
-	}
-	return rule.Name()
 }
 
 // findPrecedingAction returns the grammar.Action that fires immediately

--- a/internal/atn/atn.go
+++ b/internal/atn/atn.go
@@ -15,32 +15,29 @@ import (
 )
 
 // completionHintFor returns the per-field CompletionHint for a CrossRef whose
-// container is an Assignment in the given rule. Returns nil if the CrossRef is
-// not nested inside an Assignment (bare cross-references contribute no hint).
-// completionHintFor returns the per-field CompletionHint for a CrossRef whose
-// container is an Assignment in the given rule. Returns nil if the CrossRef is
-// not nested inside an Assignment (bare cross-references contribute no hint).
-func completionHintFor(rule grammar.AbstractRuleWithBody, cr grammar.CrossRef) *parser.CompletionHint {
-	if rule == nil {
-		return nil
-	}
+// container is an Assignment in the given rule.
+// The return value is never nil.
+func completionHintFor(cr grammar.CrossRef) *parser.CompletionHint {
 	assignment, ok := cr.Container().(grammar.Assignment)
 	if !ok {
-		return nil
+		panic(fmt.Sprintf("expected CrossRef's container to be an Assignment, got %T", cr.Container()))
 	}
 	prop := assignment.Property()
 	if prop == nil {
-		return nil
+		panic(fmt.Sprintf("expected Assignment to have a Property, got nil for %T", assignment))
 	}
 	field := prop.Ref(context.Background())
 	if field == nil {
-		return nil
+		panic(fmt.Sprintf("expected Property to resolve to a Field, got nil for %T", prop))
 	}
 	fieldName := field.Name()
 	if fieldName == "" {
-		return nil
+		panic(fmt.Sprintf("expected Field to have a name, got empty string for %T", field))
 	}
-	iface := field.Container().(grammar.Interface)
+	iface, ok := field.Container().(grammar.Interface)
+	if !ok {
+		panic(fmt.Sprintf("expected Field's container to be an Interface, got %T", field.Container()))
+	}
 	hint := &parser.CompletionHint{Field: iface.Name() + "." + fieldName}
 	if action := findPrecedingAction(assignment); action != nil {
 		typeName := ""
@@ -294,14 +291,12 @@ func convertCrossRef(
 		cardinality = cr.Cardinality()
 	}
 	rule := cr.Rule().Rule().Ref(context.Background())
-	hint := completionHintFor(rb.Rule(), cr)
+	hint := completionHintFor(cr)
 	if abstractRule, ok := rule.(grammar.AbstractRuleWithBody); ok {
 		handle := rb.RuleRef(abstractRule)
-		if hint != nil {
-			for _, t := range handle.Left.Transitions {
-				if rt, ok := t.(*RuleTransition); ok && rt.Rule == abstractRule {
-					rt.CompletionHint = hint
-				}
+		for _, t := range handle.Left.Transitions {
+			if rt, ok := t.(*RuleTransition); ok && rt.Rule == abstractRule {
+				rt.CompletionHint = hint
 			}
 		}
 		return handle, nil
@@ -309,11 +304,9 @@ func convertCrossRef(
 	id := rb.GetTokenTypeByName(rule.Name())
 	termHandle := rb.TokenRef(id)
 	termHandle.Left.ConsumedElement = cr.Rule() // tag with inner RuleCall to match generator naming
-	if hint != nil {
-		for _, t := range termHandle.Left.Transitions {
-			if at, ok := t.(*AtomTransition); ok && at.TokenTypeId == id {
-				at.CompletionHint = hint
-			}
+	for _, t := range termHandle.Left.Transitions {
+		if at, ok := t.(*AtomTransition); ok && at.TokenTypeId == id {
+			at.CompletionHint = hint
 		}
 	}
 	lookaheadName := rb.GetLookaheadNameByElement(cr)

--- a/internal/generator/completion_generator.go
+++ b/internal/generator/completion_generator.go
@@ -33,7 +33,6 @@ func GenerateCompletion(grammr grammar.Grammar, packageName string) string {
 	actions := collectActions(grammr)
 
 	node.AppendNode(generateCompletionProvider(ctx))
-	node.AppendNode(generateSyntheticFactories(ctx, grammr))
 	node.AppendNode(generateCompletionDispatch(ctx))
 	node.AppendNode(generateLspAdapter(ctx, actions))
 
@@ -135,37 +134,6 @@ func generateCompletionProvider(ctx *LinkerGeneratorContext) codegen.Node {
 	return node
 }
 
-// Synthetic factories are required to produce the expected AST shape for completion
-// when the user is completing an element which hasn't been produced by the parser yet.
-func generateSyntheticFactories(ctx *LinkerGeneratorContext, grammr grammar.Grammar) codegen.Node {
-	node := codegen.NewNode()
-	name := ctx.grammar.Name()
-
-	// One entry per parser rule (composite rules don't carry their own AST node).
-	type ruleEntry struct {
-		ruleName string
-		typeName string
-	}
-	entries := []ruleEntry{}
-	for _, rule := range grammr.Rules() {
-		if returnType, ok := ruleReturnTypeName(rule); ok {
-			entries = append(entries, ruleEntry{ruleName: rule.Name(), typeName: returnType})
-		}
-	}
-	// Sort for stable output.
-	sort.Slice(entries, func(i, j int) bool { return entries[i].ruleName < entries[j].ruleName })
-
-	node.AppendLine("var ", name, "SyntheticFactories = map[string]func() core.AstNode{")
-	node.Indent(func(n codegen.Node) {
-		for _, e := range entries {
-			n.AppendLine("\"", e.ruleName, "\": func() core.AstNode { return New", e.typeName, "() },")
-		}
-	})
-	node.AppendLine("}")
-	node.AppendLine()
-	return node
-}
-
 // generateCompletionDispatch emits the hint-field -> dispatcher map. Each
 // dispatcher resolves scope candidates for the in-progress reference and runs
 // them through the language's CompletionProvider filter for that field.
@@ -211,14 +179,6 @@ func generateCompletionDispatch(ctx *LinkerGeneratorContext) codegen.Node {
 	node.AppendLine("}")
 	node.AppendLine()
 	return node
-}
-
-func ruleReturnTypeName(rule grammar.ParserRule) (string, bool) {
-	rt := grammar.FindReturnType(rule, context.Background())
-	if rt == nil {
-		return "", false
-	}
-	return rt.Name(), true
 }
 
 func generateLspAdapter(ctx *LinkerGeneratorContext, actions []actionEntry) codegen.Node {

--- a/internal/generator/parser_generator.go
+++ b/internal/generator/parser_generator.go
@@ -879,7 +879,10 @@ func generateParseFunction(node codegen.Node, context *ParserGeneratorContext, r
 		node.Indent(func(n codegen.Node) {
 			n.AppendLine("current := New", returnType.Name(), "()")
 			n.AppendLine("current.SetSegmentStartToken(p.state.LA(1))")
+			// Generate new lexical scope for actions that immediately trigger on tule start
+			n.AppendLine("{")
 			generateAbstractElementParser(n, context, rule.Body())
+			n.AppendLine("}")
 			n.AppendLine("current.SetSegmentEndToken(p.state.LA(0))")
 			n.AppendLine("return current")
 		})
@@ -1051,9 +1054,11 @@ func generateAssignableAlternatives(node codegen.Node, context *ParserGeneratorC
 func generateGroupParser(node codegen.Node, context *ParserGeneratorContext, group grammar.Group) {
 	syncCall := buildSyncCall(context, group)
 	generateCardinality(node, func(n codegen.Node) {
-		for _, element := range group.Elements() {
-			generateAbstractElementParser(n, context, element)
-		}
+		n.Indent(func(in codegen.Node) {
+			for _, element := range group.Elements() {
+				generateAbstractElementParser(in, context, element)
+			}
+		})
 	}, func(n codegen.Node) {
 		n.Append(guardCall(context, group))
 	}, syncCall, group.Cardinality())

--- a/internal/generator/parser_generator.go
+++ b/internal/generator/parser_generator.go
@@ -879,7 +879,7 @@ func generateParseFunction(node codegen.Node, context *ParserGeneratorContext, r
 		node.Indent(func(n codegen.Node) {
 			n.AppendLine("current := New", returnType.Name(), "()")
 			n.AppendLine("current.SetSegmentStartToken(p.state.LA(1))")
-			// Generate new lexical scope for actions that immediately trigger on tule start
+			// Generate new lexical scope for actions that immediately trigger on rule start
 			n.AppendLine("{")
 			generateAbstractElementParser(n, context, rule.Body())
 			n.AppendLine("}")

--- a/internal/generator/type_generator.go
+++ b/internal/generator/type_generator.go
@@ -5,7 +5,6 @@
 package generator
 
 import (
-	"cmp"
 	"slices"
 	"sort"
 	"strings"
@@ -428,17 +427,13 @@ func generateSyntheticFactories(grammr grammar.Grammar) codegen.Node {
 	for _, iface := range grammr.Interfaces() {
 		entries = append(entries, factoryEntry{key: iface.Name(), typeName: iface.Name()})
 	}
-	slices.SortStableFunc(entries, func(a, b factoryEntry) int {
-		return cmp.Compare(a.key, b.key)
-	})
-
 	// Sort for stable output.
 	sort.Slice(entries, func(i, j int) bool { return entries[i].key < entries[j].key })
 
 	node.AppendLine("var ", name, "SyntheticFactories = map[string]func() core.AstNode{")
 	node.Indent(func(n codegen.Node) {
 		for _, e := range entries {
-			n.AppendLine("\"", e.key, "\": func() core.AstNode { return New", e.typeName, "() },")
+			n.AppendLine(`"`, e.key, `": func() core.AstNode { return New`, e.typeName, "() },")
 		}
 	})
 	node.AppendLine("}")

--- a/internal/generator/type_generator.go
+++ b/internal/generator/type_generator.go
@@ -5,7 +5,9 @@
 package generator
 
 import (
+	"cmp"
 	"slices"
+	"sort"
 	"strings"
 
 	"typefox.dev/fastbelt/internal/grammar"
@@ -28,6 +30,9 @@ func GenerateTypes(grammr grammar.Grammar, packageName string) string {
 	for _, iface := range grammr.Interfaces() {
 		generateInterface(node, grammr, iface)
 	}
+
+	node.AppendNode(generateSyntheticFactories(grammr))
+
 	return FormatIfPossible(node.String())
 }
 
@@ -406,4 +411,37 @@ func generateDataStruct(node codegen.Node, iface grammar.Interface, fields []Fie
 		node.AppendLine("}")
 		node.AppendLine()
 	}
+}
+
+// Synthetic factories are required to produce the expected AST shape for completion
+// when the user is completing an element which hasn't been produced by the parser yet.
+func generateSyntheticFactories(grammr grammar.Grammar) codegen.Node {
+	node := codegen.NewNode()
+	name := grammr.Name()
+
+	// One entry per parser rule (composite rules don't carry their own AST node).
+	type factoryEntry struct {
+		key      string
+		typeName string
+	}
+	entries := []factoryEntry{}
+	for _, iface := range grammr.Interfaces() {
+		entries = append(entries, factoryEntry{key: iface.Name(), typeName: iface.Name()})
+	}
+	slices.SortStableFunc(entries, func(a, b factoryEntry) int {
+		return cmp.Compare(a.key, b.key)
+	})
+
+	// Sort for stable output.
+	sort.Slice(entries, func(i, j int) bool { return entries[i].key < entries[j].key })
+
+	node.AppendLine("var ", name, "SyntheticFactories = map[string]func() core.AstNode{")
+	node.Indent(func(n codegen.Node) {
+		for _, e := range entries {
+			n.AppendLine("\"", e.key, "\": func() core.AstNode { return New", e.typeName, "() },")
+		}
+	})
+	node.AppendLine("}")
+	node.AppendLine()
+	return node
 }

--- a/internal/grammar/completion_gen.go
+++ b/internal/grammar/completion_gen.go
@@ -72,35 +72,6 @@ func (*DefaultFastbeltCompletionFilter) FilterActionProperty(_ context.Context, 
 	return in
 }
 
-var FastbeltSyntheticFactories = map[string]func() core.AstNode{
-	"Action":                 func() core.AstNode { return NewAction() },
-	"Alternatives":           func() core.AstNode { return NewElement() },
-	"ArrayType":              func() core.AstNode { return NewArrayType() },
-	"Assignable":             func() core.AstNode { return NewAssignable() },
-	"AssignableAlternatives": func() core.AstNode { return NewAssignable() },
-	"AssignableWithoutAlts":  func() core.AstNode { return NewAssignable() },
-	"Assignment":             func() core.AstNode { return NewAssignment() },
-	"CompositeAlternatives":  func() core.AstNode { return NewElement() },
-	"CompositeElement":       func() core.AstNode { return NewElement() },
-	"CompositeGroup":         func() core.AstNode { return NewElement() },
-	"CompositeRule":          func() core.AstNode { return NewCompositeRule() },
-	"CrossRef":               func() core.AstNode { return NewCrossRef() },
-	"Element":                func() core.AstNode { return NewElement() },
-	"Field":                  func() core.AstNode { return NewField() },
-	"FieldType":              func() core.AstNode { return NewFieldType() },
-	"Grammar":                func() core.AstNode { return NewGrammar() },
-	"Group":                  func() core.AstNode { return NewElement() },
-	"Interface":              func() core.AstNode { return NewInterface() },
-	"Keyword":                func() core.AstNode { return NewKeyword() },
-	"ParserRule":             func() core.AstNode { return NewParserRule() },
-	"PrimitiveType":          func() core.AstNode { return NewPrimitiveType() },
-	"ReferenceType":          func() core.AstNode { return NewReferenceType() },
-	"RuleCall":               func() core.AstNode { return NewRuleCall() },
-	"SimpleType":             func() core.AstNode { return NewSimpleType() },
-	"Token":                  func() core.AstNode { return NewToken() },
-	"TokenGroup":             func() core.AstNode { return NewTokenGroup() },
-}
-
 type FastbeltCompletionDispatchFunc func(
 	ctx context.Context,
 	sc *service.Container,

--- a/internal/grammar/parser_gen.go
+++ b/internal/grammar/parser_gen.go
@@ -36,72 +36,74 @@ func (p *Parser) ParseGrammar() Grammar {
 	current := NewGrammar()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_grammar)
-		core.AssignToken(current, token, Grammar_grammar)
-	}
-	{
-		token := p.state.Consume(Token_ID)
-		core.AssignToken(current, token, Grammar_Name_ID)
-		if token != nil {
-			current.SetName(token)
+		{
+			token := p.state.Consume(Keyword_grammar)
+			core.AssignToken(current, token, Grammar_grammar)
 		}
-	}
-	{
-		token := p.state.Consume(Keyword_Semicolon)
-		core.AssignToken(current, token, Grammar_Semicolon)
-	}
-	p.state.Sync(Grammar__LoopEntry)
-	for p.lookahead.GrammarLoop(p.state) {
-		switch prediction, failure := p.lookahead.GrammarAlternatives(p.state); prediction {
-		case 0:
-			{
-				p.state.EnterRule(Grammar__Basic_1)
-				result := p.ParseParserRule()
-				p.state.ExitRule()
-				if result != nil {
-					current.SetRulesItem(result)
-				}
+		{
+			token := p.state.Consume(Token_ID)
+			core.AssignToken(current, token, Grammar_Name_ID)
+			if token != nil {
+				current.SetName(token)
 			}
-		case 1:
-			{
-				p.state.EnterRule(Grammar__Basic_3)
-				result := p.ParseToken()
-				p.state.ExitRule()
-				if result != nil {
-					current.SetTerminalsItem(result)
-				}
-			}
-		case 2:
-			{
-				p.state.EnterRule(Grammar__Basic_5)
-				result := p.ParseTokenGroup()
-				p.state.ExitRule()
-				if result != nil {
-					current.SetTokenGroupsItem(result)
-				}
-			}
-		case 3:
-			{
-				p.state.EnterRule(Grammar__Basic_7)
-				result := p.ParseInterface()
-				p.state.ExitRule()
-				if result != nil {
-					current.SetInterfacesItem(result)
-				}
-			}
-		case 4:
-			{
-				p.state.EnterRule(Grammar__Basic_9)
-				result := p.ParseCompositeRule()
-				p.state.ExitRule()
-				if result != nil {
-					current.SetCompositesItem(result)
-				}
-			}
-		default:
-			p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
+		}
+		{
+			token := p.state.Consume(Keyword_Semicolon)
+			core.AssignToken(current, token, Grammar_Semicolon)
 		}
 		p.state.Sync(Grammar__LoopEntry)
+		for p.lookahead.GrammarLoop(p.state) {
+			switch prediction, failure := p.lookahead.GrammarAlternatives(p.state); prediction {
+			case 0:
+				{
+					p.state.EnterRule(Grammar__Basic_1)
+					result := p.ParseParserRule()
+					p.state.ExitRule()
+					if result != nil {
+						current.SetRulesItem(result)
+					}
+				}
+			case 1:
+				{
+					p.state.EnterRule(Grammar__Basic_3)
+					result := p.ParseToken()
+					p.state.ExitRule()
+					if result != nil {
+						current.SetTerminalsItem(result)
+					}
+				}
+			case 2:
+				{
+					p.state.EnterRule(Grammar__Basic_5)
+					result := p.ParseTokenGroup()
+					p.state.ExitRule()
+					if result != nil {
+						current.SetTokenGroupsItem(result)
+					}
+				}
+			case 3:
+				{
+					p.state.EnterRule(Grammar__Basic_7)
+					result := p.ParseInterface()
+					p.state.ExitRule()
+					if result != nil {
+						current.SetInterfacesItem(result)
+					}
+				}
+			case 4:
+				{
+					p.state.EnterRule(Grammar__Basic_9)
+					result := p.ParseCompositeRule()
+					p.state.ExitRule()
+					if result != nil {
+						current.SetCompositesItem(result)
+					}
+				}
+			default:
+				p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
+			}
+			p.state.Sync(Grammar__LoopEntry)
+		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -111,64 +113,66 @@ func (p *Parser) ParseInterface() Interface {
 	current := NewInterface()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_interface)
-		core.AssignToken(current, token, Interface_interface)
-	}
-	{
-		token := p.state.Consume(Token_ID)
-		core.AssignToken(current, token, Interface_Name_ID)
-		if token != nil {
-			current.SetName(token)
-		}
-	}
-	p.state.Sync(Interface__Basic_1)
-	if p.lookahead.InterfaceOptional(p.state) {
 		{
-			token := p.state.Consume(Keyword_extends)
-			core.AssignToken(current, token, Interface_extends)
+			token := p.state.Consume(Keyword_interface)
+			core.AssignToken(current, token, Interface_interface)
 		}
 		{
 			token := p.state.Consume(Token_ID)
-			core.AssignToken(current, token, Interface_Extends_ID_0)
+			core.AssignToken(current, token, Interface_Name_ID)
 			if token != nil {
-				current.SetExtendsItem(p.referencesConstructor.InterfaceExtends(current, token))
+				current.SetName(token)
 			}
 		}
-		p.state.Sync(Interface__LoopEntry_0)
-		for p.lookahead.InterfaceLoop(p.state) {
+		p.state.Sync(Interface__Basic_1)
+		if p.lookahead.InterfaceOptional(p.state) {
 			{
-				token := p.state.Consume(Keyword_Comma)
-				core.AssignToken(current, token, Interface_Comma)
+				token := p.state.Consume(Keyword_extends)
+				core.AssignToken(current, token, Interface_extends)
 			}
 			{
 				token := p.state.Consume(Token_ID)
-				core.AssignToken(current, token, Interface_Extends_ID_1)
+				core.AssignToken(current, token, Interface_Extends_ID_0)
 				if token != nil {
 					current.SetExtendsItem(p.referencesConstructor.InterfaceExtends(current, token))
 				}
 			}
 			p.state.Sync(Interface__LoopEntry_0)
-		}
-	}
-	{
-		token := p.state.Consume(Keyword_LeftBrace)
-		core.AssignToken(current, token, Interface_LeftBrace)
-	}
-	{
-		p.state.Sync(Interface__LoopEntry_1)
-		for p.lookahead.InterfaceFieldsLoop(p.state) {
-			p.state.EnterRule(Interface__Basic_3)
-			result := p.ParseField()
-			p.state.ExitRule()
-			if result != nil {
-				current.SetFieldsItem(result)
+			for p.lookahead.InterfaceLoop(p.state) {
+				{
+					token := p.state.Consume(Keyword_Comma)
+					core.AssignToken(current, token, Interface_Comma)
+				}
+				{
+					token := p.state.Consume(Token_ID)
+					core.AssignToken(current, token, Interface_Extends_ID_1)
+					if token != nil {
+						current.SetExtendsItem(p.referencesConstructor.InterfaceExtends(current, token))
+					}
+				}
+				p.state.Sync(Interface__LoopEntry_0)
 			}
-			p.state.Sync(Interface__LoopEntry_1)
 		}
-	}
-	{
-		token := p.state.Consume(Keyword_RightBrace)
-		core.AssignToken(current, token, Interface_RightBrace)
+		{
+			token := p.state.Consume(Keyword_LeftBrace)
+			core.AssignToken(current, token, Interface_LeftBrace)
+		}
+		{
+			p.state.Sync(Interface__LoopEntry_1)
+			for p.lookahead.InterfaceFieldsLoop(p.state) {
+				p.state.EnterRule(Interface__Basic_3)
+				result := p.ParseField()
+				p.state.ExitRule()
+				if result != nil {
+					current.SetFieldsItem(result)
+				}
+				p.state.Sync(Interface__LoopEntry_1)
+			}
+		}
+		{
+			token := p.state.Consume(Keyword_RightBrace)
+			core.AssignToken(current, token, Interface_RightBrace)
+		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -178,18 +182,20 @@ func (p *Parser) ParseField() Field {
 	current := NewField()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Token_ID)
-		core.AssignToken(current, token, Field_Name_ID)
-		if token != nil {
-			current.SetName(token)
+		{
+			token := p.state.Consume(Token_ID)
+			core.AssignToken(current, token, Field_Name_ID)
+			if token != nil {
+				current.SetName(token)
+			}
 		}
-	}
-	{
-		p.state.EnterRule(Field__Basic_1)
-		result := p.ParseFieldType()
-		p.state.ExitRule()
-		if result != nil {
-			current.SetType(result)
+		{
+			p.state.EnterRule(Field__Basic_1)
+			result := p.ParseFieldType()
+			p.state.ExitRule()
+			if result != nil {
+				current.SetType(result)
+			}
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
@@ -199,41 +205,43 @@ func (p *Parser) ParseField() Field {
 func (p *Parser) ParseFieldType() FieldType {
 	current := NewFieldType()
 	current.SetSegmentStartToken(p.state.LA(1))
-	switch prediction, failure := p.lookahead.FieldTypeAlternatives(p.state); prediction {
-	case 0:
-		{
-			p.state.EnterRule(FieldType__Basic_1)
-			result := p.ParseSimpleType()
-			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
-			current = result
+	{
+		switch prediction, failure := p.lookahead.FieldTypeAlternatives(p.state); prediction {
+		case 0:
+			{
+				p.state.EnterRule(FieldType__Basic_1)
+				result := p.ParseSimpleType()
+				p.state.ExitRule()
+				core.MergeTokens(result, current.Tokens())
+				current = result
+			}
+		case 1:
+			{
+				p.state.EnterRule(FieldType__Basic_3)
+				result := p.ParseReferenceType()
+				p.state.ExitRule()
+				core.MergeTokens(result, current.Tokens())
+				current = result
+			}
+		case 2:
+			{
+				p.state.EnterRule(FieldType__Basic_5)
+				result := p.ParseArrayType()
+				p.state.ExitRule()
+				core.MergeTokens(result, current.Tokens())
+				current = result
+			}
+		case 3:
+			{
+				p.state.EnterRule(FieldType__Basic_7)
+				result := p.ParsePrimitiveType()
+				p.state.ExitRule()
+				core.MergeTokens(result, current.Tokens())
+				current = result
+			}
+		default:
+			p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 		}
-	case 1:
-		{
-			p.state.EnterRule(FieldType__Basic_3)
-			result := p.ParseReferenceType()
-			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
-			current = result
-		}
-	case 2:
-		{
-			p.state.EnterRule(FieldType__Basic_5)
-			result := p.ParseArrayType()
-			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
-			current = result
-		}
-	case 3:
-		{
-			p.state.EnterRule(FieldType__Basic_7)
-			result := p.ParsePrimitiveType()
-			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
-			current = result
-		}
-	default:
-		p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -243,19 +251,21 @@ func (p *Parser) ParseArrayType() ArrayType {
 	current := NewArrayType()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_LeftBracket)
-		core.AssignToken(current, token, ArrayType_LeftBracket)
-	}
-	{
-		token := p.state.Consume(Keyword_RightBracket)
-		core.AssignToken(current, token, ArrayType_RightBracket)
-	}
-	{
-		p.state.EnterRule(ArrayType__Basic_1)
-		result := p.ParseFieldType()
-		p.state.ExitRule()
-		if result != nil {
-			current.SetInternalType(result)
+		{
+			token := p.state.Consume(Keyword_LeftBracket)
+			core.AssignToken(current, token, ArrayType_LeftBracket)
+		}
+		{
+			token := p.state.Consume(Keyword_RightBracket)
+			core.AssignToken(current, token, ArrayType_RightBracket)
+		}
+		{
+			p.state.EnterRule(ArrayType__Basic_1)
+			result := p.ParseFieldType()
+			p.state.ExitRule()
+			if result != nil {
+				current.SetInternalType(result)
+			}
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
@@ -266,14 +276,16 @@ func (p *Parser) ParseReferenceType() ReferenceType {
 	current := NewReferenceType()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_Asterisk)
-		core.AssignToken(current, token, ReferenceType_Asterisk)
-	}
-	{
-		token := p.state.Consume(Token_ID)
-		core.AssignToken(current, token, ReferenceType_Type_ID)
-		if token != nil {
-			current.SetType(p.referencesConstructor.ReferenceTypeType(current, token))
+		{
+			token := p.state.Consume(Keyword_Asterisk)
+			core.AssignToken(current, token, ReferenceType_Asterisk)
+		}
+		{
+			token := p.state.Consume(Token_ID)
+			core.AssignToken(current, token, ReferenceType_Type_ID)
+			if token != nil {
+				current.SetType(p.referencesConstructor.ReferenceTypeType(current, token))
+			}
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
@@ -284,10 +296,12 @@ func (p *Parser) ParseSimpleType() SimpleType {
 	current := NewSimpleType()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Token_ID)
-		core.AssignToken(current, token, SimpleType_Type_ID)
-		if token != nil {
-			current.SetType(p.referencesConstructor.SimpleTypeType(current, token))
+		{
+			token := p.state.Consume(Token_ID)
+			core.AssignToken(current, token, SimpleType_Type_ID)
+			if token != nil {
+				current.SetType(p.referencesConstructor.SimpleTypeType(current, token))
+			}
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
@@ -298,24 +312,26 @@ func (p *Parser) ParsePrimitiveType() PrimitiveType {
 	current := NewPrimitiveType()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		switch prediction, _ := p.lookahead.PrimitiveTypeTypeAlternatives(p.state); prediction {
-		case 0:
-			token := p.state.Consume(Keyword_string)
-			core.AssignToken(current, token, PrimitiveType_Type_string)
-			if token != nil {
-				current.SetType(token)
-			}
-		case 1:
-			token := p.state.Consume(Keyword_bool)
-			core.AssignToken(current, token, PrimitiveType_Type_bool)
-			if token != nil {
-				current.SetType(token)
-			}
-		case 2:
-			token := p.state.Consume(Keyword_composite)
-			core.AssignToken(current, token, PrimitiveType_Type_composite)
-			if token != nil {
-				current.SetType(token)
+		{
+			switch prediction, _ := p.lookahead.PrimitiveTypeTypeAlternatives(p.state); prediction {
+			case 0:
+				token := p.state.Consume(Keyword_string)
+				core.AssignToken(current, token, PrimitiveType_Type_string)
+				if token != nil {
+					current.SetType(token)
+				}
+			case 1:
+				token := p.state.Consume(Keyword_bool)
+				core.AssignToken(current, token, PrimitiveType_Type_bool)
+				if token != nil {
+					current.SetType(token)
+				}
+			case 2:
+				token := p.state.Consume(Keyword_composite)
+				core.AssignToken(current, token, PrimitiveType_Type_composite)
+				if token != nil {
+					current.SetType(token)
+				}
 			}
 		}
 	}
@@ -327,41 +343,43 @@ func (p *Parser) ParseParserRule() ParserRule {
 	current := NewParserRule()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Token_ID)
-		core.AssignToken(current, token, ParserRule_Name_ID)
-		if token != nil {
-			current.SetName(token)
-		}
-	}
-	p.state.Sync(ParserRule__Basic_1)
-	if p.lookahead.ParserRuleOptional(p.state) {
-		{
-			token := p.state.Consume(Keyword_returns)
-			core.AssignToken(current, token, ParserRule_returns)
-		}
 		{
 			token := p.state.Consume(Token_ID)
-			core.AssignToken(current, token, ParserRule_ReturnType_ID)
+			core.AssignToken(current, token, ParserRule_Name_ID)
 			if token != nil {
-				current.SetReturnType(p.referencesConstructor.ParserRuleReturnType(current, token))
+				current.SetName(token)
 			}
 		}
-	}
-	{
-		token := p.state.Consume(Keyword_Colon)
-		core.AssignToken(current, token, ParserRule_Colon)
-	}
-	{
-		p.state.EnterRule(ParserRule_Semicolon)
-		result := p.ParseAlternatives()
-		p.state.ExitRule()
-		if result != nil {
-			current.SetBody(result)
+		p.state.Sync(ParserRule__Basic_1)
+		if p.lookahead.ParserRuleOptional(p.state) {
+			{
+				token := p.state.Consume(Keyword_returns)
+				core.AssignToken(current, token, ParserRule_returns)
+			}
+			{
+				token := p.state.Consume(Token_ID)
+				core.AssignToken(current, token, ParserRule_ReturnType_ID)
+				if token != nil {
+					current.SetReturnType(p.referencesConstructor.ParserRuleReturnType(current, token))
+				}
+			}
 		}
-	}
-	{
-		token := p.state.Consume(Keyword_Semicolon)
-		core.AssignToken(current, token, ParserRule_Semicolon)
+		{
+			token := p.state.Consume(Keyword_Colon)
+			core.AssignToken(current, token, ParserRule_Colon)
+		}
+		{
+			p.state.EnterRule(ParserRule_Semicolon)
+			result := p.ParseAlternatives()
+			p.state.ExitRule()
+			if result != nil {
+				current.SetBody(result)
+			}
+		}
+		{
+			token := p.state.Consume(Keyword_Semicolon)
+			core.AssignToken(current, token, ParserRule_Semicolon)
+		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -370,50 +388,52 @@ func (p *Parser) ParseParserRule() ParserRule {
 func (p *Parser) ParseToken() Token {
 	current := NewToken()
 	current.SetSegmentStartToken(p.state.LA(1))
-	p.state.Sync(Token__Basic_3)
-	switch prediction, _ := p.lookahead.TokenAlternatives(p.state); prediction {
-	case 0:
-		{
-			token := p.state.Consume(Keyword_hidden)
-			core.AssignToken(current, token, Token_Type_hidden)
-			if token != nil {
-				current.SetType(token)
+	{
+		p.state.Sync(Token__Basic_3)
+		switch prediction, _ := p.lookahead.TokenAlternatives(p.state); prediction {
+		case 0:
+			{
+				token := p.state.Consume(Keyword_hidden)
+				core.AssignToken(current, token, Token_Type_hidden)
+				if token != nil {
+					current.SetType(token)
+				}
+			}
+		case 1:
+			{
+				token := p.state.Consume(Keyword_comment)
+				core.AssignToken(current, token, Token_Type_comment)
+				if token != nil {
+					current.SetType(token)
+				}
 			}
 		}
-	case 1:
 		{
-			token := p.state.Consume(Keyword_comment)
-			core.AssignToken(current, token, Token_Type_comment)
+			token := p.state.Consume(Keyword_token)
+			core.AssignToken(current, token, Token_token)
+		}
+		{
+			token := p.state.Consume(Token_ID)
+			core.AssignToken(current, token, Token_Name_ID)
 			if token != nil {
-				current.SetType(token)
+				current.SetName(token)
 			}
 		}
-	}
-	{
-		token := p.state.Consume(Keyword_token)
-		core.AssignToken(current, token, Token_token)
-	}
-	{
-		token := p.state.Consume(Token_ID)
-		core.AssignToken(current, token, Token_Name_ID)
-		if token != nil {
-			current.SetName(token)
+		{
+			token := p.state.Consume(Keyword_Colon)
+			core.AssignToken(current, token, Token_Colon)
 		}
-	}
-	{
-		token := p.state.Consume(Keyword_Colon)
-		core.AssignToken(current, token, Token_Colon)
-	}
-	{
-		token := p.state.Consume(Token_RegexLiteral)
-		core.AssignToken(current, token, Token_Regexp_RegexLiteral)
-		if token != nil {
-			current.SetRegexp(token)
+		{
+			token := p.state.Consume(Token_RegexLiteral)
+			core.AssignToken(current, token, Token_Regexp_RegexLiteral)
+			if token != nil {
+				current.SetRegexp(token)
+			}
 		}
-	}
-	{
-		token := p.state.Consume(Keyword_Semicolon)
-		core.AssignToken(current, token, Token_Semicolon)
+		{
+			token := p.state.Consume(Keyword_Semicolon)
+			core.AssignToken(current, token, Token_Semicolon)
+		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -423,65 +443,67 @@ func (p *Parser) ParseTokenGroup() TokenGroup {
 	current := NewTokenGroup()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_token)
-		core.AssignToken(current, token, TokenGroup_token)
-	}
-	{
-		token := p.state.Consume(Keyword_group)
-		core.AssignToken(current, token, TokenGroup_group)
-	}
-	{
-		token := p.state.Consume(Token_ID)
-		core.AssignToken(current, token, TokenGroup_Name_ID)
-		if token != nil {
-			current.SetName(token)
+		{
+			token := p.state.Consume(Keyword_token)
+			core.AssignToken(current, token, TokenGroup_token)
 		}
-	}
-	{
-		token := p.state.Consume(Keyword_LeftBrace)
-		core.AssignToken(current, token, TokenGroup_LeftBrace)
-	}
-	p.state.Sync(TokenGroup__LoopEntry)
-loop0:
-	for {
-		switch prediction, _ := p.lookahead.TokenGroupAlternatives(p.state); prediction {
-		case 0:
-			{
-				token := p.state.Consume(Token_ID)
-				core.AssignToken(current, token, TokenGroup_TokenRefs_ID)
-				if token != nil {
-					current.SetTokenRefsItem(p.referencesConstructor.TokenGroupTokenRefs(current, token))
-				}
+		{
+			token := p.state.Consume(Keyword_group)
+			core.AssignToken(current, token, TokenGroup_group)
+		}
+		{
+			token := p.state.Consume(Token_ID)
+			core.AssignToken(current, token, TokenGroup_Name_ID)
+			if token != nil {
+				current.SetName(token)
 			}
-		case 1:
-			{
-				token := p.state.Consume(Keyword_keywords)
-				core.AssignToken(current, token, TokenGroup_keywords)
-			}
-			{
-				token := p.state.Consume(Token_RegexLiteral)
-				core.AssignToken(current, token, TokenGroup_Regexps_RegexLiteral)
-				if token != nil {
-					current.SetRegexpsItem(token)
-				}
-			}
-		case 2:
-			{
-				p.state.EnterRule(TokenGroup__Basic_3)
-				result := p.ParseKeyword()
-				p.state.ExitRule()
-				if result != nil {
-					current.SetKeywordsItem(result)
-				}
-			}
-		default:
-			break loop0
+		}
+		{
+			token := p.state.Consume(Keyword_LeftBrace)
+			core.AssignToken(current, token, TokenGroup_LeftBrace)
 		}
 		p.state.Sync(TokenGroup__LoopEntry)
-	}
-	{
-		token := p.state.Consume(Keyword_RightBrace)
-		core.AssignToken(current, token, TokenGroup_RightBrace)
+	loop0:
+		for {
+			switch prediction, _ := p.lookahead.TokenGroupAlternatives(p.state); prediction {
+			case 0:
+				{
+					token := p.state.Consume(Token_ID)
+					core.AssignToken(current, token, TokenGroup_TokenRefs_ID)
+					if token != nil {
+						current.SetTokenRefsItem(p.referencesConstructor.TokenGroupTokenRefs(current, token))
+					}
+				}
+			case 1:
+				{
+					token := p.state.Consume(Keyword_keywords)
+					core.AssignToken(current, token, TokenGroup_keywords)
+				}
+				{
+					token := p.state.Consume(Token_RegexLiteral)
+					core.AssignToken(current, token, TokenGroup_Regexps_RegexLiteral)
+					if token != nil {
+						current.SetRegexpsItem(token)
+					}
+				}
+			case 2:
+				{
+					p.state.EnterRule(TokenGroup__Basic_3)
+					result := p.ParseKeyword()
+					p.state.ExitRule()
+					if result != nil {
+						current.SetKeywordsItem(result)
+					}
+				}
+			default:
+				break loop0
+			}
+			p.state.Sync(TokenGroup__LoopEntry)
+		}
+		{
+			token := p.state.Consume(Keyword_RightBrace)
+			core.AssignToken(current, token, TokenGroup_RightBrace)
+		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -491,36 +513,38 @@ func (p *Parser) ParseAlternatives() Element {
 	current := NewElement()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		p.state.EnterRule(Alternatives__Basic_3)
-		result := p.ParseGroup()
-		p.state.ExitRule()
-		core.MergeTokens(result, current.Tokens())
-		current = result
-	}
-	p.state.Sync(Alternatives__Basic_3)
-	if p.lookahead.AlternativesOptional(p.state) {
 		{
-			result := NewAlternatives()
-			result.SetSegment(current.Segment())
-			result.SetAltsItem(current)
-			current.SetSegmentEndToken(p.state.LA(0))
+			p.state.EnterRule(Alternatives__Basic_3)
+			result := p.ParseGroup()
+			p.state.ExitRule()
+			core.MergeTokens(result, current.Tokens())
 			current = result
 		}
-		current := current.(Alternatives)
-		for ok := true; ok; ok = p.lookahead.AlternativesLoop(p.state) {
+		p.state.Sync(Alternatives__Basic_3)
+		if p.lookahead.AlternativesOptional(p.state) {
 			{
-				token := p.state.Consume(Keyword_Pipe)
-				core.AssignToken(current, token, Alternatives_Pipe)
+				result := NewAlternatives()
+				result.SetSegment(current.Segment())
+				result.SetAltsItem(current)
+				current.SetSegmentEndToken(p.state.LA(0))
+				current = result
 			}
-			{
-				p.state.EnterRule(Alternatives__Basic_2)
-				result := p.ParseGroup()
-				p.state.ExitRule()
-				if result != nil {
-					current.SetAltsItem(result)
+			current := current.(Alternatives)
+			for ok := true; ok; ok = p.lookahead.AlternativesLoop(p.state) {
+				{
+					token := p.state.Consume(Keyword_Pipe)
+					core.AssignToken(current, token, Alternatives_Pipe)
 				}
+				{
+					p.state.EnterRule(Alternatives__Basic_2)
+					result := p.ParseGroup()
+					p.state.ExitRule()
+					if result != nil {
+						current.SetAltsItem(result)
+					}
+				}
+				p.state.Sync(Alternatives__LoopBack)
 			}
-			p.state.Sync(Alternatives__LoopBack)
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
@@ -531,31 +555,33 @@ func (p *Parser) ParseGroup() Element {
 	current := NewElement()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		p.state.EnterRule(Group__Basic_3)
-		result := p.ParseElement()
-		p.state.ExitRule()
-		core.MergeTokens(result, current.Tokens())
-		current = result
-	}
-	p.state.Sync(Group__Basic_3)
-	if p.lookahead.GroupOptional(p.state) {
 		{
-			result := NewGroup()
-			result.SetSegment(current.Segment())
-			result.SetElementsItem(current)
-			current.SetSegmentEndToken(p.state.LA(0))
+			p.state.EnterRule(Group__Basic_3)
+			result := p.ParseElement()
+			p.state.ExitRule()
+			core.MergeTokens(result, current.Tokens())
 			current = result
 		}
-		current := current.(Group)
-		{
-			for ok := true; ok; ok = p.lookahead.GroupElementsLoop(p.state) {
-				p.state.EnterRule(Group__Basic_2)
-				result := p.ParseElement()
-				p.state.ExitRule()
-				if result != nil {
-					current.SetElementsItem(result)
+		p.state.Sync(Group__Basic_3)
+		if p.lookahead.GroupOptional(p.state) {
+			{
+				result := NewGroup()
+				result.SetSegment(current.Segment())
+				result.SetElementsItem(current)
+				current.SetSegmentEndToken(p.state.LA(0))
+				current = result
+			}
+			current := current.(Group)
+			{
+				for ok := true; ok; ok = p.lookahead.GroupElementsLoop(p.state) {
+					p.state.EnterRule(Group__Basic_2)
+					result := p.ParseElement()
+					p.state.ExitRule()
+					if result != nil {
+						current.SetElementsItem(result)
+					}
+					p.state.Sync(Group__LoopBack)
 				}
-				p.state.Sync(Group__LoopBack)
 			}
 		}
 	}
@@ -566,78 +592,80 @@ func (p *Parser) ParseGroup() Element {
 func (p *Parser) ParseElement() Element {
 	current := NewElement()
 	current.SetSegmentStartToken(p.state.LA(1))
-	switch prediction, failure := p.lookahead.ElementAlternatives(p.state); prediction {
-	case 0:
-		{
-			p.state.EnterRule(Element__Basic_1)
-			result := p.ParseKeyword()
-			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
-			current = result
-		}
-	case 1:
-		{
-			p.state.EnterRule(Element__Basic_3)
-			result := p.ParseAssignment()
-			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
-			current = result
-		}
-	case 2:
-		{
-			p.state.EnterRule(Element__Basic_5)
-			result := p.ParseRuleCall()
-			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
-			current = result
-		}
-	case 3:
-		{
-			p.state.EnterRule(Element__Basic_7)
-			result := p.ParseAction()
-			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
-			current = result
-		}
-	case 4:
-		{
-			token := p.state.Consume(Keyword_LeftParen)
-			core.AssignToken(current, token, Element_LeftParen)
-		}
-		{
-			p.state.EnterRule(Element_RightParen)
-			result := p.ParseAlternatives()
-			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
-			current = result
-		}
-		{
-			token := p.state.Consume(Keyword_RightParen)
-			core.AssignToken(current, token, Element_RightParen)
-		}
-	default:
-		p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
-	}
 	{
-		p.state.Sync(Element__Basic_15)
-		switch prediction, _ := p.lookahead.ElementCardinalityAlternatives(p.state); prediction {
+		switch prediction, failure := p.lookahead.ElementAlternatives(p.state); prediction {
 		case 0:
-			token := p.state.Consume(Keyword_Asterisk)
-			core.AssignToken(current, token, Element_Cardinality_Asterisk)
-			if token != nil {
-				current.SetCardinality(token)
+			{
+				p.state.EnterRule(Element__Basic_1)
+				result := p.ParseKeyword()
+				p.state.ExitRule()
+				core.MergeTokens(result, current.Tokens())
+				current = result
 			}
 		case 1:
-			token := p.state.Consume(Keyword_Plus)
-			core.AssignToken(current, token, Element_Cardinality_Plus)
-			if token != nil {
-				current.SetCardinality(token)
+			{
+				p.state.EnterRule(Element__Basic_3)
+				result := p.ParseAssignment()
+				p.state.ExitRule()
+				core.MergeTokens(result, current.Tokens())
+				current = result
 			}
 		case 2:
-			token := p.state.Consume(Keyword_Question)
-			core.AssignToken(current, token, Element_Cardinality_Question)
-			if token != nil {
-				current.SetCardinality(token)
+			{
+				p.state.EnterRule(Element__Basic_5)
+				result := p.ParseRuleCall()
+				p.state.ExitRule()
+				core.MergeTokens(result, current.Tokens())
+				current = result
+			}
+		case 3:
+			{
+				p.state.EnterRule(Element__Basic_7)
+				result := p.ParseAction()
+				p.state.ExitRule()
+				core.MergeTokens(result, current.Tokens())
+				current = result
+			}
+		case 4:
+			{
+				token := p.state.Consume(Keyword_LeftParen)
+				core.AssignToken(current, token, Element_LeftParen)
+			}
+			{
+				p.state.EnterRule(Element_RightParen)
+				result := p.ParseAlternatives()
+				p.state.ExitRule()
+				core.MergeTokens(result, current.Tokens())
+				current = result
+			}
+			{
+				token := p.state.Consume(Keyword_RightParen)
+				core.AssignToken(current, token, Element_RightParen)
+			}
+		default:
+			p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
+		}
+		{
+			p.state.Sync(Element__Basic_15)
+			switch prediction, _ := p.lookahead.ElementCardinalityAlternatives(p.state); prediction {
+			case 0:
+				token := p.state.Consume(Keyword_Asterisk)
+				core.AssignToken(current, token, Element_Cardinality_Asterisk)
+				if token != nil {
+					current.SetCardinality(token)
+				}
+			case 1:
+				token := p.state.Consume(Keyword_Plus)
+				core.AssignToken(current, token, Element_Cardinality_Plus)
+				if token != nil {
+					current.SetCardinality(token)
+				}
+			case 2:
+				token := p.state.Consume(Keyword_Question)
+				core.AssignToken(current, token, Element_Cardinality_Question)
+				if token != nil {
+					current.SetCardinality(token)
+				}
 			}
 		}
 	}
@@ -649,10 +677,12 @@ func (p *Parser) ParseKeyword() Keyword {
 	current := NewKeyword()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Token_StringLiteral)
-		core.AssignToken(current, token, Keyword_Value_StringLiteral)
-		if token != nil {
-			current.SetValue(token)
+		{
+			token := p.state.Consume(Token_StringLiteral)
+			core.AssignToken(current, token, Keyword_Value_StringLiteral)
+			if token != nil {
+				current.SetValue(token)
+			}
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
@@ -663,40 +693,42 @@ func (p *Parser) ParseAssignment() Assignment {
 	current := NewAssignment()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Token_ID)
-		core.AssignToken(current, token, Assignment_Property_ID)
-		if token != nil {
-			current.SetProperty(p.referencesConstructor.AssignmentProperty(current, token))
-		}
-	}
-	{
-		switch prediction, _ := p.lookahead.AssignmentOperatorAlternatives(p.state); prediction {
-		case 0:
-			token := p.state.Consume(Keyword_PlusEquals)
-			core.AssignToken(current, token, Assignment_Operator_PlusEquals)
+		{
+			token := p.state.Consume(Token_ID)
+			core.AssignToken(current, token, Assignment_Property_ID)
 			if token != nil {
-				current.SetOperator(token)
-			}
-		case 1:
-			token := p.state.Consume(Keyword_Equals)
-			core.AssignToken(current, token, Assignment_Operator_Equals)
-			if token != nil {
-				current.SetOperator(token)
-			}
-		case 2:
-			token := p.state.Consume(Keyword_QuestionEquals)
-			core.AssignToken(current, token, Assignment_Operator_QuestionEquals)
-			if token != nil {
-				current.SetOperator(token)
+				current.SetProperty(p.referencesConstructor.AssignmentProperty(current, token))
 			}
 		}
-	}
-	{
-		p.state.EnterRule(Assignment__Basic_5)
-		result := p.ParseAssignable()
-		p.state.ExitRule()
-		if result != nil {
-			current.SetValue(result)
+		{
+			switch prediction, _ := p.lookahead.AssignmentOperatorAlternatives(p.state); prediction {
+			case 0:
+				token := p.state.Consume(Keyword_PlusEquals)
+				core.AssignToken(current, token, Assignment_Operator_PlusEquals)
+				if token != nil {
+					current.SetOperator(token)
+				}
+			case 1:
+				token := p.state.Consume(Keyword_Equals)
+				core.AssignToken(current, token, Assignment_Operator_Equals)
+				if token != nil {
+					current.SetOperator(token)
+				}
+			case 2:
+				token := p.state.Consume(Keyword_QuestionEquals)
+				core.AssignToken(current, token, Assignment_Operator_QuestionEquals)
+				if token != nil {
+					current.SetOperator(token)
+				}
+			}
+		}
+		{
+			p.state.EnterRule(Assignment__Basic_5)
+			result := p.ParseAssignable()
+			p.state.ExitRule()
+			if result != nil {
+				current.SetValue(result)
+			}
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
@@ -706,49 +738,51 @@ func (p *Parser) ParseAssignment() Assignment {
 func (p *Parser) ParseAssignable() Assignable {
 	current := NewAssignable()
 	current.SetSegmentStartToken(p.state.LA(1))
-	switch prediction, failure := p.lookahead.AssignableAlternatives(p.state); prediction {
-	case 0:
-		{
-			p.state.EnterRule(Assignable__Basic_1)
-			result := p.ParseKeyword()
-			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
-			current = result
+	{
+		switch prediction, failure := p.lookahead.AssignableAlternatives(p.state); prediction {
+		case 0:
+			{
+				p.state.EnterRule(Assignable__Basic_1)
+				result := p.ParseKeyword()
+				p.state.ExitRule()
+				core.MergeTokens(result, current.Tokens())
+				current = result
+			}
+		case 1:
+			{
+				p.state.EnterRule(Assignable__Basic_3)
+				result := p.ParseRuleCall()
+				p.state.ExitRule()
+				core.MergeTokens(result, current.Tokens())
+				current = result
+			}
+		case 2:
+			{
+				p.state.EnterRule(Assignable__Basic_5)
+				result := p.ParseCrossRef()
+				p.state.ExitRule()
+				core.MergeTokens(result, current.Tokens())
+				current = result
+			}
+		case 3:
+			{
+				token := p.state.Consume(Keyword_LeftParen)
+				core.AssignToken(current, token, Assignable_LeftParen)
+			}
+			{
+				p.state.EnterRule(Assignable_RightParen)
+				result := p.ParseAssignableAlternatives()
+				p.state.ExitRule()
+				core.MergeTokens(result, current.Tokens())
+				current = result
+			}
+			{
+				token := p.state.Consume(Keyword_RightParen)
+				core.AssignToken(current, token, Assignable_RightParen)
+			}
+		default:
+			p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 		}
-	case 1:
-		{
-			p.state.EnterRule(Assignable__Basic_3)
-			result := p.ParseRuleCall()
-			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
-			current = result
-		}
-	case 2:
-		{
-			p.state.EnterRule(Assignable__Basic_5)
-			result := p.ParseCrossRef()
-			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
-			current = result
-		}
-	case 3:
-		{
-			token := p.state.Consume(Keyword_LeftParen)
-			core.AssignToken(current, token, Assignable_LeftParen)
-		}
-		{
-			p.state.EnterRule(Assignable_RightParen)
-			result := p.ParseAssignableAlternatives()
-			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
-			current = result
-		}
-		{
-			token := p.state.Consume(Keyword_RightParen)
-			core.AssignToken(current, token, Assignable_RightParen)
-		}
-	default:
-		p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -757,33 +791,35 @@ func (p *Parser) ParseAssignable() Assignable {
 func (p *Parser) ParseAssignableWithoutAlts() Assignable {
 	current := NewAssignable()
 	current.SetSegmentStartToken(p.state.LA(1))
-	switch prediction, failure := p.lookahead.AssignableWithoutAltsAlternatives(p.state); prediction {
-	case 0:
-		{
-			p.state.EnterRule(AssignableWithoutAlts__Basic_1)
-			result := p.ParseKeyword()
-			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
-			current = result
+	{
+		switch prediction, failure := p.lookahead.AssignableWithoutAltsAlternatives(p.state); prediction {
+		case 0:
+			{
+				p.state.EnterRule(AssignableWithoutAlts__Basic_1)
+				result := p.ParseKeyword()
+				p.state.ExitRule()
+				core.MergeTokens(result, current.Tokens())
+				current = result
+			}
+		case 1:
+			{
+				p.state.EnterRule(AssignableWithoutAlts__Basic_3)
+				result := p.ParseRuleCall()
+				p.state.ExitRule()
+				core.MergeTokens(result, current.Tokens())
+				current = result
+			}
+		case 2:
+			{
+				p.state.EnterRule(AssignableWithoutAlts__Basic_5)
+				result := p.ParseCrossRef()
+				p.state.ExitRule()
+				core.MergeTokens(result, current.Tokens())
+				current = result
+			}
+		default:
+			p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 		}
-	case 1:
-		{
-			p.state.EnterRule(AssignableWithoutAlts__Basic_3)
-			result := p.ParseRuleCall()
-			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
-			current = result
-		}
-	case 2:
-		{
-			p.state.EnterRule(AssignableWithoutAlts__Basic_5)
-			result := p.ParseCrossRef()
-			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
-			current = result
-		}
-	default:
-		p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -793,36 +829,38 @@ func (p *Parser) ParseAssignableAlternatives() Assignable {
 	current := NewAssignable()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		p.state.EnterRule(AssignableAlternatives__Basic_3)
-		result := p.ParseAssignableWithoutAlts()
-		p.state.ExitRule()
-		core.MergeTokens(result, current.Tokens())
-		current = result
-	}
-	p.state.Sync(AssignableAlternatives__Basic_3)
-	if p.lookahead.AssignableAlternativesOptional(p.state) {
 		{
-			result := NewAlternatives()
-			result.SetSegment(current.Segment())
-			result.SetAltsItem(current)
-			current.SetSegmentEndToken(p.state.LA(0))
+			p.state.EnterRule(AssignableAlternatives__Basic_3)
+			result := p.ParseAssignableWithoutAlts()
+			p.state.ExitRule()
+			core.MergeTokens(result, current.Tokens())
 			current = result
 		}
-		current := current.(Alternatives)
-		for ok := true; ok; ok = p.lookahead.AssignableAlternativesLoop(p.state) {
+		p.state.Sync(AssignableAlternatives__Basic_3)
+		if p.lookahead.AssignableAlternativesOptional(p.state) {
 			{
-				token := p.state.Consume(Keyword_Pipe)
-				core.AssignToken(current, token, AssignableAlternatives_Pipe)
+				result := NewAlternatives()
+				result.SetSegment(current.Segment())
+				result.SetAltsItem(current)
+				current.SetSegmentEndToken(p.state.LA(0))
+				current = result
 			}
-			{
-				p.state.EnterRule(AssignableAlternatives__Basic_2)
-				result := p.ParseAssignableWithoutAlts()
-				p.state.ExitRule()
-				if result != nil {
-					current.SetAltsItem(result)
+			current := current.(Alternatives)
+			for ok := true; ok; ok = p.lookahead.AssignableAlternativesLoop(p.state) {
+				{
+					token := p.state.Consume(Keyword_Pipe)
+					core.AssignToken(current, token, AssignableAlternatives_Pipe)
 				}
+				{
+					p.state.EnterRule(AssignableAlternatives__Basic_2)
+					result := p.ParseAssignableWithoutAlts()
+					p.state.ExitRule()
+					if result != nil {
+						current.SetAltsItem(result)
+					}
+				}
+				p.state.Sync(AssignableAlternatives__LoopBack)
 			}
-			p.state.Sync(AssignableAlternatives__LoopBack)
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
@@ -833,34 +871,36 @@ func (p *Parser) ParseCrossRef() CrossRef {
 	current := NewCrossRef()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_LeftBracket)
-		core.AssignToken(current, token, CrossRef_LeftBracket)
-	}
-	{
-		token := p.state.Consume(Token_ID)
-		core.AssignToken(current, token, CrossRef_Type_ID)
-		if token != nil {
-			current.SetType(p.referencesConstructor.CrossRefType(current, token))
-		}
-	}
-	p.state.Sync(CrossRef__Basic_2)
-	if p.lookahead.CrossRefOptional(p.state) {
 		{
-			token := p.state.Consume(Keyword_Colon)
-			core.AssignToken(current, token, CrossRef_Colon)
+			token := p.state.Consume(Keyword_LeftBracket)
+			core.AssignToken(current, token, CrossRef_LeftBracket)
 		}
 		{
-			p.state.EnterRule(CrossRef__Basic_1)
-			result := p.ParseRuleCall()
-			p.state.ExitRule()
-			if result != nil {
-				current.SetRule(result)
+			token := p.state.Consume(Token_ID)
+			core.AssignToken(current, token, CrossRef_Type_ID)
+			if token != nil {
+				current.SetType(p.referencesConstructor.CrossRefType(current, token))
 			}
 		}
-	}
-	{
-		token := p.state.Consume(Keyword_RightBracket)
-		core.AssignToken(current, token, CrossRef_RightBracket)
+		p.state.Sync(CrossRef__Basic_2)
+		if p.lookahead.CrossRefOptional(p.state) {
+			{
+				token := p.state.Consume(Keyword_Colon)
+				core.AssignToken(current, token, CrossRef_Colon)
+			}
+			{
+				p.state.EnterRule(CrossRef__Basic_1)
+				result := p.ParseRuleCall()
+				p.state.ExitRule()
+				if result != nil {
+					current.SetRule(result)
+				}
+			}
+		}
+		{
+			token := p.state.Consume(Keyword_RightBracket)
+			core.AssignToken(current, token, CrossRef_RightBracket)
+		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -870,10 +910,12 @@ func (p *Parser) ParseRuleCall() RuleCall {
 	current := NewRuleCall()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Token_ID)
-		core.AssignToken(current, token, RuleCall_Rule_ID)
-		if token != nil {
-			current.SetRule(p.referencesConstructor.RuleCallRule(current, token))
+		{
+			token := p.state.Consume(Token_ID)
+			core.AssignToken(current, token, RuleCall_Rule_ID)
+			if token != nil {
+				current.SetRule(p.referencesConstructor.RuleCallRule(current, token))
+			}
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
@@ -884,53 +926,55 @@ func (p *Parser) ParseAction() Action {
 	current := NewAction()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_LeftBrace)
-		core.AssignToken(current, token, Action_LeftBrace)
-	}
-	{
-		token := p.state.Consume(Token_ID)
-		core.AssignToken(current, token, Action_Type_ID)
-		if token != nil {
-			current.SetType(p.referencesConstructor.ActionType(current, token))
-		}
-	}
-	p.state.Sync(Action__Basic_4)
-	if p.lookahead.ActionOptional(p.state) {
 		{
-			token := p.state.Consume(Keyword_Dot)
-			core.AssignToken(current, token, Action_Dot)
+			token := p.state.Consume(Keyword_LeftBrace)
+			core.AssignToken(current, token, Action_LeftBrace)
 		}
 		{
 			token := p.state.Consume(Token_ID)
-			core.AssignToken(current, token, Action_Property_ID)
+			core.AssignToken(current, token, Action_Type_ID)
 			if token != nil {
-				current.SetProperty(p.referencesConstructor.ActionProperty(current, token))
+				current.SetType(p.referencesConstructor.ActionType(current, token))
+			}
+		}
+		p.state.Sync(Action__Basic_4)
+		if p.lookahead.ActionOptional(p.state) {
+			{
+				token := p.state.Consume(Keyword_Dot)
+				core.AssignToken(current, token, Action_Dot)
+			}
+			{
+				token := p.state.Consume(Token_ID)
+				core.AssignToken(current, token, Action_Property_ID)
+				if token != nil {
+					current.SetProperty(p.referencesConstructor.ActionProperty(current, token))
+				}
+			}
+			{
+				switch prediction, _ := p.lookahead.ActionOperatorAlternatives(p.state); prediction {
+				case 0:
+					token := p.state.Consume(Keyword_PlusEquals)
+					core.AssignToken(current, token, Action_Operator_PlusEquals)
+					if token != nil {
+						current.SetOperator(token)
+					}
+				case 1:
+					token := p.state.Consume(Keyword_Equals)
+					core.AssignToken(current, token, Action_Operator_Equals)
+					if token != nil {
+						current.SetOperator(token)
+					}
+				}
+			}
+			{
+				token := p.state.Consume(Keyword_current)
+				core.AssignToken(current, token, Action_current)
 			}
 		}
 		{
-			switch prediction, _ := p.lookahead.ActionOperatorAlternatives(p.state); prediction {
-			case 0:
-				token := p.state.Consume(Keyword_PlusEquals)
-				core.AssignToken(current, token, Action_Operator_PlusEquals)
-				if token != nil {
-					current.SetOperator(token)
-				}
-			case 1:
-				token := p.state.Consume(Keyword_Equals)
-				core.AssignToken(current, token, Action_Operator_Equals)
-				if token != nil {
-					current.SetOperator(token)
-				}
-			}
+			token := p.state.Consume(Keyword_RightBrace)
+			core.AssignToken(current, token, Action_RightBrace)
 		}
-		{
-			token := p.state.Consume(Keyword_current)
-			core.AssignToken(current, token, Action_current)
-		}
-	}
-	{
-		token := p.state.Consume(Keyword_RightBrace)
-		core.AssignToken(current, token, Action_RightBrace)
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -940,31 +984,33 @@ func (p *Parser) ParseCompositeRule() CompositeRule {
 	current := NewCompositeRule()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_composite)
-		core.AssignToken(current, token, CompositeRule_composite)
-	}
-	{
-		token := p.state.Consume(Token_ID)
-		core.AssignToken(current, token, CompositeRule_Name_ID)
-		if token != nil {
-			current.SetName(token)
+		{
+			token := p.state.Consume(Keyword_composite)
+			core.AssignToken(current, token, CompositeRule_composite)
 		}
-	}
-	{
-		token := p.state.Consume(Keyword_Colon)
-		core.AssignToken(current, token, CompositeRule_Colon)
-	}
-	{
-		p.state.EnterRule(CompositeRule_Semicolon)
-		result := p.ParseCompositeAlternatives()
-		p.state.ExitRule()
-		if result != nil {
-			current.SetBody(result)
+		{
+			token := p.state.Consume(Token_ID)
+			core.AssignToken(current, token, CompositeRule_Name_ID)
+			if token != nil {
+				current.SetName(token)
+			}
 		}
-	}
-	{
-		token := p.state.Consume(Keyword_Semicolon)
-		core.AssignToken(current, token, CompositeRule_Semicolon)
+		{
+			token := p.state.Consume(Keyword_Colon)
+			core.AssignToken(current, token, CompositeRule_Colon)
+		}
+		{
+			p.state.EnterRule(CompositeRule_Semicolon)
+			result := p.ParseCompositeAlternatives()
+			p.state.ExitRule()
+			if result != nil {
+				current.SetBody(result)
+			}
+		}
+		{
+			token := p.state.Consume(Keyword_Semicolon)
+			core.AssignToken(current, token, CompositeRule_Semicolon)
+		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -974,36 +1020,38 @@ func (p *Parser) ParseCompositeAlternatives() Element {
 	current := NewElement()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		p.state.EnterRule(CompositeAlternatives__Basic_3)
-		result := p.ParseCompositeGroup()
-		p.state.ExitRule()
-		core.MergeTokens(result, current.Tokens())
-		current = result
-	}
-	p.state.Sync(CompositeAlternatives__Basic_3)
-	if p.lookahead.CompositeAlternativesOptional(p.state) {
 		{
-			result := NewAlternatives()
-			result.SetSegment(current.Segment())
-			result.SetAltsItem(current)
-			current.SetSegmentEndToken(p.state.LA(0))
+			p.state.EnterRule(CompositeAlternatives__Basic_3)
+			result := p.ParseCompositeGroup()
+			p.state.ExitRule()
+			core.MergeTokens(result, current.Tokens())
 			current = result
 		}
-		current := current.(Alternatives)
-		for ok := true; ok; ok = p.lookahead.CompositeAlternativesLoop(p.state) {
+		p.state.Sync(CompositeAlternatives__Basic_3)
+		if p.lookahead.CompositeAlternativesOptional(p.state) {
 			{
-				token := p.state.Consume(Keyword_Pipe)
-				core.AssignToken(current, token, CompositeAlternatives_Pipe)
+				result := NewAlternatives()
+				result.SetSegment(current.Segment())
+				result.SetAltsItem(current)
+				current.SetSegmentEndToken(p.state.LA(0))
+				current = result
 			}
-			{
-				p.state.EnterRule(CompositeAlternatives__Basic_2)
-				result := p.ParseCompositeGroup()
-				p.state.ExitRule()
-				if result != nil {
-					current.SetAltsItem(result)
+			current := current.(Alternatives)
+			for ok := true; ok; ok = p.lookahead.CompositeAlternativesLoop(p.state) {
+				{
+					token := p.state.Consume(Keyword_Pipe)
+					core.AssignToken(current, token, CompositeAlternatives_Pipe)
 				}
+				{
+					p.state.EnterRule(CompositeAlternatives__Basic_2)
+					result := p.ParseCompositeGroup()
+					p.state.ExitRule()
+					if result != nil {
+						current.SetAltsItem(result)
+					}
+				}
+				p.state.Sync(CompositeAlternatives__LoopBack)
 			}
-			p.state.Sync(CompositeAlternatives__LoopBack)
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
@@ -1014,31 +1062,33 @@ func (p *Parser) ParseCompositeGroup() Element {
 	current := NewElement()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		p.state.EnterRule(CompositeGroup__Basic_3)
-		result := p.ParseCompositeElement()
-		p.state.ExitRule()
-		core.MergeTokens(result, current.Tokens())
-		current = result
-	}
-	p.state.Sync(CompositeGroup__Basic_3)
-	if p.lookahead.CompositeGroupOptional(p.state) {
 		{
-			result := NewGroup()
-			result.SetSegment(current.Segment())
-			result.SetElementsItem(current)
-			current.SetSegmentEndToken(p.state.LA(0))
+			p.state.EnterRule(CompositeGroup__Basic_3)
+			result := p.ParseCompositeElement()
+			p.state.ExitRule()
+			core.MergeTokens(result, current.Tokens())
 			current = result
 		}
-		current := current.(Group)
-		{
-			for ok := true; ok; ok = p.lookahead.CompositeGroupElementsLoop(p.state) {
-				p.state.EnterRule(CompositeGroup__Basic_2)
-				result := p.ParseCompositeElement()
-				p.state.ExitRule()
-				if result != nil {
-					current.SetElementsItem(result)
+		p.state.Sync(CompositeGroup__Basic_3)
+		if p.lookahead.CompositeGroupOptional(p.state) {
+			{
+				result := NewGroup()
+				result.SetSegment(current.Segment())
+				result.SetElementsItem(current)
+				current.SetSegmentEndToken(p.state.LA(0))
+				current = result
+			}
+			current := current.(Group)
+			{
+				for ok := true; ok; ok = p.lookahead.CompositeGroupElementsLoop(p.state) {
+					p.state.EnterRule(CompositeGroup__Basic_2)
+					result := p.ParseCompositeElement()
+					p.state.ExitRule()
+					if result != nil {
+						current.SetElementsItem(result)
+					}
+					p.state.Sync(CompositeGroup__LoopBack)
 				}
-				p.state.Sync(CompositeGroup__LoopBack)
 			}
 		}
 	}
@@ -1049,62 +1099,64 @@ func (p *Parser) ParseCompositeGroup() Element {
 func (p *Parser) ParseCompositeElement() Element {
 	current := NewElement()
 	current.SetSegmentStartToken(p.state.LA(1))
-	switch prediction, failure := p.lookahead.CompositeElementAlternatives(p.state); prediction {
-	case 0:
-		{
-			p.state.EnterRule(CompositeElement__Basic_1)
-			result := p.ParseKeyword()
-			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
-			current = result
-		}
-	case 1:
-		{
-			p.state.EnterRule(CompositeElement__Basic_3)
-			result := p.ParseRuleCall()
-			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
-			current = result
-		}
-	case 2:
-		{
-			token := p.state.Consume(Keyword_LeftParen)
-			core.AssignToken(current, token, CompositeElement_LeftParen)
-		}
-		{
-			p.state.EnterRule(CompositeElement_RightParen)
-			result := p.ParseCompositeAlternatives()
-			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
-			current = result
-		}
-		{
-			token := p.state.Consume(Keyword_RightParen)
-			core.AssignToken(current, token, CompositeElement_RightParen)
-		}
-	default:
-		p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
-	}
 	{
-		p.state.Sync(CompositeElement__Basic_11)
-		switch prediction, _ := p.lookahead.CompositeElementCardinalityAlternatives(p.state); prediction {
+		switch prediction, failure := p.lookahead.CompositeElementAlternatives(p.state); prediction {
 		case 0:
-			token := p.state.Consume(Keyword_Asterisk)
-			core.AssignToken(current, token, CompositeElement_Cardinality_Asterisk)
-			if token != nil {
-				current.SetCardinality(token)
+			{
+				p.state.EnterRule(CompositeElement__Basic_1)
+				result := p.ParseKeyword()
+				p.state.ExitRule()
+				core.MergeTokens(result, current.Tokens())
+				current = result
 			}
 		case 1:
-			token := p.state.Consume(Keyword_Plus)
-			core.AssignToken(current, token, CompositeElement_Cardinality_Plus)
-			if token != nil {
-				current.SetCardinality(token)
+			{
+				p.state.EnterRule(CompositeElement__Basic_3)
+				result := p.ParseRuleCall()
+				p.state.ExitRule()
+				core.MergeTokens(result, current.Tokens())
+				current = result
 			}
 		case 2:
-			token := p.state.Consume(Keyword_Question)
-			core.AssignToken(current, token, CompositeElement_Cardinality_Question)
-			if token != nil {
-				current.SetCardinality(token)
+			{
+				token := p.state.Consume(Keyword_LeftParen)
+				core.AssignToken(current, token, CompositeElement_LeftParen)
+			}
+			{
+				p.state.EnterRule(CompositeElement_RightParen)
+				result := p.ParseCompositeAlternatives()
+				p.state.ExitRule()
+				core.MergeTokens(result, current.Tokens())
+				current = result
+			}
+			{
+				token := p.state.Consume(Keyword_RightParen)
+				core.AssignToken(current, token, CompositeElement_RightParen)
+			}
+		default:
+			p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
+		}
+		{
+			p.state.Sync(CompositeElement__Basic_11)
+			switch prediction, _ := p.lookahead.CompositeElementCardinalityAlternatives(p.state); prediction {
+			case 0:
+				token := p.state.Consume(Keyword_Asterisk)
+				core.AssignToken(current, token, CompositeElement_Cardinality_Asterisk)
+				if token != nil {
+					current.SetCardinality(token)
+				}
+			case 1:
+				token := p.state.Consume(Keyword_Plus)
+				core.AssignToken(current, token, CompositeElement_Cardinality_Plus)
+				if token != nil {
+					current.SetCardinality(token)
+				}
+			case 2:
+				token := p.state.Consume(Keyword_Question)
+				core.AssignToken(current, token, CompositeElement_Cardinality_Question)
+				if token != nil {
+					current.SetCardinality(token)
+				}
 			}
 		}
 	}

--- a/internal/grammar/types_gen.go
+++ b/internal/grammar/types_gen.go
@@ -1747,3 +1747,30 @@ func (i *CompositeRuleImpl) ForEachReference(fn func(core.UntypedReference)) {
 	i.AbstractRuleData.ForEachReference(fn)
 	i.CompositeRuleData.ForEachReference(fn)
 }
+
+var FastbeltSyntheticFactories = map[string]func() core.AstNode{
+	"AbstractRule":         func() core.AstNode { return NewAbstractRule() },
+	"AbstractRuleWithBody": func() core.AstNode { return NewAbstractRuleWithBody() },
+	"AbstractTokenRule":    func() core.AstNode { return NewAbstractTokenRule() },
+	"Action":               func() core.AstNode { return NewAction() },
+	"Alternatives":         func() core.AstNode { return NewAlternatives() },
+	"ArrayType":            func() core.AstNode { return NewArrayType() },
+	"Assignable":           func() core.AstNode { return NewAssignable() },
+	"Assignment":           func() core.AstNode { return NewAssignment() },
+	"CompositeRule":        func() core.AstNode { return NewCompositeRule() },
+	"CrossRef":             func() core.AstNode { return NewCrossRef() },
+	"Element":              func() core.AstNode { return NewElement() },
+	"Field":                func() core.AstNode { return NewField() },
+	"FieldType":            func() core.AstNode { return NewFieldType() },
+	"Grammar":              func() core.AstNode { return NewGrammar() },
+	"Group":                func() core.AstNode { return NewGroup() },
+	"Interface":            func() core.AstNode { return NewInterface() },
+	"Keyword":              func() core.AstNode { return NewKeyword() },
+	"ParserRule":           func() core.AstNode { return NewParserRule() },
+	"PrimitiveType":        func() core.AstNode { return NewPrimitiveType() },
+	"ReferenceType":        func() core.AstNode { return NewReferenceType() },
+	"RuleCall":             func() core.AstNode { return NewRuleCall() },
+	"SimpleType":           func() core.AstNode { return NewSimpleType() },
+	"Token":                func() core.AstNode { return NewToken() },
+	"TokenGroup":           func() core.AstNode { return NewTokenGroup() },
+}

--- a/internal/languages/completion/atn_gen.go
+++ b/internal/languages/completion/atn_gen.go
@@ -50,6 +50,8 @@ const (
 	M__Stop
 	N__Start
 	N__Stop
+	O__Start
+	O__Stop
 	FQN__Start
 	FQN__Stop
 	Root__Basic_0
@@ -83,6 +85,8 @@ const (
 	Root__Basic_28
 	Root__Basic_29
 	Root__Basic_30
+	Root__Basic_31
+	Root__Basic_32
 	Root__BlockEnd
 	Root__LoopEntry
 	Root__LoopEnd
@@ -192,6 +196,9 @@ const (
 	N_n
 	N__Basic_0
 	N__Basic_1
+	O_o
+	O_Ref_ID
+	O__Basic
 	FQN_ID_0
 	FQN_Dot
 	FQN_ID_1
@@ -211,7 +218,7 @@ func ATN() *parser.RuntimeATN {
 	return atn
 }
 func BuildATN() *parser.RuntimeATN {
-	states := make([]*parser.RuntimeATNState, 191)
+	states := make([]*parser.RuntimeATNState, 198)
 	states[Root__Start] = parser.NewATNState(Root__Start, parser.ATNRuleStart, true)
 	states[Root__Stop] = parser.NewATNState(Root__Stop, parser.ATNRuleStop, false)
 	states[Declare__Start] = parser.NewATNState(Declare__Start, parser.ATNRuleStart, true)
@@ -254,6 +261,8 @@ func BuildATN() *parser.RuntimeATN {
 	states[M__Stop] = parser.NewATNState(M__Stop, parser.ATNRuleStop, false)
 	states[N__Start] = parser.NewATNState(N__Start, parser.ATNRuleStart, true)
 	states[N__Stop] = parser.NewATNState(N__Stop, parser.ATNRuleStop, false)
+	states[O__Start] = parser.NewATNState(O__Start, parser.ATNRuleStart, true)
+	states[O__Stop] = parser.NewATNState(O__Stop, parser.ATNRuleStop, false)
 	states[FQN__Start] = parser.NewATNState(FQN__Start, parser.ATNRuleStart, true)
 	states[FQN__Stop] = parser.NewATNState(FQN__Stop, parser.ATNRuleStop, false)
 	states[Root__Basic_0] = parser.NewATNState(Root__Basic_0, parser.ATNBasic, true)
@@ -286,7 +295,9 @@ func BuildATN() *parser.RuntimeATN {
 	states[Root__Basic_27] = parser.NewATNState(Root__Basic_27, parser.ATNBasic, true)
 	states[Root__Basic_28] = parser.NewATNState(Root__Basic_28, parser.ATNBasic, true)
 	states[Root__Basic_29] = parser.NewATNState(Root__Basic_29, parser.ATNBasic, true)
-	states[Root__Basic_30] = parser.NewATNState(Root__Basic_30, parser.ATNBasic, true).SetDecision(0)
+	states[Root__Basic_30] = parser.NewATNState(Root__Basic_30, parser.ATNBasic, true)
+	states[Root__Basic_31] = parser.NewATNState(Root__Basic_31, parser.ATNBasic, true)
+	states[Root__Basic_32] = parser.NewATNState(Root__Basic_32, parser.ATNBasic, true).SetDecision(0)
 	states[Root__BlockEnd] = parser.NewATNState(Root__BlockEnd, parser.ATNBlockEnd, true)
 	states[Root__LoopEntry] = parser.NewATNState(Root__LoopEntry, parser.ATNLoopEntry, true).SetDecision(1)
 	states[Root__LoopEnd] = parser.NewATNState(Root__LoopEnd, parser.ATNLoopEnd, true)
@@ -396,6 +407,9 @@ func BuildATN() *parser.RuntimeATN {
 	states[N_n] = parser.NewATNState(N_n, parser.ATNBasic, false)
 	states[N__Basic_0] = parser.NewATNState(N__Basic_0, parser.ATNBasic, false)
 	states[N__Basic_1] = parser.NewATNState(N__Basic_1, parser.ATNBasic, true)
+	states[O_o] = parser.NewATNState(O_o, parser.ATNBasic, false)
+	states[O_Ref_ID] = parser.NewATNState(O_Ref_ID, parser.ATNBasic, false)
+	states[O__Basic] = parser.NewATNState(O__Basic, parser.ATNBasic, true)
 	states[FQN_ID_0] = parser.NewATNState(FQN_ID_0, parser.ATNBasic, false)
 	states[FQN_Dot] = parser.NewATNState(FQN_Dot, parser.ATNBasic, false)
 	states[FQN_ID_1] = parser.NewATNState(FQN_ID_1, parser.ATNBasic, false)
@@ -465,6 +479,9 @@ func BuildATN() *parser.RuntimeATN {
 	)
 	states[N__Start].AppendTransitions(
 		parser.NewEpsilonTransition(states[N_n]),
+	)
+	states[O__Start].AppendTransitions(
+		parser.NewEpsilonTransition(states[O_o]),
 	)
 	states[FQN__Start].AppendTransitions(
 		parser.NewEpsilonTransition(states[FQN_ID_0]),
@@ -560,6 +577,12 @@ func BuildATN() *parser.RuntimeATN {
 		parser.NewEpsilonTransition(states[Root__BlockEnd]),
 	)
 	states[Root__Basic_30].AppendTransitions(
+		parser.NewRuleTransition(states[O__Start], states[Root__Basic_31], nil),
+	)
+	states[Root__Basic_31].AppendTransitions(
+		parser.NewEpsilonTransition(states[Root__BlockEnd]),
+	)
+	states[Root__Basic_32].AppendTransitions(
 		parser.NewEpsilonTransition(states[Root__Basic_0]),
 		parser.NewEpsilonTransition(states[Root__Basic_2]),
 		parser.NewEpsilonTransition(states[Root__Basic_4]),
@@ -575,12 +598,13 @@ func BuildATN() *parser.RuntimeATN {
 		parser.NewEpsilonTransition(states[Root__Basic_24]),
 		parser.NewEpsilonTransition(states[Root__Basic_26]),
 		parser.NewEpsilonTransition(states[Root__Basic_28]),
+		parser.NewEpsilonTransition(states[Root__Basic_30]),
 	)
 	states[Root__BlockEnd].AppendTransitions(
 		parser.NewEpsilonTransition(states[Root__LoopBack]),
 	)
 	states[Root__LoopEntry].AppendTransitions(
-		parser.NewEpsilonTransition(states[Root__Basic_30]),
+		parser.NewEpsilonTransition(states[Root__Basic_32]),
 		parser.NewEpsilonTransition(states[Root__LoopEnd]),
 	)
 	states[Root__LoopEnd].AppendTransitions(
@@ -915,6 +939,15 @@ func BuildATN() *parser.RuntimeATN {
 	states[N__Basic_1].AppendTransitions(
 		parser.NewEpsilonTransition(states[N__Stop]),
 	)
+	states[O_o].AppendTransitions(
+		parser.NewAtomTransition(states[O_Ref_ID], Keyword_o, nil),
+	)
+	states[O_Ref_ID].AppendTransitions(
+		parser.NewAtomTransition(states[O__Basic], Token_ID, &parser.CompletionHint{Field: "O.Ref"}),
+	)
+	states[O__Basic].AppendTransitions(
+		parser.NewEpsilonTransition(states[O__Stop]),
+	)
 	states[FQN_ID_0].AppendTransitions(
 		parser.NewAtomTransition(states[FQN__LoopEntry], Token_ID, nil),
 	)
@@ -938,7 +971,7 @@ func BuildATN() *parser.RuntimeATN {
 		parser.NewEpsilonTransition(states[FQN__LoopEntry]),
 	)
 	decisionStates := make([]*parser.RuntimeATNState, 14)
-	decisionStates[0] = states[Root__Basic_30]
+	decisionStates[0] = states[Root__Basic_32]
 	decisionStates[1] = states[Root__LoopEntry]
 	decisionStates[2] = states[Declare__LoopEntry]
 	decisionStates[3] = states[Declare__Basic_4]
@@ -953,7 +986,7 @@ func BuildATN() *parser.RuntimeATN {
 	decisionStates[12] = states[L__Basic_1]
 	decisionStates[13] = states[FQN__LoopEntry]
 	decisionMap := make([]*parser.RuntimeATNState, 14)
-	decisionMap[0] = states[Root__Basic_30]
+	decisionMap[0] = states[Root__Basic_32]
 	decisionMap[1] = states[Root__LoopEntry]
 	decisionMap[2] = states[Declare__LoopEntry]
 	decisionMap[3] = states[Declare__Basic_4]

--- a/internal/languages/completion/completion.fb
+++ b/internal/languages/completion/completion.fb
@@ -7,7 +7,7 @@ interface Root {
     Objects []Obj
 }
 
-Root: Objects+=(Declare | A | B | C | D | E | F | G | H | I | J | K | L | M | N)*;
+Root: Objects+=(Declare | A | B | C | D | E | F | G | H | I | J | K | L | M | N | O)*;
 
 interface Declare extends Obj {
     Name composite
@@ -111,6 +111,13 @@ interface N extends Obj {
 
 // token group used to perform cross reference
 N: "n" Ref=[Declare:SomeTokenGroup];
+
+interface O extends Obj {
+    Ref *Declare
+}
+
+// action used to change type
+O returns Obj: {O} "o" Ref=[Declare:ID];
 
 hidden token WS: /[ \t\r\n]+/;
 token ID: /\w[\w0-9]*/;

--- a/internal/languages/completion/completion_engine_test.go
+++ b/internal/languages/completion/completion_engine_test.go
@@ -537,6 +537,16 @@ func TestCompletion_AfterN_TokenGroupCrossRef_MultipleDeclares(t *testing.T) {
 	}
 }
 
+// We use a token group as a cross reference terminal
+// It should propose the names as usual
+func TestCompletion_AfterO_ActionCrossRef(t *testing.T) {
+	items := completionAt(t, "declare some o <|cursor>")
+	assert.Len(t, items, 1)
+	if !hasLabel(items, "some") {
+		t.Errorf("expected 'some' as O.Ref candidate; got %v", itemLabels(items))
+	}
+}
+
 // A token group used as a cross-reference terminal must resolve like any other
 // cross-reference, not just drive completion.
 func TestTokenGroupReference_Resolves(t *testing.T) {

--- a/internal/languages/completion/completion_gen.go
+++ b/internal/languages/completion/completion_gen.go
@@ -22,6 +22,7 @@ type CompletionCompletionFilter interface {
 	FilterKRef1(ctx context.Context, reference *core.Reference[Declare], in iter.Seq[*core.SymbolDescription]) iter.Seq[*core.SymbolDescription]
 	FilterKRef2(ctx context.Context, reference *core.Reference[Declare], in iter.Seq[*core.SymbolDescription]) iter.Seq[*core.SymbolDescription]
 	FilterNRef(ctx context.Context, reference *core.Reference[Declare], in iter.Seq[*core.SymbolDescription]) iter.Seq[*core.SymbolDescription]
+	FilterORef(ctx context.Context, reference *core.Reference[Declare], in iter.Seq[*core.SymbolDescription]) iter.Seq[*core.SymbolDescription]
 }
 
 type DefaultCompletionCompletionFilter struct{}
@@ -62,28 +63,8 @@ func (*DefaultCompletionCompletionFilter) FilterNRef(_ context.Context, _ *core.
 	return in
 }
 
-var CompletionSyntheticFactories = map[string]func() core.AstNode{
-	"A":               func() core.AstNode { return NewObj() },
-	"B":               func() core.AstNode { return NewObj() },
-	"C":               func() core.AstNode { return NewObj() },
-	"D":               func() core.AstNode { return NewObj() },
-	"DLong":           func() core.AstNode { return NewObj() },
-	"DShort":          func() core.AstNode { return NewObj() },
-	"Declare":         func() core.AstNode { return NewDeclare() },
-	"E":               func() core.AstNode { return NewE() },
-	"F":               func() core.AstNode { return NewF() },
-	"FItem":           func() core.AstNode { return NewFItem() },
-	"G":               func() core.AstNode { return NewG() },
-	"H":               func() core.AstNode { return NewH() },
-	"I":               func() core.AstNode { return NewH() },
-	"J":               func() core.AstNode { return NewJ() },
-	"K":               func() core.AstNode { return NewK() },
-	"L":               func() core.AstNode { return NewObj() },
-	"M":               func() core.AstNode { return NewObj() },
-	"MemberCall":      func() core.AstNode { return NewMemberCall() },
-	"MemberCallNoDot": func() core.AstNode { return NewMemberCall() },
-	"N":               func() core.AstNode { return NewN() },
-	"Root":            func() core.AstNode { return NewRoot() },
+func (*DefaultCompletionCompletionFilter) FilterORef(_ context.Context, _ *core.Reference[Declare], in iter.Seq[*core.SymbolDescription]) iter.Seq[*core.SymbolDescription] {
+	return in
 }
 
 type CompletionCompletionDispatchFunc func(
@@ -189,6 +170,18 @@ var CompletionCompletionDispatch = map[string]CompletionCompletionDispatchFunc{
 		candidates := scopes.ScopeNRef(ctx, ref).AllElements()
 		return filter.FilterNRef(ctx, ref, candidates)
 	},
+	"O.Ref": func(ctx context.Context, sc *service.Container, owner core.AstNode) iter.Seq[*core.SymbolDescription] {
+		typedOwner, ok := owner.(O)
+		if !ok {
+			return func(yield func(*core.SymbolDescription) bool) {}
+		}
+		refs := service.MustGet[CompletionReferencesConstructor](sc)
+		scopes := service.MustGet[CompletionScopeProvider](sc)
+		filter := service.MustGet[CompletionCompletionFilter](sc)
+		ref := refs.ORef(typedOwner, nil)
+		candidates := scopes.ScopeORef(ctx, ref).AllElements()
+		return filter.FilterORef(ctx, ref, candidates)
+	},
 }
 
 type CompletionCompletionAdapter struct {
@@ -258,6 +251,11 @@ func (a *CompletionCompletionAdapter) HasAssignment(node core.AstNode, property 
 			return n.Ref() != nil
 		}
 	case N:
+		switch property {
+		case "Ref":
+			return n.Ref() != nil
+		}
+	case O:
 		switch property {
 		case "Ref":
 			return n.Ref() != nil

--- a/internal/languages/completion/completion_parser_gen.go
+++ b/internal/languages/completion/completion_parser_gen.go
@@ -138,6 +138,12 @@ func (p *CompletionParser) ParseRoot() {
 				p.ParseN()
 				p.state.ExitRule()
 				p.cp.ClearAssignment()
+			case 15:
+				p.cp.MarkAssignment("Objects")
+				p.state.EnterRule(Root__Basic_31)
+				p.ParseO()
+				p.state.ExitRule()
+				p.cp.ClearAssignment()
 			default:
 				break loop0
 			}
@@ -518,6 +524,19 @@ func (p *CompletionParser) ParseN() {
 	{
 		p.cp.MarkAssignment("Ref")
 		p.state.Consume(Token_SomeTokenGroup)
+		p.cp.ClearAssignment()
+	}
+}
+
+func (p *CompletionParser) ParseO() {
+	p.cp.EnterRule("O", O__Start)
+	defer p.cp.ExitRule()
+	{
+		p.state.Consume(Keyword_o)
+	}
+	{
+		p.cp.MarkAssignment("Ref")
+		p.state.Consume(Token_ID)
 		p.cp.ClearAssignment()
 	}
 }

--- a/internal/languages/completion/lexer_gen.go
+++ b/internal/languages/completion/lexer_gen.go
@@ -408,7 +408,26 @@ var Keyword_n = core.NewTokenType(
 	[]rune{'n'},
 )
 
-const Keyword_optional_Idx = 22
+const Keyword_o_Idx = 22
+
+var Keyword_o = core.NewTokenType(
+	Keyword_o_Idx,
+	"o",
+	"o",
+	0,
+	core.TokenKindKeyword,
+	0,
+	false,
+	func(text string, offset int) int {
+		if strings.HasPrefix(text[offset:], "o") {
+			return 1
+		}
+		return 0
+	},
+	[]rune{'o'},
+)
+
+const Keyword_optional_Idx = 23
 
 var Keyword_optional = core.NewTokenType(
 	Keyword_optional_Idx,
@@ -427,7 +446,7 @@ var Keyword_optional = core.NewTokenType(
 	[]rune{'o'},
 )
 
-const Keyword_second_Idx = 23
+const Keyword_second_Idx = 24
 
 var Keyword_second = core.NewTokenType(
 	Keyword_second_Idx,
@@ -446,7 +465,7 @@ var Keyword_second = core.NewTokenType(
 	[]rune{'s'},
 )
 
-const Keyword_self_Idx = 24
+const Keyword_self_Idx = 25
 
 var Keyword_self = core.NewTokenType(
 	Keyword_self_Idx,
@@ -465,7 +484,7 @@ var Keyword_self = core.NewTokenType(
 	[]rune{'s'},
 )
 
-const Keyword_then_Idx = 25
+const Keyword_then_Idx = 26
 
 var Keyword_then = core.NewTokenType(
 	Keyword_then_Idx,
@@ -484,7 +503,7 @@ var Keyword_then = core.NewTokenType(
 	[]rune{'t'},
 )
 
-const Keyword_x_Idx = 26
+const Keyword_x_Idx = 27
 
 var Keyword_x = core.NewTokenType(
 	Keyword_x_Idx,
@@ -503,7 +522,7 @@ var Keyword_x = core.NewTokenType(
 	[]rune{'x'},
 )
 
-const Keyword_y_Idx = 27
+const Keyword_y_Idx = 28
 
 var Keyword_y = core.NewTokenType(
 	Keyword_y_Idx,
@@ -522,7 +541,7 @@ var Keyword_y = core.NewTokenType(
 	[]rune{'y'},
 )
 
-const Keyword_LeftBrace_Idx = 28
+const Keyword_LeftBrace_Idx = 29
 
 var Keyword_LeftBrace = core.NewTokenType(
 	Keyword_LeftBrace_Idx,
@@ -541,7 +560,7 @@ var Keyword_LeftBrace = core.NewTokenType(
 	[]rune{'{'},
 )
 
-const Keyword_RightBrace_Idx = 29
+const Keyword_RightBrace_Idx = 30
 
 var Keyword_RightBrace = core.NewTokenType(
 	Keyword_RightBrace_Idx,
@@ -560,7 +579,7 @@ var Keyword_RightBrace = core.NewTokenType(
 	[]rune{'}'},
 )
 
-const Token_WS_Idx = 30
+const Token_WS_Idx = 31
 
 var Token_WS = core.NewTokenType(
 	Token_WS_Idx,
@@ -634,7 +653,7 @@ var Token_WS_Accepting = [2]bool{
 	1: true,
 }
 
-const Token_ID_Idx = 31
+const Token_ID_Idx = 32
 
 var Token_ID = core.NewTokenType(
 	Token_ID_Idx,
@@ -708,7 +727,7 @@ var Token_ID_Accepting = [2]bool{
 	1: true,
 }
 
-const Token_SomeTokenGroup_Idx = 32
+const Token_SomeTokenGroup_Idx = 33
 
 var Token_SomeTokenGroup = core.NewTokenGroup(
 	Token_SomeTokenGroup_Idx,
@@ -744,6 +763,7 @@ func NewLexer() lexer.Lexer {
 		Keyword_long,
 		Keyword_m,
 		Keyword_n,
+		Keyword_o,
 		Keyword_optional,
 		Keyword_second,
 		Keyword_self,

--- a/internal/languages/completion/linker_gen.go
+++ b/internal/languages/completion/linker_gen.go
@@ -23,6 +23,7 @@ type CompletionScopeProvider interface {
 	ScopeKRef1(ctx context.Context, reference *core.Reference[Declare]) core.Scope
 	ScopeKRef2(ctx context.Context, reference *core.Reference[Declare]) core.Scope
 	ScopeNRef(ctx context.Context, reference *core.Reference[Declare]) core.Scope
+	ScopeORef(ctx context.Context, reference *core.Reference[Declare]) core.Scope
 }
 
 type DefaultCompletionScopeProvider struct {
@@ -65,6 +66,10 @@ func (s *DefaultCompletionScopeProvider) ScopeNRef(ctx context.Context, referenc
 	return linking.DefaultScopeOfType[Declare](reference.Owner())
 }
 
+func (s *DefaultCompletionScopeProvider) ScopeORef(ctx context.Context, reference *core.Reference[Declare]) core.Scope {
+	return linking.DefaultScopeOfType[Declare](reference.Owner())
+}
+
 type CompletionReferenceLinker interface {
 	LinkERef(ctx context.Context, reference *core.Reference[Declare]) (*core.SymbolDescription, *core.ReferenceError)
 	LinkFItemRef(ctx context.Context, reference *core.Reference[Declare]) (*core.SymbolDescription, *core.ReferenceError)
@@ -74,6 +79,7 @@ type CompletionReferenceLinker interface {
 	LinkKRef1(ctx context.Context, reference *core.Reference[Declare]) (*core.SymbolDescription, *core.ReferenceError)
 	LinkKRef2(ctx context.Context, reference *core.Reference[Declare]) (*core.SymbolDescription, *core.ReferenceError)
 	LinkNRef(ctx context.Context, reference *core.Reference[Declare]) (*core.SymbolDescription, *core.ReferenceError)
+	LinkORef(ctx context.Context, reference *core.Reference[Declare]) (*core.SymbolDescription, *core.ReferenceError)
 }
 
 type DefaultCompletionReferenceLinker struct {
@@ -130,6 +136,11 @@ func (s *DefaultCompletionReferenceLinker) LinkNRef(ctx context.Context, referen
 	return core.DefaultLink(scope, reference.Text())
 }
 
+func (s *DefaultCompletionReferenceLinker) LinkORef(ctx context.Context, reference *core.Reference[Declare]) (*core.SymbolDescription, *core.ReferenceError) {
+	scope := s.scopeProvider().ScopeORef(ctx, reference)
+	return core.DefaultLink(scope, reference.Text())
+}
+
 type CompletionReferencesConstructor interface {
 	ERef(owner core.AstNode, unit core.StringUnit) *core.Reference[Declare]
 	FItemRef(owner core.AstNode, unit core.StringUnit) *core.Reference[Declare]
@@ -139,6 +150,7 @@ type CompletionReferencesConstructor interface {
 	KRef1(owner core.AstNode, unit core.StringUnit) *core.Reference[Declare]
 	KRef2(owner core.AstNode, unit core.StringUnit) *core.Reference[Declare]
 	NRef(owner core.AstNode, unit core.StringUnit) *core.Reference[Declare]
+	ORef(owner core.AstNode, unit core.StringUnit) *core.Reference[Declare]
 }
 
 type DefaultCompletionReferencesConstructor struct {
@@ -192,6 +204,11 @@ func (s *DefaultCompletionReferencesConstructor) KRef2(owner core.AstNode, unit 
 
 func (s *DefaultCompletionReferencesConstructor) NRef(owner core.AstNode, unit core.StringUnit) *core.Reference[Declare] {
 	fn := s.referenceLinker().LinkNRef
+	return core.NewReference(owner, unit, fn)
+}
+
+func (s *DefaultCompletionReferencesConstructor) ORef(owner core.AstNode, unit core.StringUnit) *core.Reference[Declare] {
+	fn := s.referenceLinker().LinkORef
 	return core.NewReference(owner, unit, fn)
 }
 

--- a/internal/languages/completion/parser_gen.go
+++ b/internal/languages/completion/parser_gen.go
@@ -36,119 +36,128 @@ func (p *Parser) ParseRoot() Root {
 	current := NewRoot()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		p.state.Sync(Root__LoopEntry)
-	loop0:
-		for {
-			switch prediction, _ := p.lookahead.RootObjectsAlternatives(p.state); prediction {
-			case 0:
-				p.state.EnterRule(Root__Basic_1)
-				result := p.ParseDeclare()
-				p.state.ExitRule()
-				if result != nil {
-					current.SetObjectsItem(result)
-				}
-			case 1:
-				p.state.EnterRule(Root__Basic_3)
-				result := p.ParseA()
-				p.state.ExitRule()
-				if result != nil {
-					current.SetObjectsItem(result)
-				}
-			case 2:
-				p.state.EnterRule(Root__Basic_5)
-				result := p.ParseB()
-				p.state.ExitRule()
-				if result != nil {
-					current.SetObjectsItem(result)
-				}
-			case 3:
-				p.state.EnterRule(Root__Basic_7)
-				result := p.ParseC()
-				p.state.ExitRule()
-				if result != nil {
-					current.SetObjectsItem(result)
-				}
-			case 4:
-				p.state.EnterRule(Root__Basic_9)
-				result := p.ParseD()
-				p.state.ExitRule()
-				if result != nil {
-					current.SetObjectsItem(result)
-				}
-			case 5:
-				p.state.EnterRule(Root__Basic_11)
-				result := p.ParseE()
-				p.state.ExitRule()
-				if result != nil {
-					current.SetObjectsItem(result)
-				}
-			case 6:
-				p.state.EnterRule(Root__Basic_13)
-				result := p.ParseF()
-				p.state.ExitRule()
-				if result != nil {
-					current.SetObjectsItem(result)
-				}
-			case 7:
-				p.state.EnterRule(Root__Basic_15)
-				result := p.ParseG()
-				p.state.ExitRule()
-				if result != nil {
-					current.SetObjectsItem(result)
-				}
-			case 8:
-				p.state.EnterRule(Root__Basic_17)
-				result := p.ParseH()
-				p.state.ExitRule()
-				if result != nil {
-					current.SetObjectsItem(result)
-				}
-			case 9:
-				p.state.EnterRule(Root__Basic_19)
-				result := p.ParseI()
-				p.state.ExitRule()
-				if result != nil {
-					current.SetObjectsItem(result)
-				}
-			case 10:
-				p.state.EnterRule(Root__Basic_21)
-				result := p.ParseJ()
-				p.state.ExitRule()
-				if result != nil {
-					current.SetObjectsItem(result)
-				}
-			case 11:
-				p.state.EnterRule(Root__Basic_23)
-				result := p.ParseK()
-				p.state.ExitRule()
-				if result != nil {
-					current.SetObjectsItem(result)
-				}
-			case 12:
-				p.state.EnterRule(Root__Basic_25)
-				result := p.ParseL()
-				p.state.ExitRule()
-				if result != nil {
-					current.SetObjectsItem(result)
-				}
-			case 13:
-				p.state.EnterRule(Root__Basic_27)
-				result := p.ParseM()
-				p.state.ExitRule()
-				if result != nil {
-					current.SetObjectsItem(result)
-				}
-			case 14:
-				p.state.EnterRule(Root__Basic_29)
-				result := p.ParseN()
-				p.state.ExitRule()
-				if result != nil {
-					current.SetObjectsItem(result)
-				}
-			default:
-				break loop0
-			}
+		{
 			p.state.Sync(Root__LoopEntry)
+		loop0:
+			for {
+				switch prediction, _ := p.lookahead.RootObjectsAlternatives(p.state); prediction {
+				case 0:
+					p.state.EnterRule(Root__Basic_1)
+					result := p.ParseDeclare()
+					p.state.ExitRule()
+					if result != nil {
+						current.SetObjectsItem(result)
+					}
+				case 1:
+					p.state.EnterRule(Root__Basic_3)
+					result := p.ParseA()
+					p.state.ExitRule()
+					if result != nil {
+						current.SetObjectsItem(result)
+					}
+				case 2:
+					p.state.EnterRule(Root__Basic_5)
+					result := p.ParseB()
+					p.state.ExitRule()
+					if result != nil {
+						current.SetObjectsItem(result)
+					}
+				case 3:
+					p.state.EnterRule(Root__Basic_7)
+					result := p.ParseC()
+					p.state.ExitRule()
+					if result != nil {
+						current.SetObjectsItem(result)
+					}
+				case 4:
+					p.state.EnterRule(Root__Basic_9)
+					result := p.ParseD()
+					p.state.ExitRule()
+					if result != nil {
+						current.SetObjectsItem(result)
+					}
+				case 5:
+					p.state.EnterRule(Root__Basic_11)
+					result := p.ParseE()
+					p.state.ExitRule()
+					if result != nil {
+						current.SetObjectsItem(result)
+					}
+				case 6:
+					p.state.EnterRule(Root__Basic_13)
+					result := p.ParseF()
+					p.state.ExitRule()
+					if result != nil {
+						current.SetObjectsItem(result)
+					}
+				case 7:
+					p.state.EnterRule(Root__Basic_15)
+					result := p.ParseG()
+					p.state.ExitRule()
+					if result != nil {
+						current.SetObjectsItem(result)
+					}
+				case 8:
+					p.state.EnterRule(Root__Basic_17)
+					result := p.ParseH()
+					p.state.ExitRule()
+					if result != nil {
+						current.SetObjectsItem(result)
+					}
+				case 9:
+					p.state.EnterRule(Root__Basic_19)
+					result := p.ParseI()
+					p.state.ExitRule()
+					if result != nil {
+						current.SetObjectsItem(result)
+					}
+				case 10:
+					p.state.EnterRule(Root__Basic_21)
+					result := p.ParseJ()
+					p.state.ExitRule()
+					if result != nil {
+						current.SetObjectsItem(result)
+					}
+				case 11:
+					p.state.EnterRule(Root__Basic_23)
+					result := p.ParseK()
+					p.state.ExitRule()
+					if result != nil {
+						current.SetObjectsItem(result)
+					}
+				case 12:
+					p.state.EnterRule(Root__Basic_25)
+					result := p.ParseL()
+					p.state.ExitRule()
+					if result != nil {
+						current.SetObjectsItem(result)
+					}
+				case 13:
+					p.state.EnterRule(Root__Basic_27)
+					result := p.ParseM()
+					p.state.ExitRule()
+					if result != nil {
+						current.SetObjectsItem(result)
+					}
+				case 14:
+					p.state.EnterRule(Root__Basic_29)
+					result := p.ParseN()
+					p.state.ExitRule()
+					if result != nil {
+						current.SetObjectsItem(result)
+					}
+				case 15:
+					p.state.EnterRule(Root__Basic_31)
+					result := p.ParseO()
+					p.state.ExitRule()
+					if result != nil {
+						current.SetObjectsItem(result)
+					}
+				default:
+					break loop0
+				}
+				p.state.Sync(Root__LoopEntry)
+			}
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
@@ -159,41 +168,43 @@ func (p *Parser) ParseDeclare() Declare {
 	current := NewDeclare()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_declare)
-		core.AssignToken(current, token, Declare_declare)
-	}
-	{
-		result := core.NewCompositeNode()
-		result.SetSegmentStartToken(p.state.LA(1))
-		p.state.EnterRule(Declare__Basic_4)
-		p.ParseFQN(result)
-		p.state.ExitRule()
-		result.SetSegmentEndToken(p.state.LA(0))
-		if result != nil {
-			current.SetName(result)
-		}
-	}
-	p.state.Sync(Declare__Basic_4)
-	if p.lookahead.DeclareOptional(p.state) {
 		{
-			token := p.state.Consume(Keyword_LeftBrace)
-			core.AssignToken(current, token, Declare_LeftBrace)
+			token := p.state.Consume(Keyword_declare)
+			core.AssignToken(current, token, Declare_declare)
 		}
 		{
-			p.state.Sync(Declare__LoopEntry)
-			for p.lookahead.DeclareChildrenLoop(p.state) {
-				p.state.EnterRule(Declare__Basic_2)
-				result := p.ParseDeclare()
-				p.state.ExitRule()
-				if result != nil {
-					current.SetChildrenItem(result)
-				}
-				p.state.Sync(Declare__LoopEntry)
+			result := core.NewCompositeNode()
+			result.SetSegmentStartToken(p.state.LA(1))
+			p.state.EnterRule(Declare__Basic_4)
+			p.ParseFQN(result)
+			p.state.ExitRule()
+			result.SetSegmentEndToken(p.state.LA(0))
+			if result != nil {
+				current.SetName(result)
 			}
 		}
-		{
-			token := p.state.Consume(Keyword_RightBrace)
-			core.AssignToken(current, token, Declare_RightBrace)
+		p.state.Sync(Declare__Basic_4)
+		if p.lookahead.DeclareOptional(p.state) {
+			{
+				token := p.state.Consume(Keyword_LeftBrace)
+				core.AssignToken(current, token, Declare_LeftBrace)
+			}
+			{
+				p.state.Sync(Declare__LoopEntry)
+				for p.lookahead.DeclareChildrenLoop(p.state) {
+					p.state.EnterRule(Declare__Basic_2)
+					result := p.ParseDeclare()
+					p.state.ExitRule()
+					if result != nil {
+						current.SetChildrenItem(result)
+					}
+					p.state.Sync(Declare__LoopEntry)
+				}
+			}
+			{
+				token := p.state.Consume(Keyword_RightBrace)
+				core.AssignToken(current, token, Declare_RightBrace)
+			}
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
@@ -204,12 +215,14 @@ func (p *Parser) ParseA() Obj {
 	current := NewObj()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_a)
-		core.AssignToken(current, token, A_a)
-	}
-	{
-		token := p.state.Consume(Keyword_first)
-		core.AssignToken(current, token, A_first)
+		{
+			token := p.state.Consume(Keyword_a)
+			core.AssignToken(current, token, A_a)
+		}
+		{
+			token := p.state.Consume(Keyword_first)
+			core.AssignToken(current, token, A_first)
+		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -219,22 +232,24 @@ func (p *Parser) ParseB() Obj {
 	current := NewObj()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_b)
-		core.AssignToken(current, token, B_b)
-	}
-	switch prediction, failure := p.lookahead.BAlternatives(p.state); prediction {
-	case 0:
 		{
-			token := p.state.Consume(Keyword_first)
-			core.AssignToken(current, token, B_first)
+			token := p.state.Consume(Keyword_b)
+			core.AssignToken(current, token, B_b)
 		}
-	case 1:
-		{
-			token := p.state.Consume(Keyword_second)
-			core.AssignToken(current, token, B_second)
+		switch prediction, failure := p.lookahead.BAlternatives(p.state); prediction {
+		case 0:
+			{
+				token := p.state.Consume(Keyword_first)
+				core.AssignToken(current, token, B_first)
+			}
+		case 1:
+			{
+				token := p.state.Consume(Keyword_second)
+				core.AssignToken(current, token, B_second)
+			}
+		default:
+			p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 		}
-	default:
-		p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -244,30 +259,32 @@ func (p *Parser) ParseC() Obj {
 	current := NewObj()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_c)
-		core.AssignToken(current, token, C_c)
-	}
-	switch prediction, failure := p.lookahead.CAlternatives(p.state); prediction {
-	case 0:
 		{
-			token := p.state.Consume(Keyword_common)
-			core.AssignToken(current, token, C_common_0)
+			token := p.state.Consume(Keyword_c)
+			core.AssignToken(current, token, C_c)
 		}
-		{
-			token := p.state.Consume(Keyword_first)
-			core.AssignToken(current, token, C_first)
+		switch prediction, failure := p.lookahead.CAlternatives(p.state); prediction {
+		case 0:
+			{
+				token := p.state.Consume(Keyword_common)
+				core.AssignToken(current, token, C_common_0)
+			}
+			{
+				token := p.state.Consume(Keyword_first)
+				core.AssignToken(current, token, C_first)
+			}
+		case 1:
+			{
+				token := p.state.Consume(Keyword_common)
+				core.AssignToken(current, token, C_common_1)
+			}
+			{
+				token := p.state.Consume(Keyword_second)
+				core.AssignToken(current, token, C_second)
+			}
+		default:
+			p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 		}
-	case 1:
-		{
-			token := p.state.Consume(Keyword_common)
-			core.AssignToken(current, token, C_common_1)
-		}
-		{
-			token := p.state.Consume(Keyword_second)
-			core.AssignToken(current, token, C_second)
-		}
-	default:
-		p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -277,28 +294,30 @@ func (p *Parser) ParseD() Obj {
 	current := NewObj()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_d)
-		core.AssignToken(current, token, D_d)
-	}
-	switch prediction, failure := p.lookahead.DAlternatives(p.state); prediction {
-	case 0:
 		{
-			p.state.EnterRule(D__Basic_1)
-			result := p.ParseDLong()
-			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
-			current = result
+			token := p.state.Consume(Keyword_d)
+			core.AssignToken(current, token, D_d)
 		}
-	case 1:
-		{
-			p.state.EnterRule(D__Basic_3)
-			result := p.ParseDShort()
-			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
-			current = result
+		switch prediction, failure := p.lookahead.DAlternatives(p.state); prediction {
+		case 0:
+			{
+				p.state.EnterRule(D__Basic_1)
+				result := p.ParseDLong()
+				p.state.ExitRule()
+				core.MergeTokens(result, current.Tokens())
+				current = result
+			}
+		case 1:
+			{
+				p.state.EnterRule(D__Basic_3)
+				result := p.ParseDShort()
+				p.state.ExitRule()
+				core.MergeTokens(result, current.Tokens())
+				current = result
+			}
+		default:
+			p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 		}
-	default:
-		p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -308,18 +327,20 @@ func (p *Parser) ParseE() E {
 	current := NewE()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_e)
-		core.AssignToken(current, token, E_e)
-	}
-	{
-		result := core.NewCompositeNode()
-		result.SetSegmentStartToken(p.state.LA(1))
-		p.state.EnterRule(0)
-		p.ParseFQN(result)
-		p.state.ExitRule()
-		result.SetSegmentEndToken(p.state.LA(0))
-		if result != nil {
-			current.SetRef(p.referencesConstructor.ERef(current, result))
+		{
+			token := p.state.Consume(Keyword_e)
+			core.AssignToken(current, token, E_e)
+		}
+		{
+			result := core.NewCompositeNode()
+			result.SetSegmentStartToken(p.state.LA(1))
+			p.state.EnterRule(0)
+			p.ParseFQN(result)
+			p.state.ExitRule()
+			result.SetSegmentEndToken(p.state.LA(0))
+			if result != nil {
+				current.SetRef(p.referencesConstructor.ERef(current, result))
+			}
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
@@ -330,16 +351,18 @@ func (p *Parser) ParseDLong() Obj {
 	current := NewObj()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_common)
-		core.AssignToken(current, token, DLong_common)
-	}
-	{
-		token := p.state.Consume(Keyword_then)
-		core.AssignToken(current, token, DLong_then)
-	}
-	{
-		token := p.state.Consume(Keyword_long)
-		core.AssignToken(current, token, DLong_long)
+		{
+			token := p.state.Consume(Keyword_common)
+			core.AssignToken(current, token, DLong_common)
+		}
+		{
+			token := p.state.Consume(Keyword_then)
+			core.AssignToken(current, token, DLong_then)
+		}
+		{
+			token := p.state.Consume(Keyword_long)
+			core.AssignToken(current, token, DLong_long)
+		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -349,8 +372,10 @@ func (p *Parser) ParseDShort() Obj {
 	current := NewObj()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_common)
-		core.AssignToken(current, token, DShort_common)
+		{
+			token := p.state.Consume(Keyword_common)
+			core.AssignToken(current, token, DShort_common)
+		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -360,18 +385,20 @@ func (p *Parser) ParseF() F {
 	current := NewF()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_f)
-		core.AssignToken(current, token, F_f)
-	}
-	{
-		for ok := true; ok; ok = p.lookahead.FItemsLoop(p.state) {
-			p.state.EnterRule(F__Basic_1)
-			result := p.ParseFItem()
-			p.state.ExitRule()
-			if result != nil {
-				current.SetItemsItem(result)
+		{
+			token := p.state.Consume(Keyword_f)
+			core.AssignToken(current, token, F_f)
+		}
+		{
+			for ok := true; ok; ok = p.lookahead.FItemsLoop(p.state) {
+				p.state.EnterRule(F__Basic_1)
+				result := p.ParseFItem()
+				p.state.ExitRule()
+				if result != nil {
+					current.SetItemsItem(result)
+				}
+				p.state.Sync(F__LoopBack)
 			}
-			p.state.Sync(F__LoopBack)
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
@@ -382,14 +409,16 @@ func (p *Parser) ParseFItem() FItem {
 	current := NewFItem()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		result := core.NewCompositeNode()
-		result.SetSegmentStartToken(p.state.LA(1))
-		p.state.EnterRule(0)
-		p.ParseFQN(result)
-		p.state.ExitRule()
-		result.SetSegmentEndToken(p.state.LA(0))
-		if result != nil {
-			current.SetRef(p.referencesConstructor.FItemRef(current, result))
+		{
+			result := core.NewCompositeNode()
+			result.SetSegmentStartToken(p.state.LA(1))
+			p.state.EnterRule(0)
+			p.ParseFQN(result)
+			p.state.ExitRule()
+			result.SetSegmentEndToken(p.state.LA(0))
+			if result != nil {
+				current.SetRef(p.referencesConstructor.FItemRef(current, result))
+			}
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
@@ -400,14 +429,16 @@ func (p *Parser) ParseG() G {
 	current := NewG()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_g)
-		core.AssignToken(current, token, G_g)
-	}
-	{
-		token := p.state.Consume(Token_ID)
-		core.AssignToken(current, token, G_Ref_ID)
-		if token != nil {
-			current.SetRef(p.referencesConstructor.GRef(current, token))
+		{
+			token := p.state.Consume(Keyword_g)
+			core.AssignToken(current, token, G_g)
+		}
+		{
+			token := p.state.Consume(Token_ID)
+			core.AssignToken(current, token, G_Ref_ID)
+			if token != nil {
+				current.SetRef(p.referencesConstructor.GRef(current, token))
+			}
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
@@ -418,15 +449,17 @@ func (p *Parser) ParseH() H {
 	current := NewH()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_h)
-		core.AssignToken(current, token, H_h)
-	}
-	{
-		p.state.EnterRule(H__Basic_1)
-		result := p.ParseMemberCall()
-		p.state.ExitRule()
-		if result != nil {
-			current.SetMember(result)
+		{
+			token := p.state.Consume(Keyword_h)
+			core.AssignToken(current, token, H_h)
+		}
+		{
+			p.state.EnterRule(H__Basic_1)
+			result := p.ParseMemberCall()
+			p.state.ExitRule()
+			if result != nil {
+				current.SetMember(result)
+			}
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
@@ -437,15 +470,17 @@ func (p *Parser) ParseI() H {
 	current := NewH()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_i)
-		core.AssignToken(current, token, I_i)
-	}
-	{
-		p.state.EnterRule(I__Basic_1)
-		result := p.ParseMemberCallNoDot()
-		p.state.ExitRule()
-		if result != nil {
-			current.SetMember(result)
+		{
+			token := p.state.Consume(Keyword_i)
+			core.AssignToken(current, token, I_i)
+		}
+		{
+			p.state.EnterRule(I__Basic_1)
+			result := p.ParseMemberCallNoDot()
+			p.state.ExitRule()
+			if result != nil {
+				current.SetMember(result)
+			}
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
@@ -456,34 +491,36 @@ func (p *Parser) ParseMemberCall() MemberCall {
 	current := NewMemberCall()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Token_ID)
-		core.AssignToken(current, token, MemberCall_Ref_ID_0)
-		if token != nil {
-			current.SetRef(p.referencesConstructor.MemberCallRef(current, token))
-		}
-	}
-	p.state.Sync(MemberCall__LoopEntry)
-	for p.lookahead.MemberCallLoop(p.state) {
-		{
-			result := NewMemberCall()
-			result.SetSegment(current.Segment())
-			result.SetPrevious(current)
-			current.SetSegmentEndToken(p.state.LA(0))
-			current = result
-		}
-		current := current.(MemberCall)
-		{
-			token := p.state.Consume(Keyword_Dot)
-			core.AssignToken(current, token, MemberCall_Dot)
-		}
 		{
 			token := p.state.Consume(Token_ID)
-			core.AssignToken(current, token, MemberCall_Ref_ID_1)
+			core.AssignToken(current, token, MemberCall_Ref_ID_0)
 			if token != nil {
 				current.SetRef(p.referencesConstructor.MemberCallRef(current, token))
 			}
 		}
 		p.state.Sync(MemberCall__LoopEntry)
+		for p.lookahead.MemberCallLoop(p.state) {
+			{
+				result := NewMemberCall()
+				result.SetSegment(current.Segment())
+				result.SetPrevious(current)
+				current.SetSegmentEndToken(p.state.LA(0))
+				current = result
+			}
+			current := current.(MemberCall)
+			{
+				token := p.state.Consume(Keyword_Dot)
+				core.AssignToken(current, token, MemberCall_Dot)
+			}
+			{
+				token := p.state.Consume(Token_ID)
+				core.AssignToken(current, token, MemberCall_Ref_ID_1)
+				if token != nil {
+					current.SetRef(p.referencesConstructor.MemberCallRef(current, token))
+				}
+			}
+			p.state.Sync(MemberCall__LoopEntry)
+		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -493,30 +530,32 @@ func (p *Parser) ParseMemberCallNoDot() MemberCall {
 	current := NewMemberCall()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Token_ID)
-		core.AssignToken(current, token, MemberCallNoDot_Ref_ID_0)
-		if token != nil {
-			current.SetRef(p.referencesConstructor.MemberCallRef(current, token))
-		}
-	}
-	p.state.Sync(MemberCallNoDot__LoopEntry)
-	for p.lookahead.MemberCallNoDotLoop(p.state) {
-		{
-			result := NewMemberCall()
-			result.SetSegment(current.Segment())
-			result.SetPrevious(current)
-			current.SetSegmentEndToken(p.state.LA(0))
-			current = result
-		}
-		current := current.(MemberCall)
 		{
 			token := p.state.Consume(Token_ID)
-			core.AssignToken(current, token, MemberCallNoDot_Ref_ID_1)
+			core.AssignToken(current, token, MemberCallNoDot_Ref_ID_0)
 			if token != nil {
 				current.SetRef(p.referencesConstructor.MemberCallRef(current, token))
 			}
 		}
 		p.state.Sync(MemberCallNoDot__LoopEntry)
+		for p.lookahead.MemberCallNoDotLoop(p.state) {
+			{
+				result := NewMemberCall()
+				result.SetSegment(current.Segment())
+				result.SetPrevious(current)
+				current.SetSegmentEndToken(p.state.LA(0))
+				current = result
+			}
+			current := current.(MemberCall)
+			{
+				token := p.state.Consume(Token_ID)
+				core.AssignToken(current, token, MemberCallNoDot_Ref_ID_1)
+				if token != nil {
+					current.SetRef(p.referencesConstructor.MemberCallRef(current, token))
+				}
+			}
+			p.state.Sync(MemberCallNoDot__LoopEntry)
+		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -526,25 +565,27 @@ func (p *Parser) ParseJ() J {
 	current := NewJ()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_j)
-		core.AssignToken(current, token, J_j)
-	}
-	switch prediction, failure := p.lookahead.JAlternatives(p.state); prediction {
-	case 0:
 		{
-			token := p.state.Consume(Token_ID)
-			core.AssignToken(current, token, J_Ref_ID)
-			if token != nil {
-				current.SetRef(p.referencesConstructor.JRef(current, token))
+			token := p.state.Consume(Keyword_j)
+			core.AssignToken(current, token, J_j)
+		}
+		switch prediction, failure := p.lookahead.JAlternatives(p.state); prediction {
+		case 0:
+			{
+				token := p.state.Consume(Token_ID)
+				core.AssignToken(current, token, J_Ref_ID)
+				if token != nil {
+					current.SetRef(p.referencesConstructor.JRef(current, token))
+				}
 			}
+		case 1:
+			{
+				token := p.state.Consume(Keyword_self)
+				core.AssignToken(current, token, J_self)
+			}
+		default:
+			p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 		}
-	case 1:
-		{
-			token := p.state.Consume(Keyword_self)
-			core.AssignToken(current, token, J_self)
-		}
-	default:
-		p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -554,36 +595,38 @@ func (p *Parser) ParseK() K {
 	current := NewK()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_k)
-		core.AssignToken(current, token, K_k)
-	}
-	switch prediction, failure := p.lookahead.KAlternatives(p.state); prediction {
-	case 0:
 		{
-			token := p.state.Consume(Token_ID)
-			core.AssignToken(current, token, K_Ref1_ID)
-			if token != nil {
-				current.SetRef1(p.referencesConstructor.KRef1(current, token))
+			token := p.state.Consume(Keyword_k)
+			core.AssignToken(current, token, K_k)
+		}
+		switch prediction, failure := p.lookahead.KAlternatives(p.state); prediction {
+		case 0:
+			{
+				token := p.state.Consume(Token_ID)
+				core.AssignToken(current, token, K_Ref1_ID)
+				if token != nil {
+					current.SetRef1(p.referencesConstructor.KRef1(current, token))
+				}
 			}
-		}
-		{
-			token := p.state.Consume(Keyword_x)
-			core.AssignToken(current, token, K_x)
-		}
-	case 1:
-		{
-			token := p.state.Consume(Token_ID)
-			core.AssignToken(current, token, K_Ref2_ID)
-			if token != nil {
-				current.SetRef2(p.referencesConstructor.KRef2(current, token))
+			{
+				token := p.state.Consume(Keyword_x)
+				core.AssignToken(current, token, K_x)
 			}
+		case 1:
+			{
+				token := p.state.Consume(Token_ID)
+				core.AssignToken(current, token, K_Ref2_ID)
+				if token != nil {
+					current.SetRef2(p.referencesConstructor.KRef2(current, token))
+				}
+			}
+			{
+				token := p.state.Consume(Keyword_y)
+				core.AssignToken(current, token, K_y)
+			}
+		default:
+			p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 		}
-		{
-			token := p.state.Consume(Keyword_y)
-			core.AssignToken(current, token, K_y)
-		}
-	default:
-		p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -593,27 +636,29 @@ func (p *Parser) ParseL() Obj {
 	current := NewObj()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_l)
-		core.AssignToken(current, token, L_l)
-	}
-	p.state.Sync(L__Basic_1)
-	if p.lookahead.LOptional(p.state) {
 		{
-			token := p.state.Consume(Keyword_optional)
-			core.AssignToken(current, token, L_optional)
+			token := p.state.Consume(Keyword_l)
+			core.AssignToken(current, token, L_l)
+		}
+		p.state.Sync(L__Basic_1)
+		if p.lookahead.LOptional(p.state) {
+			{
+				token := p.state.Consume(Keyword_optional)
+				core.AssignToken(current, token, L_optional)
+			}
+			{
+				token := p.state.Consume(Keyword_and)
+				core.AssignToken(current, token, L_and)
+			}
 		}
 		{
-			token := p.state.Consume(Keyword_and)
-			core.AssignToken(current, token, L_and)
+			token := p.state.Consume(Keyword_then)
+			core.AssignToken(current, token, L_then)
 		}
-	}
-	{
-		token := p.state.Consume(Keyword_then)
-		core.AssignToken(current, token, L_then)
-	}
-	{
-		token := p.state.Consume(Keyword_end)
-		core.AssignToken(current, token, L_end)
+		{
+			token := p.state.Consume(Keyword_end)
+			core.AssignToken(current, token, L_end)
+		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -623,12 +668,14 @@ func (p *Parser) ParseM() Obj {
 	current := NewObj()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_m)
-		core.AssignToken(current, token, M_m)
-	}
-	{
-		token := p.state.Consume(Token_SomeTokenGroup)
-		core.AssignToken(current, token, M__Basic_0)
+		{
+			token := p.state.Consume(Keyword_m)
+			core.AssignToken(current, token, M_m)
+		}
+		{
+			token := p.state.Consume(Token_SomeTokenGroup)
+			core.AssignToken(current, token, M__Basic_0)
+		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -638,14 +685,43 @@ func (p *Parser) ParseN() N {
 	current := NewN()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_n)
-		core.AssignToken(current, token, N_n)
+		{
+			token := p.state.Consume(Keyword_n)
+			core.AssignToken(current, token, N_n)
+		}
+		{
+			token := p.state.Consume(Token_SomeTokenGroup)
+			core.AssignToken(current, token, N__Basic_0)
+			if token != nil {
+				current.SetRef(p.referencesConstructor.NRef(current, token))
+			}
+		}
 	}
+	current.SetSegmentEndToken(p.state.LA(0))
+	return current
+}
+
+func (p *Parser) ParseO() Obj {
+	current := NewObj()
+	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Token_SomeTokenGroup)
-		core.AssignToken(current, token, N__Basic_0)
-		if token != nil {
-			current.SetRef(p.referencesConstructor.NRef(current, token))
+		{
+			result := NewO()
+			result.SetSegment(current.Segment())
+			core.AssignTokens(result, current.Tokens())
+			current = result
+		}
+		current := current.(O)
+		{
+			token := p.state.Consume(Keyword_o)
+			core.AssignToken(current, token, O_o)
+		}
+		{
+			token := p.state.Consume(Token_ID)
+			core.AssignToken(current, token, O_Ref_ID)
+			if token != nil {
+				current.SetRef(p.referencesConstructor.ORef(current, token))
+			}
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))

--- a/internal/languages/completion/parser_lookahead_gen.go
+++ b/internal/languages/completion/parser_lookahead_gen.go
@@ -15,17 +15,17 @@ const (
 
 var BAlternatives = parser.LL1Lookahead{
 	Types:  []*core.TokenType{Keyword_first, Keyword_second},
-	Lookup: []int{12: 1, 23: 2},
+	Lookup: []int{12: 1, 24: 2},
 }
 
 var JAlternatives = parser.LL1Lookahead{
 	Types:  []*core.TokenType{Token_ID, Keyword_self},
-	Lookup: []int{24: 2, 31: 1},
+	Lookup: []int{25: 2, 32: 1},
 }
 
 var RootObjectsAlternatives = parser.LL1Lookahead{
-	Types:  []*core.TokenType{Keyword_declare, Keyword_a, Keyword_b, Keyword_c, Keyword_d, Keyword_e, Keyword_f, Keyword_g, Keyword_h, Keyword_i, Keyword_j, Keyword_k, Keyword_l, Keyword_m, Keyword_n},
-	Lookup: []int{2: 2, 4: 3, 5: 4, 7: 5, 8: 1, 9: 6, 11: 7, 13: 8, 14: 9, 15: 10, 16: 11, 17: 12, 18: 13, 20: 14, 21: 15},
+	Types:  []*core.TokenType{Keyword_declare, Keyword_a, Keyword_b, Keyword_c, Keyword_d, Keyword_e, Keyword_f, Keyword_g, Keyword_h, Keyword_i, Keyword_j, Keyword_k, Keyword_l, Keyword_m, Keyword_n, Keyword_o},
+	Lookup: []int{2: 2, 4: 3, 5: 4, 7: 5, 8: 1, 9: 6, 11: 7, 13: 8, 14: 9, 15: 10, 16: 11, 17: 12, 18: 13, 20: 14, 21: 15, 22: 16},
 }
 
 // CompletionParserLookahead abstracts every lookahead/prediction decision performed by

--- a/internal/languages/completion/types_gen.go
+++ b/internal/languages/completion/types_gen.go
@@ -788,3 +788,83 @@ func (i *NImpl) ForEachReference(fn func(core.UntypedReference)) {
 	i.ObjData.ForEachReference(fn)
 	i.NData.ForEachReference(fn)
 }
+
+type O interface {
+	core.AstNode
+	Obj
+
+	IsO()
+	Ref() *core.Reference[Declare]
+	SetRef(value *core.Reference[Declare])
+}
+
+func NewO() O {
+	return &OImpl{
+		AstNodeBase: core.NewAstNode(),
+		ObjData:     NewObjData(),
+		OData:       NewOData(),
+	}
+}
+
+type OData struct {
+	ref *core.Reference[Declare]
+}
+
+func NewOData() OData {
+	return OData{}
+}
+
+func (i *OData) IsO() {}
+
+func (i *OData) ForEachNode(fn func(core.AstNode)) {
+}
+
+func (i *OData) ForEachReference(fn func(core.UntypedReference)) {
+	if i.ref != nil {
+		fn(i.ref)
+	}
+}
+
+func (i *OData) Ref() *core.Reference[Declare] {
+	if i != nil && i.ref != nil {
+		return i.ref
+	} else {
+		return nil
+	}
+}
+
+func (i *OData) SetRef(value *core.Reference[Declare]) {
+	i.ref = value
+}
+
+type OImpl struct {
+	core.AstNodeBase
+	ObjData
+	OData
+}
+
+func (i *OImpl) ForEachNode(fn func(core.AstNode)) {
+	i.ObjData.ForEachNode(fn)
+	i.OData.ForEachNode(fn)
+}
+
+func (i *OImpl) ForEachReference(fn func(core.UntypedReference)) {
+	i.ObjData.ForEachReference(fn)
+	i.OData.ForEachReference(fn)
+}
+
+var CompletionSyntheticFactories = map[string]func() core.AstNode{
+	"Declare":    func() core.AstNode { return NewDeclare() },
+	"E":          func() core.AstNode { return NewE() },
+	"F":          func() core.AstNode { return NewF() },
+	"FItem":      func() core.AstNode { return NewFItem() },
+	"G":          func() core.AstNode { return NewG() },
+	"H":          func() core.AstNode { return NewH() },
+	"J":          func() core.AstNode { return NewJ() },
+	"K":          func() core.AstNode { return NewK() },
+	"MemberCall": func() core.AstNode { return NewMemberCall() },
+	"N":          func() core.AstNode { return NewN() },
+	"O":          func() core.AstNode { return NewO() },
+	"Obj":        func() core.AstNode { return NewObj() },
+	"Root":       func() core.AstNode { return NewRoot() },
+}

--- a/internal/languages/lookahead/completion_gen.go
+++ b/internal/languages/lookahead/completion_gen.go
@@ -22,20 +22,6 @@ func NewDefaultLookaheadCompletionFilter() LookaheadCompletionFilter {
 	return &DefaultLookaheadCompletionFilter{}
 }
 
-var LookaheadSyntheticFactories = map[string]func() core.AstNode{
-	"A":    func() core.AstNode { return NewObj() },
-	"B":    func() core.AstNode { return NewB() },
-	"C":    func() core.AstNode { return NewObj() },
-	"D":    func() core.AstNode { return NewObj() },
-	"E":    func() core.AstNode { return NewObj() },
-	"F":    func() core.AstNode { return NewObj() },
-	"G":    func() core.AstNode { return NewObj() },
-	"H":    func() core.AstNode { return NewObj() },
-	"I":    func() core.AstNode { return NewObj() },
-	"Obj":  func() core.AstNode { return NewObj() },
-	"Root": func() core.AstNode { return NewRoot() },
-}
-
 var LookaheadCompletionDispatch = map[string]LookaheadCompletionDispatchFunc{}
 
 type LookaheadCompletionDispatchFunc func(ctx context.Context, sc *core.AstNode) iter.Seq[*core.SymbolDescription]

--- a/internal/languages/lookahead/parser_gen.go
+++ b/internal/languages/lookahead/parser_gen.go
@@ -36,11 +36,13 @@ func (p *Parser) ParseRoot() Root {
 	current := NewRoot()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		p.state.EnterRule(Root__Basic_1)
-		result := p.ParseObj()
-		p.state.ExitRule()
-		if result != nil {
-			current.SetItem(result)
+		{
+			p.state.EnterRule(Root__Basic_1)
+			result := p.ParseObj()
+			p.state.ExitRule()
+			if result != nil {
+				current.SetItem(result)
+			}
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
@@ -50,81 +52,83 @@ func (p *Parser) ParseRoot() Root {
 func (p *Parser) ParseObj() Obj {
 	current := NewObj()
 	current.SetSegmentStartToken(p.state.LA(1))
-	switch prediction, failure := p.lookahead.ObjAlternatives(p.state); prediction {
-	case 0:
-		{
-			p.state.EnterRule(Obj__Basic_1)
-			result := p.ParseA()
-			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
-			current = result
+	{
+		switch prediction, failure := p.lookahead.ObjAlternatives(p.state); prediction {
+		case 0:
+			{
+				p.state.EnterRule(Obj__Basic_1)
+				result := p.ParseA()
+				p.state.ExitRule()
+				core.MergeTokens(result, current.Tokens())
+				current = result
+			}
+		case 1:
+			{
+				p.state.EnterRule(Obj__Basic_3)
+				result := p.ParseB()
+				p.state.ExitRule()
+				core.MergeTokens(result, current.Tokens())
+				current = result
+			}
+		case 2:
+			{
+				p.state.EnterRule(Obj__Basic_5)
+				result := p.ParseC()
+				p.state.ExitRule()
+				core.MergeTokens(result, current.Tokens())
+				current = result
+			}
+		case 3:
+			{
+				p.state.EnterRule(Obj__Basic_7)
+				result := p.ParseD()
+				p.state.ExitRule()
+				core.MergeTokens(result, current.Tokens())
+				current = result
+			}
+		case 4:
+			{
+				p.state.EnterRule(Obj__Basic_9)
+				result := p.ParseE()
+				p.state.ExitRule()
+				core.MergeTokens(result, current.Tokens())
+				current = result
+			}
+		case 5:
+			{
+				p.state.EnterRule(Obj__Basic_11)
+				result := p.ParseF()
+				p.state.ExitRule()
+				core.MergeTokens(result, current.Tokens())
+				current = result
+			}
+		case 6:
+			{
+				p.state.EnterRule(Obj__Basic_13)
+				result := p.ParseG()
+				p.state.ExitRule()
+				core.MergeTokens(result, current.Tokens())
+				current = result
+			}
+		case 7:
+			{
+				p.state.EnterRule(Obj__Basic_15)
+				result := p.ParseH()
+				p.state.ExitRule()
+				core.MergeTokens(result, current.Tokens())
+				current = result
+			}
+		case 8:
+			{
+				p.state.EnterRule(Obj__Basic_17)
+				result := p.ParseI()
+				p.state.ExitRule()
+				core.MergeTokens(result, current.Tokens())
+				current = result
+			}
+		default:
+			p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 		}
-	case 1:
-		{
-			p.state.EnterRule(Obj__Basic_3)
-			result := p.ParseB()
-			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
-			current = result
-		}
-	case 2:
-		{
-			p.state.EnterRule(Obj__Basic_5)
-			result := p.ParseC()
-			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
-			current = result
-		}
-	case 3:
-		{
-			p.state.EnterRule(Obj__Basic_7)
-			result := p.ParseD()
-			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
-			current = result
-		}
-	case 4:
-		{
-			p.state.EnterRule(Obj__Basic_9)
-			result := p.ParseE()
-			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
-			current = result
-		}
-	case 5:
-		{
-			p.state.EnterRule(Obj__Basic_11)
-			result := p.ParseF()
-			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
-			current = result
-		}
-	case 6:
-		{
-			p.state.EnterRule(Obj__Basic_13)
-			result := p.ParseG()
-			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
-			current = result
-		}
-	case 7:
-		{
-			p.state.EnterRule(Obj__Basic_15)
-			result := p.ParseH()
-			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
-			current = result
-		}
-	case 8:
-		{
-			p.state.EnterRule(Obj__Basic_17)
-			result := p.ParseI()
-			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
-			current = result
-		}
-	default:
-		p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -134,18 +138,20 @@ func (p *Parser) ParseA() Obj {
 	current := NewObj()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_a)
-		core.AssignToken(current, token, A_a)
-	}
-	{
-		result := core.NewCompositeNode()
-		result.SetSegmentStartToken(p.state.LA(1))
-		p.state.EnterRule(A__Basic_1)
-		p.ParseQualifiedPath(result)
-		p.state.ExitRule()
-		result.SetSegmentEndToken(p.state.LA(0))
-		if result != nil {
-			current.SetNode(result)
+		{
+			token := p.state.Consume(Keyword_a)
+			core.AssignToken(current, token, A_a)
+		}
+		{
+			result := core.NewCompositeNode()
+			result.SetSegmentStartToken(p.state.LA(1))
+			p.state.EnterRule(A__Basic_1)
+			p.ParseQualifiedPath(result)
+			p.state.ExitRule()
+			result.SetSegmentEndToken(p.state.LA(0))
+			if result != nil {
+				current.SetNode(result)
+			}
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
@@ -156,29 +162,31 @@ func (p *Parser) ParseB() B {
 	current := NewB()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_b)
-		core.AssignToken(current, token, B_b)
-	}
-	{
-		result := core.NewCompositeNode()
-		result.SetSegmentStartToken(p.state.LA(1))
-		p.state.EnterRule(B_Dot)
-		p.ParseQualifiedPath(result)
-		p.state.ExitRule()
-		result.SetSegmentEndToken(p.state.LA(0))
-		if result != nil {
-			current.SetNode(result)
+		{
+			token := p.state.Consume(Keyword_b)
+			core.AssignToken(current, token, B_b)
 		}
-	}
-	{
-		token := p.state.Consume(Keyword_Dot)
-		core.AssignToken(current, token, B_Dot)
-	}
-	{
-		token := p.state.Consume(Token_ID)
-		core.AssignToken(current, token, B_Post_ID)
-		if token != nil {
-			current.SetPost(token)
+		{
+			result := core.NewCompositeNode()
+			result.SetSegmentStartToken(p.state.LA(1))
+			p.state.EnterRule(B_Dot)
+			p.ParseQualifiedPath(result)
+			p.state.ExitRule()
+			result.SetSegmentEndToken(p.state.LA(0))
+			if result != nil {
+				current.SetNode(result)
+			}
+		}
+		{
+			token := p.state.Consume(Keyword_Dot)
+			core.AssignToken(current, token, B_Dot)
+		}
+		{
+			token := p.state.Consume(Token_ID)
+			core.AssignToken(current, token, B_Post_ID)
+			if token != nil {
+				current.SetPost(token)
+			}
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
@@ -189,31 +197,33 @@ func (p *Parser) ParseC() Obj {
 	current := NewObj()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_c)
-		core.AssignToken(current, token, C_c)
-	}
-	{
-		result := core.NewCompositeNode()
-		result.SetSegmentStartToken(p.state.LA(1))
-		p.state.EnterRule(C__Basic_2)
-		p.ParseCLoop(result)
-		p.state.ExitRule()
-		result.SetSegmentEndToken(p.state.LA(0))
-		if result != nil {
-			current.SetNode(result)
-		}
-	}
-	p.state.Sync(C__Basic_2)
-	if p.lookahead.COptional(p.state) {
 		{
-			token := p.state.Consume(Keyword_ColonColon)
-			core.AssignToken(current, token, C_ColonColon)
+			token := p.state.Consume(Keyword_c)
+			core.AssignToken(current, token, C_c)
 		}
 		{
-			token := p.state.Consume(Keyword_AsteriskAsterisk)
-			core.AssignToken(current, token, C_Value_AsteriskAsterisk)
-			if token != nil {
-				current.SetValue(token)
+			result := core.NewCompositeNode()
+			result.SetSegmentStartToken(p.state.LA(1))
+			p.state.EnterRule(C__Basic_2)
+			p.ParseCLoop(result)
+			p.state.ExitRule()
+			result.SetSegmentEndToken(p.state.LA(0))
+			if result != nil {
+				current.SetNode(result)
+			}
+		}
+		p.state.Sync(C__Basic_2)
+		if p.lookahead.COptional(p.state) {
+			{
+				token := p.state.Consume(Keyword_ColonColon)
+				core.AssignToken(current, token, C_ColonColon)
+			}
+			{
+				token := p.state.Consume(Keyword_AsteriskAsterisk)
+				core.AssignToken(current, token, C_Value_AsteriskAsterisk)
+				if token != nil {
+					current.SetValue(token)
+				}
 			}
 		}
 	}
@@ -225,31 +235,33 @@ func (p *Parser) ParseD() Obj {
 	current := NewObj()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_d)
-		core.AssignToken(current, token, D_d)
-	}
-	{
-		result := core.NewCompositeNode()
-		result.SetSegmentStartToken(p.state.LA(1))
-		p.state.EnterRule(D__Basic_2)
-		p.ParseDOpt(result)
-		p.state.ExitRule()
-		result.SetSegmentEndToken(p.state.LA(0))
-		if result != nil {
-			current.SetNode(result)
-		}
-	}
-	p.state.Sync(D__Basic_2)
-	if p.lookahead.DOptional(p.state) {
 		{
-			token := p.state.Consume(Keyword_ColonColon)
-			core.AssignToken(current, token, D_ColonColon)
+			token := p.state.Consume(Keyword_d)
+			core.AssignToken(current, token, D_d)
 		}
 		{
-			token := p.state.Consume(Keyword_AsteriskAsterisk)
-			core.AssignToken(current, token, D_Value_AsteriskAsterisk)
-			if token != nil {
-				current.SetValue(token)
+			result := core.NewCompositeNode()
+			result.SetSegmentStartToken(p.state.LA(1))
+			p.state.EnterRule(D__Basic_2)
+			p.ParseDOpt(result)
+			p.state.ExitRule()
+			result.SetSegmentEndToken(p.state.LA(0))
+			if result != nil {
+				current.SetNode(result)
+			}
+		}
+		p.state.Sync(D__Basic_2)
+		if p.lookahead.DOptional(p.state) {
+			{
+				token := p.state.Consume(Keyword_ColonColon)
+				core.AssignToken(current, token, D_ColonColon)
+			}
+			{
+				token := p.state.Consume(Keyword_AsteriskAsterisk)
+				core.AssignToken(current, token, D_Value_AsteriskAsterisk)
+				if token != nil {
+					current.SetValue(token)
+				}
 			}
 		}
 	}
@@ -261,23 +273,25 @@ func (p *Parser) ParseE() Obj {
 	current := NewObj()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_e)
-		core.AssignToken(current, token, E_e)
-	}
-	{
-		p.state.Sync(E__Basic_1)
-		if p.lookahead.EValueOptional(p.state) {
-			token := p.state.Consume(Keyword_hello)
-			core.AssignToken(current, token, E_Value_hello)
-			if token != nil {
-				current.SetValue(token)
+		{
+			token := p.state.Consume(Keyword_e)
+			core.AssignToken(current, token, E_e)
+		}
+		{
+			p.state.Sync(E__Basic_1)
+			if p.lookahead.EValueOptional(p.state) {
+				token := p.state.Consume(Keyword_hello)
+				core.AssignToken(current, token, E_Value_hello)
+				if token != nil {
+					current.SetValue(token)
+				}
 			}
 		}
-	}
-	{
-		if p.lookahead.EworldOptional(p.state) {
-			token := p.state.Consume(Keyword_world)
-			core.AssignToken(current, token, E_world)
+		{
+			if p.lookahead.EworldOptional(p.state) {
+				token := p.state.Consume(Keyword_world)
+				core.AssignToken(current, token, E_world)
+			}
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
@@ -288,40 +302,42 @@ func (p *Parser) ParseF() Obj {
 	current := NewObj()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_f)
-		core.AssignToken(current, token, F_f)
-	}
-	switch prediction, failure := p.lookahead.FAlternatives(p.state); prediction {
-	case 0:
 		{
-			for p.lookahead.FLoop_0(p.state) {
-				token := p.state.Consume(Token_ID)
-				core.AssignToken(current, token, F_ID_0)
-			}
+			token := p.state.Consume(Keyword_f)
+			core.AssignToken(current, token, F_f)
 		}
-		{
-			token := p.state.Consume(Keyword_hello)
-			core.AssignToken(current, token, F_Value_hello)
-			if token != nil {
-				current.SetValue(token)
+		switch prediction, failure := p.lookahead.FAlternatives(p.state); prediction {
+		case 0:
+			{
+				for p.lookahead.FLoop_0(p.state) {
+					token := p.state.Consume(Token_ID)
+					core.AssignToken(current, token, F_ID_0)
+				}
 			}
-		}
-	case 1:
-		{
-			for p.lookahead.FLoop_1(p.state) {
-				token := p.state.Consume(Token_ID)
-				core.AssignToken(current, token, F_ID_1)
+			{
+				token := p.state.Consume(Keyword_hello)
+				core.AssignToken(current, token, F_Value_hello)
+				if token != nil {
+					current.SetValue(token)
+				}
 			}
-		}
-		{
-			token := p.state.Consume(Keyword_world)
-			core.AssignToken(current, token, F_Value_world)
-			if token != nil {
-				current.SetValue(token)
+		case 1:
+			{
+				for p.lookahead.FLoop_1(p.state) {
+					token := p.state.Consume(Token_ID)
+					core.AssignToken(current, token, F_ID_1)
+				}
 			}
+			{
+				token := p.state.Consume(Keyword_world)
+				core.AssignToken(current, token, F_Value_world)
+				if token != nil {
+					current.SetValue(token)
+				}
+			}
+		default:
+			p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 		}
-	default:
-		p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -331,50 +347,52 @@ func (p *Parser) ParseG() Obj {
 	current := NewObj()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_g)
-		core.AssignToken(current, token, G_g)
-	}
-	switch prediction, failure := p.lookahead.GAlternatives(p.state); prediction {
-	case 0:
 		{
-			result := core.NewCompositeNode()
-			result.SetSegmentStartToken(p.state.LA(1))
-			p.state.EnterRule(G_Value_hello)
-			p.ParseQualifiedName(result)
-			p.state.ExitRule()
-			result.SetSegmentEndToken(p.state.LA(0))
-			if result != nil {
-				current.SetNode(result)
-			}
+			token := p.state.Consume(Keyword_g)
+			core.AssignToken(current, token, G_g)
 		}
-		{
-			token := p.state.Consume(Keyword_hello)
-			core.AssignToken(current, token, G_Value_hello)
-			if token != nil {
-				current.SetValue(token)
+		switch prediction, failure := p.lookahead.GAlternatives(p.state); prediction {
+		case 0:
+			{
+				result := core.NewCompositeNode()
+				result.SetSegmentStartToken(p.state.LA(1))
+				p.state.EnterRule(G_Value_hello)
+				p.ParseQualifiedName(result)
+				p.state.ExitRule()
+				result.SetSegmentEndToken(p.state.LA(0))
+				if result != nil {
+					current.SetNode(result)
+				}
 			}
-		}
-	case 1:
-		{
-			result := core.NewCompositeNode()
-			result.SetSegmentStartToken(p.state.LA(1))
-			p.state.EnterRule(G_Value_world)
-			p.ParseQualifiedName(result)
-			p.state.ExitRule()
-			result.SetSegmentEndToken(p.state.LA(0))
-			if result != nil {
-				current.SetNode(result)
+			{
+				token := p.state.Consume(Keyword_hello)
+				core.AssignToken(current, token, G_Value_hello)
+				if token != nil {
+					current.SetValue(token)
+				}
 			}
-		}
-		{
-			token := p.state.Consume(Keyword_world)
-			core.AssignToken(current, token, G_Value_world)
-			if token != nil {
-				current.SetValue(token)
+		case 1:
+			{
+				result := core.NewCompositeNode()
+				result.SetSegmentStartToken(p.state.LA(1))
+				p.state.EnterRule(G_Value_world)
+				p.ParseQualifiedName(result)
+				p.state.ExitRule()
+				result.SetSegmentEndToken(p.state.LA(0))
+				if result != nil {
+					current.SetNode(result)
+				}
 			}
+			{
+				token := p.state.Consume(Keyword_world)
+				core.AssignToken(current, token, G_Value_world)
+				if token != nil {
+					current.SetValue(token)
+				}
+			}
+		default:
+			p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 		}
-	default:
-		p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -384,50 +402,52 @@ func (p *Parser) ParseH() Obj {
 	current := NewObj()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_h)
-		core.AssignToken(current, token, H_h)
-	}
-	switch prediction, failure := p.lookahead.HAlternatives(p.state); prediction {
-	case 0:
 		{
-			result := core.NewCompositeNode()
-			result.SetSegmentStartToken(p.state.LA(1))
-			p.state.EnterRule(H_Value_hello)
-			p.ParseQualifiedNameRecursive(result)
-			p.state.ExitRule()
-			result.SetSegmentEndToken(p.state.LA(0))
-			if result != nil {
-				current.SetNode(result)
-			}
+			token := p.state.Consume(Keyword_h)
+			core.AssignToken(current, token, H_h)
 		}
-		{
-			token := p.state.Consume(Keyword_hello)
-			core.AssignToken(current, token, H_Value_hello)
-			if token != nil {
-				current.SetValue(token)
+		switch prediction, failure := p.lookahead.HAlternatives(p.state); prediction {
+		case 0:
+			{
+				result := core.NewCompositeNode()
+				result.SetSegmentStartToken(p.state.LA(1))
+				p.state.EnterRule(H_Value_hello)
+				p.ParseQualifiedNameRecursive(result)
+				p.state.ExitRule()
+				result.SetSegmentEndToken(p.state.LA(0))
+				if result != nil {
+					current.SetNode(result)
+				}
 			}
-		}
-	case 1:
-		{
-			result := core.NewCompositeNode()
-			result.SetSegmentStartToken(p.state.LA(1))
-			p.state.EnterRule(H_Value_world)
-			p.ParseQualifiedNameRecursive(result)
-			p.state.ExitRule()
-			result.SetSegmentEndToken(p.state.LA(0))
-			if result != nil {
-				current.SetNode(result)
+			{
+				token := p.state.Consume(Keyword_hello)
+				core.AssignToken(current, token, H_Value_hello)
+				if token != nil {
+					current.SetValue(token)
+				}
 			}
-		}
-		{
-			token := p.state.Consume(Keyword_world)
-			core.AssignToken(current, token, H_Value_world)
-			if token != nil {
-				current.SetValue(token)
+		case 1:
+			{
+				result := core.NewCompositeNode()
+				result.SetSegmentStartToken(p.state.LA(1))
+				p.state.EnterRule(H_Value_world)
+				p.ParseQualifiedNameRecursive(result)
+				p.state.ExitRule()
+				result.SetSegmentEndToken(p.state.LA(0))
+				if result != nil {
+					current.SetNode(result)
+				}
 			}
+			{
+				token := p.state.Consume(Keyword_world)
+				core.AssignToken(current, token, H_Value_world)
+				if token != nil {
+					current.SetValue(token)
+				}
+			}
+		default:
+			p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 		}
-	default:
-		p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current
@@ -437,50 +457,52 @@ func (p *Parser) ParseI() Obj {
 	current := NewObj()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_i)
-		core.AssignToken(current, token, I_i)
-	}
-	switch prediction, failure := p.lookahead.IAlternatives(p.state); prediction {
-	case 0:
 		{
-			result := core.NewCompositeNode()
-			result.SetSegmentStartToken(p.state.LA(1))
-			p.state.EnterRule(I_Value_ID_0)
-			p.ParseQualifiedNameRecursive(result)
-			p.state.ExitRule()
-			result.SetSegmentEndToken(p.state.LA(0))
-			if result != nil {
-				current.SetNode(result)
-			}
+			token := p.state.Consume(Keyword_i)
+			core.AssignToken(current, token, I_i)
 		}
-		{
-			token := p.state.Consume(Token_ID)
-			core.AssignToken(current, token, I_Value_ID_0)
-			if token != nil {
-				current.SetValue(token)
+		switch prediction, failure := p.lookahead.IAlternatives(p.state); prediction {
+		case 0:
+			{
+				result := core.NewCompositeNode()
+				result.SetSegmentStartToken(p.state.LA(1))
+				p.state.EnterRule(I_Value_ID_0)
+				p.ParseQualifiedNameRecursive(result)
+				p.state.ExitRule()
+				result.SetSegmentEndToken(p.state.LA(0))
+				if result != nil {
+					current.SetNode(result)
+				}
 			}
-		}
-	case 1:
-		{
-			result := core.NewCompositeNode()
-			result.SetSegmentStartToken(p.state.LA(1))
-			p.state.EnterRule(I_Value_ID_1)
-			p.ParseQualifiedNameRecursive(result)
-			p.state.ExitRule()
-			result.SetSegmentEndToken(p.state.LA(0))
-			if result != nil {
-				current.SetNode(result)
+			{
+				token := p.state.Consume(Token_ID)
+				core.AssignToken(current, token, I_Value_ID_0)
+				if token != nil {
+					current.SetValue(token)
+				}
 			}
-		}
-		{
-			token := p.state.Consume(Token_ID)
-			core.AssignToken(current, token, I_Value_ID_1)
-			if token != nil {
-				current.SetValue(token)
+		case 1:
+			{
+				result := core.NewCompositeNode()
+				result.SetSegmentStartToken(p.state.LA(1))
+				p.state.EnterRule(I_Value_ID_1)
+				p.ParseQualifiedNameRecursive(result)
+				p.state.ExitRule()
+				result.SetSegmentEndToken(p.state.LA(0))
+				if result != nil {
+					current.SetNode(result)
+				}
 			}
+			{
+				token := p.state.Consume(Token_ID)
+				core.AssignToken(current, token, I_Value_ID_1)
+				if token != nil {
+					current.SetValue(token)
+				}
+			}
+		default:
+			p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 		}
-	default:
-		p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current

--- a/internal/languages/lookahead/types_gen.go
+++ b/internal/languages/lookahead/types_gen.go
@@ -214,3 +214,9 @@ func (i *BImpl) ForEachReference(fn func(core.UntypedReference)) {
 	i.ObjData.ForEachReference(fn)
 	i.BData.ForEachReference(fn)
 }
+
+var LookaheadSyntheticFactories = map[string]func() core.AstNode{
+	"B":    func() core.AstNode { return NewB() },
+	"Obj":  func() core.AstNode { return NewObj() },
+	"Root": func() core.AstNode { return NewRoot() },
+}

--- a/internal/languages/token_groups/completion_gen.go
+++ b/internal/languages/token_groups/completion_gen.go
@@ -22,18 +22,6 @@ func NewDefaultTokenGroupsCompletionFilter() TokenGroupsCompletionFilter {
 	return &DefaultTokenGroupsCompletionFilter{}
 }
 
-var TokenGroupsSyntheticFactories = map[string]func() core.AstNode{
-	"A":     func() core.AstNode { return NewItem() },
-	"B":     func() core.AstNode { return NewItem() },
-	"C":     func() core.AstNode { return NewItem() },
-	"D":     func() core.AstNode { return NewItem() },
-	"E":     func() core.AstNode { return NewRecovery() },
-	"F":     func() core.AstNode { return NewItem() },
-	"G":     func() core.AstNode { return NewItem() },
-	"H":     func() core.AstNode { return NewItem() },
-	"Model": func() core.AstNode { return NewModel() },
-}
-
 var TokenGroupsCompletionDispatch = map[string]TokenGroupsCompletionDispatchFunc{}
 
 type TokenGroupsCompletionDispatchFunc func(ctx context.Context, sc *core.AstNode) iter.Seq[*core.SymbolDescription]

--- a/internal/languages/token_groups/parser_gen.go
+++ b/internal/languages/token_groups/parser_gen.go
@@ -36,62 +36,64 @@ func (p *Parser) ParseModel() Model {
 	current := NewModel()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		switch prediction, _ := p.lookahead.ModelItemAlternatives(p.state); prediction {
-		case 0:
-			p.state.EnterRule(Model__Basic_1)
-			result := p.ParseA()
-			p.state.ExitRule()
-			if result != nil {
-				current.SetItem(result)
-			}
-		case 1:
-			p.state.EnterRule(Model__Basic_3)
-			result := p.ParseB()
-			p.state.ExitRule()
-			if result != nil {
-				current.SetItem(result)
-			}
-		case 2:
-			p.state.EnterRule(Model__Basic_5)
-			result := p.ParseC()
-			p.state.ExitRule()
-			if result != nil {
-				current.SetItem(result)
-			}
-		case 3:
-			p.state.EnterRule(Model__Basic_7)
-			result := p.ParseD()
-			p.state.ExitRule()
-			if result != nil {
-				current.SetItem(result)
-			}
-		case 4:
-			p.state.EnterRule(Model__Basic_9)
-			result := p.ParseE()
-			p.state.ExitRule()
-			if result != nil {
-				current.SetItem(result)
-			}
-		case 5:
-			p.state.EnterRule(Model__Basic_11)
-			result := p.ParseF()
-			p.state.ExitRule()
-			if result != nil {
-				current.SetItem(result)
-			}
-		case 6:
-			p.state.EnterRule(Model__Basic_13)
-			result := p.ParseG()
-			p.state.ExitRule()
-			if result != nil {
-				current.SetItem(result)
-			}
-		case 7:
-			p.state.EnterRule(Model__Basic_15)
-			result := p.ParseH()
-			p.state.ExitRule()
-			if result != nil {
-				current.SetItem(result)
+		{
+			switch prediction, _ := p.lookahead.ModelItemAlternatives(p.state); prediction {
+			case 0:
+				p.state.EnterRule(Model__Basic_1)
+				result := p.ParseA()
+				p.state.ExitRule()
+				if result != nil {
+					current.SetItem(result)
+				}
+			case 1:
+				p.state.EnterRule(Model__Basic_3)
+				result := p.ParseB()
+				p.state.ExitRule()
+				if result != nil {
+					current.SetItem(result)
+				}
+			case 2:
+				p.state.EnterRule(Model__Basic_5)
+				result := p.ParseC()
+				p.state.ExitRule()
+				if result != nil {
+					current.SetItem(result)
+				}
+			case 3:
+				p.state.EnterRule(Model__Basic_7)
+				result := p.ParseD()
+				p.state.ExitRule()
+				if result != nil {
+					current.SetItem(result)
+				}
+			case 4:
+				p.state.EnterRule(Model__Basic_9)
+				result := p.ParseE()
+				p.state.ExitRule()
+				if result != nil {
+					current.SetItem(result)
+				}
+			case 5:
+				p.state.EnterRule(Model__Basic_11)
+				result := p.ParseF()
+				p.state.ExitRule()
+				if result != nil {
+					current.SetItem(result)
+				}
+			case 6:
+				p.state.EnterRule(Model__Basic_13)
+				result := p.ParseG()
+				p.state.ExitRule()
+				if result != nil {
+					current.SetItem(result)
+				}
+			case 7:
+				p.state.EnterRule(Model__Basic_15)
+				result := p.ParseH()
+				p.state.ExitRule()
+				if result != nil {
+					current.SetItem(result)
+				}
 			}
 		}
 	}
@@ -103,14 +105,16 @@ func (p *Parser) ParseA() Item {
 	current := NewItem()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_a)
-		core.AssignToken(current, token, A_a)
-	}
-	{
-		token := p.state.Consume(Token_Identifier)
-		core.AssignToken(current, token, A__Basic_0)
-		if token != nil {
-			current.SetValue(token)
+		{
+			token := p.state.Consume(Keyword_a)
+			core.AssignToken(current, token, A_a)
+		}
+		{
+			token := p.state.Consume(Token_Identifier)
+			core.AssignToken(current, token, A__Basic_0)
+			if token != nil {
+				current.SetValue(token)
+			}
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
@@ -121,22 +125,24 @@ func (p *Parser) ParseB() Item {
 	current := NewItem()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_b)
-		core.AssignToken(current, token, B_b)
-	}
-	{
-		switch prediction, _ := p.lookahead.BValueAlternatives(p.state); prediction {
-		case 0:
-			token := p.state.Consume(Token_Identifier)
-			core.AssignToken(current, token, B__Basic_0)
-			if token != nil {
-				current.SetValue(token)
-			}
-		case 1:
+		{
 			token := p.state.Consume(Keyword_b)
-			core.AssignToken(current, token, B_Value_b)
-			if token != nil {
-				current.SetValue(token)
+			core.AssignToken(current, token, B_b)
+		}
+		{
+			switch prediction, _ := p.lookahead.BValueAlternatives(p.state); prediction {
+			case 0:
+				token := p.state.Consume(Token_Identifier)
+				core.AssignToken(current, token, B__Basic_0)
+				if token != nil {
+					current.SetValue(token)
+				}
+			case 1:
+				token := p.state.Consume(Keyword_b)
+				core.AssignToken(current, token, B_Value_b)
+				if token != nil {
+					current.SetValue(token)
+				}
 			}
 		}
 	}
@@ -148,14 +154,16 @@ func (p *Parser) ParseC() Item {
 	current := NewItem()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_c)
-		core.AssignToken(current, token, C_c)
-	}
-	{
-		token := p.state.Consume(Token_NestedIdentifier)
-		core.AssignToken(current, token, C__Basic_0)
-		if token != nil {
-			current.SetValue(token)
+		{
+			token := p.state.Consume(Keyword_c)
+			core.AssignToken(current, token, C_c)
+		}
+		{
+			token := p.state.Consume(Token_NestedIdentifier)
+			core.AssignToken(current, token, C__Basic_0)
+			if token != nil {
+				current.SetValue(token)
+			}
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
@@ -166,16 +174,18 @@ func (p *Parser) ParseD() Item {
 	current := NewItem()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_d)
-		core.AssignToken(current, token, D_d)
-	}
-	{
-		p.state.Sync(D__Basic_2)
-		if p.lookahead.DValueOptional(p.state) {
-			token := p.state.Consume(Token_Identifier)
-			core.AssignToken(current, token, D__Basic_0)
-			if token != nil {
-				current.SetValue(token)
+		{
+			token := p.state.Consume(Keyword_d)
+			core.AssignToken(current, token, D_d)
+		}
+		{
+			p.state.Sync(D__Basic_2)
+			if p.lookahead.DValueOptional(p.state) {
+				token := p.state.Consume(Token_Identifier)
+				core.AssignToken(current, token, D__Basic_0)
+				if token != nil {
+					current.SetValue(token)
+				}
 			}
 		}
 	}
@@ -187,21 +197,23 @@ func (p *Parser) ParseE() Recovery {
 	current := NewRecovery()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_e)
-		core.AssignToken(current, token, E_e)
-	}
-	{
-		token := p.state.Consume(Token_Identifier)
-		core.AssignToken(current, token, E__Basic_0)
-		if token != nil {
-			current.SetFirst(token)
+		{
+			token := p.state.Consume(Keyword_e)
+			core.AssignToken(current, token, E_e)
 		}
-	}
-	{
-		token := p.state.Consume(Token_NestedIdentifier)
-		core.AssignToken(current, token, E__Basic_1)
-		if token != nil {
-			current.SetSecond(token)
+		{
+			token := p.state.Consume(Token_Identifier)
+			core.AssignToken(current, token, E__Basic_0)
+			if token != nil {
+				current.SetFirst(token)
+			}
+		}
+		{
+			token := p.state.Consume(Token_NestedIdentifier)
+			core.AssignToken(current, token, E__Basic_1)
+			if token != nil {
+				current.SetSecond(token)
+			}
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
@@ -212,14 +224,16 @@ func (p *Parser) ParseF() Item {
 	current := NewItem()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_f)
-		core.AssignToken(current, token, F_f)
-	}
-	{
-		token := p.state.Consume(Token_KeywordGroup)
-		core.AssignToken(current, token, F__Basic_0)
-		if token != nil {
-			current.SetValue(token)
+		{
+			token := p.state.Consume(Keyword_f)
+			core.AssignToken(current, token, F_f)
+		}
+		{
+			token := p.state.Consume(Token_KeywordGroup)
+			core.AssignToken(current, token, F__Basic_0)
+			if token != nil {
+				current.SetValue(token)
+			}
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
@@ -230,14 +244,16 @@ func (p *Parser) ParseG() Item {
 	current := NewItem()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_g)
-		core.AssignToken(current, token, G_g)
-	}
-	{
-		token := p.state.Consume(Token_RegexGroup)
-		core.AssignToken(current, token, G__Basic_0)
-		if token != nil {
-			current.SetValue(token)
+		{
+			token := p.state.Consume(Keyword_g)
+			core.AssignToken(current, token, G_g)
+		}
+		{
+			token := p.state.Consume(Token_RegexGroup)
+			core.AssignToken(current, token, G__Basic_0)
+			if token != nil {
+				current.SetValue(token)
+			}
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
@@ -248,36 +264,38 @@ func (p *Parser) ParseH() Item {
 	current := NewItem()
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
-		token := p.state.Consume(Keyword_h)
-		core.AssignToken(current, token, H_h)
-	}
-	switch prediction, failure := p.lookahead.HAlternatives(p.state); prediction {
-	case 0:
 		{
-			token := p.state.Consume(Token_Identifier)
-			core.AssignToken(current, token, H__Basic_0)
+			token := p.state.Consume(Keyword_h)
+			core.AssignToken(current, token, H_h)
 		}
-		{
-			token := p.state.Consume(Keyword_a)
-			core.AssignToken(current, token, H_Value_a)
-			if token != nil {
-				current.SetValue(token)
+		switch prediction, failure := p.lookahead.HAlternatives(p.state); prediction {
+		case 0:
+			{
+				token := p.state.Consume(Token_Identifier)
+				core.AssignToken(current, token, H__Basic_0)
 			}
-		}
-	case 1:
-		{
-			token := p.state.Consume(Token_Identifier)
-			core.AssignToken(current, token, H__Basic_2)
-		}
-		{
-			token := p.state.Consume(Keyword_b)
-			core.AssignToken(current, token, H_Value_b)
-			if token != nil {
-				current.SetValue(token)
+			{
+				token := p.state.Consume(Keyword_a)
+				core.AssignToken(current, token, H_Value_a)
+				if token != nil {
+					current.SetValue(token)
+				}
 			}
+		case 1:
+			{
+				token := p.state.Consume(Token_Identifier)
+				core.AssignToken(current, token, H__Basic_2)
+			}
+			{
+				token := p.state.Consume(Keyword_b)
+				core.AssignToken(current, token, H_Value_b)
+				if token != nil {
+					current.SetValue(token)
+				}
+			}
+		default:
+			p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 		}
-	default:
-		p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
 	return current

--- a/internal/languages/token_groups/types_gen.go
+++ b/internal/languages/token_groups/types_gen.go
@@ -211,3 +211,9 @@ func (i *RecoveryImpl) ForEachReference(fn func(core.UntypedReference)) {
 	i.ItemData.ForEachReference(fn)
 	i.RecoveryData.ForEachReference(fn)
 }
+
+var TokenGroupsSyntheticFactories = map[string]func() core.AstNode{
+	"Item":     func() core.AstNode { return NewItem() },
+	"Model":    func() core.AstNode { return NewModel() },
+	"Recovery": func() core.AstNode { return NewRecovery() },
+}

--- a/internal/vscode-extensions/arithmetics/package.json
+++ b/internal/vscode-extensions/arithmetics/package.json
@@ -42,7 +42,7 @@
     "watch:tsc": "tsc --noEmit --watch",
     "vscode:prepublish": "npm run check-types && node esbuild.js --production",
     "check-types": "tsc --noEmit",
-    "build-server": "go build -o dist/server ../../../examples/arithmetics/server"
+    "build-server": "go build -o dist/ ../../../examples/arithmetics/server"
   },
   "dependencies": {
     "vscode-languageclient": "~9.0.1"

--- a/server/completion_provider.go
+++ b/server/completion_provider.go
@@ -475,7 +475,7 @@ func buildSyntheticOwnerChain(adapter parser.LanguageCompletionAdapter, doc *cor
 // completion request then yields no candidates for this hint rather than
 // silently returning the wrong scope.
 func buildSyntheticOwnerChainFor(adapter parser.LanguageCompletionAdapter, doc *core.Document, ruleStack []parser.RuleContext, hintField string, cursorOffset int) core.AstNode {
-	ownerRule, _, ok := splitHintField(hintField)
+	ownerType, _, ok := splitHintField(hintField)
 	if !ok {
 		return buildSyntheticOwnerChain(adapter, doc, ruleStack)
 	}
@@ -484,7 +484,7 @@ func buildSyntheticOwnerChainFor(adapter parser.LanguageCompletionAdapter, doc *
 	// the cursor already carries the chain a scope provider needs -
 	// reusing it avoids resynthesising state the parser tracked
 	// correctly.
-	if real := findExistingOwnerAtCursor(adapter, doc, ownerRule, cursorOffset); real != nil {
+	if real := findExistingOwnerAtCursor(adapter, doc, ownerType, cursorOffset); real != nil {
 		return real
 	}
 	// If the owner rule appears anywhere on the stack, the parser is
@@ -495,7 +495,7 @@ func buildSyntheticOwnerChainFor(adapter parser.LanguageCompletionAdapter, doc *
 	// reference) sits one frame higher. Searching from the top down
 	// picks the innermost matching frame.
 	for i := len(ruleStack) - 1; i >= 0; i-- {
-		if ruleStack[i].RuleKey == ownerRule {
+		if ruleStack[i].RuleKey == ownerType {
 			return buildSyntheticOwnerChain(adapter, doc, ruleStack[:i+1])
 		}
 	}
@@ -505,7 +505,7 @@ func buildSyntheticOwnerChainFor(adapter parser.LanguageCompletionAdapter, doc *
 	// dispatch on.
 	extended := make([]parser.RuleContext, 0, len(ruleStack)+1)
 	extended = append(extended, ruleStack...)
-	extended = append(extended, parser.RuleContext{RuleKey: ownerRule})
+	extended = append(extended, parser.RuleContext{RuleKey: ownerType})
 	return buildSyntheticOwnerChain(adapter, doc, extended)
 }
 
@@ -543,7 +543,7 @@ func applyPrecedingAction(adapter parser.LanguageCompletionAdapter, owner core.A
 	return wrapper
 }
 
-// findExistingOwnerAtCursor returns the AST node of the hint's owner-rule
+// findExistingOwnerAtCursor returns the AST node of the hint's owner-ast
 // type that is closest to (and contains) the cursor, by walking up from
 // the owner of the token immediately preceding the cursor. Returns nil
 // if no such node exists - typically because the cursor is at a position


### PR DESCRIPTION
Takes a tiny part of https://github.com/TypeFox/fastbelt/pull/98 to fix the completion after executing an action. Previously, synthetic objects had the wrong type after an action. That's because they used the Rule type name, instead of the actual computed interface name - which differs after actions.

Because of a minor parser generator issue if actions appear right at the start of the rule, I had to re-generate all parsers. This makes up 99% of the changes of this PR :)

The actual test for this is in the `TestCompletion_AfterO_ActionCrossRef` test.