### PR TITLE
Properly expect EOF after parser exits

### DIFF
--- a/examples/arithmetics/parser_gen.go
+++ b/examples/arithmetics/parser_gen.go
@@ -22,6 +22,7 @@ func (p *Parser) Parse(document *core.Document) *parser.ParseResult {
 	lookahead := service.MustGet[ArithmeticsParserLookahead](p.sc)
 	cp := &Parser{sc: p.sc, referencesConstructor: referencesConstructor, lookahead: lookahead, state: parser.NewParserState(document.Tokens, ATN(), recovery, messages)}
 	result := cp.ParseModule()
+	cp.state.ExpectEndOfInput()
 	core.AssignContainers(document, result)
 	return &parser.ParseResult{Node: result, Errors: cp.state.Errors()}
 }

--- a/examples/statemachine/parser_gen.go
+++ b/examples/statemachine/parser_gen.go
@@ -22,6 +22,7 @@ func (p *Parser) Parse(document *core.Document) *parser.ParseResult {
 	lookahead := service.MustGet[StatemachineModelParserLookahead](p.sc)
 	cp := &Parser{sc: p.sc, referencesConstructor: referencesConstructor, lookahead: lookahead, state: parser.NewParserState(document.Tokens, ATN(), recovery, messages)}
 	result := cp.ParseStatemachine()
+	cp.state.ExpectEndOfInput()
 	core.AssignContainers(document, result)
 	return &parser.ParseResult{Node: result, Errors: cp.state.Errors()}
 }

--- a/internal/generator/parser_generator.go
+++ b/internal/generator/parser_generator.go
@@ -416,6 +416,7 @@ func GenerateParser(grammr grammar.Grammar, packageName string, tokenTypes Gener
 		n.AppendLine("lookahead := service.MustGet[", grammr.Name(), "ParserLookahead](p.sc)")
 		n.AppendLine("cp := &Parser{sc: p.sc, referencesConstructor: referencesConstructor, lookahead: lookahead, state: parser.NewParserState(document.Tokens, ATN(), recovery, messages)}")
 		n.AppendLine("result := cp.Parse", firstRule.Name(), "()")
+		n.AppendLine("cp.state.ExpectEndOfInput()")
 		n.AppendLine("core.AssignContainers(document, result)")
 		n.AppendLine("return &parser.ParseResult{Node: result, Errors: cp.state.Errors()}")
 	})

--- a/internal/grammar/parser_gen.go
+++ b/internal/grammar/parser_gen.go
@@ -22,6 +22,7 @@ func (p *Parser) Parse(document *core.Document) *parser.ParseResult {
 	lookahead := service.MustGet[FastbeltParserLookahead](p.sc)
 	cp := &Parser{sc: p.sc, referencesConstructor: referencesConstructor, lookahead: lookahead, state: parser.NewParserState(document.Tokens, ATN(), recovery, messages)}
 	result := cp.ParseGrammar()
+	cp.state.ExpectEndOfInput()
 	core.AssignContainers(document, result)
 	return &parser.ParseResult{Node: result, Errors: cp.state.Errors()}
 }

--- a/internal/languages/completion/parser_gen.go
+++ b/internal/languages/completion/parser_gen.go
@@ -22,6 +22,7 @@ func (p *Parser) Parse(document *core.Document) *parser.ParseResult {
 	lookahead := service.MustGet[CompletionParserLookahead](p.sc)
 	cp := &Parser{sc: p.sc, referencesConstructor: referencesConstructor, lookahead: lookahead, state: parser.NewParserState(document.Tokens, ATN(), recovery, messages)}
 	result := cp.ParseRoot()
+	cp.state.ExpectEndOfInput()
 	core.AssignContainers(document, result)
 	return &parser.ParseResult{Node: result, Errors: cp.state.Errors()}
 }

--- a/internal/languages/lookahead/parser_gen.go
+++ b/internal/languages/lookahead/parser_gen.go
@@ -22,6 +22,7 @@ func (p *Parser) Parse(document *core.Document) *parser.ParseResult {
 	lookahead := service.MustGet[LookaheadParserLookahead](p.sc)
 	cp := &Parser{sc: p.sc, referencesConstructor: referencesConstructor, lookahead: lookahead, state: parser.NewParserState(document.Tokens, ATN(), recovery, messages)}
 	result := cp.ParseRoot()
+	cp.state.ExpectEndOfInput()
 	core.AssignContainers(document, result)
 	return &parser.ParseResult{Node: result, Errors: cp.state.Errors()}
 }

--- a/internal/languages/lookahead/parser_test.go
+++ b/internal/languages/lookahead/parser_test.go
@@ -150,6 +150,16 @@ func TestEBothValueLookahead(t *testing.T) {
 	expectValue(t, doc, "hello")
 }
 
+func TestErrorTokenAfterExpectedEOF(t *testing.T) {
+	sc := CreateServices()
+	doc := test.New(t, sc).Parse("e hello world someExtraToken otherExtraToken")
+	// Only expect one error, because the extra token report should only flag
+	// the first unexpected token after the parser exits
+	require.Len(t, doc.Document.ParserErrors, 1)
+	first := doc.Document.ParserErrors[0]
+	assert.Equal(t, "Expected end of input, but found 'someExtraToken'.", first.Msg)
+}
+
 func TestFUnlimitedLookaheadPositiveHello(t *testing.T) {
 	sc := CreateServices()
 	doc := test.New(t, sc).Parse("f A B C D E F G hello")

--- a/internal/languages/token_groups/parser_gen.go
+++ b/internal/languages/token_groups/parser_gen.go
@@ -22,6 +22,7 @@ func (p *Parser) Parse(document *core.Document) *parser.ParseResult {
 	lookahead := service.MustGet[TokenGroupsParserLookahead](p.sc)
 	cp := &Parser{sc: p.sc, referencesConstructor: referencesConstructor, lookahead: lookahead, state: parser.NewParserState(document.Tokens, ATN(), recovery, messages)}
 	result := cp.ParseModel()
+	cp.state.ExpectEndOfInput()
 	core.AssignContainers(document, result)
 	return &parser.ParseResult{Node: result, Errors: cp.state.Errors()}
 }

--- a/parser/error_messages.go
+++ b/parser/error_messages.go
@@ -17,6 +17,9 @@ type ErrorMessageProvider interface {
 	// UnexpectedEndOfInput is used when the parser needs another token but
 	// the token stream is already exhausted.
 	UnexpectedEndOfInput(expected *core.TokenType) string
+	// ExpectedEndOfInput is used when the parser has already exited, but
+	// the token stream still has more tokens.
+	ExpectedEndOfInput(found *core.Token) string
 	// UnexpectedToken is used when the current token does not match what the
 	// parser expected and recovery decided not to synthesise or skip a token.
 	UnexpectedToken(found *core.Token) string
@@ -43,6 +46,10 @@ func NewDefaultErrorMessageProvider() DefaultErrorMessageProvider {
 
 func (DefaultErrorMessageProvider) UnexpectedEndOfInput(expected *core.TokenType) string {
 	return "Unexpected end of input, expected '" + expected.Name + "'."
+}
+
+func (DefaultErrorMessageProvider) ExpectedEndOfInput(found *core.Token) string {
+	return "Expected end of input, but found '" + tokenImage(found) + "'."
 }
 
 func (DefaultErrorMessageProvider) UnexpectedToken(found *core.Token) string {

--- a/parser/error_recovery.go
+++ b/parser/error_recovery.go
@@ -41,13 +41,13 @@ func NewBailErrorRecovery() BailErrorRecovery {
 
 func (DefaultErrorRecovery) RecoverInline(parserState *ParserState, expectedTokenType *core.TokenType) (*core.Token, bool) {
 	la1 := parserState.LA(1)
-	if la1 == nil {
-		parserState.AppendError(parserState.messages.UnexpectedEndOfInput(expectedTokenType), nil)
+	if la1.Type == core.EOF {
+		parserState.AppendError(parserState.messages.UnexpectedEndOfInput(expectedTokenType), la1)
 		return nil, false
 	}
 	la2 := parserState.LA(2)
 	// Single-token deletion: if the next-next token matches, skip the current one.
-	if la2 != nil && expectedTokenType.Matches(la2.Type) {
+	if expectedTokenType.Matches(la2.Type) {
 		parserState.ReportError(parserState.messages.ExtraneousInput(la1), la1)
 		// Skip the bad token and return the next one as if it were a match.
 		parserState.Index += 2

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -91,6 +91,20 @@ func (p *ParserState) ReportError(msg string, token *core.Token) {
 	p.errors = append(p.errors, core.NewParserError(msg, token))
 }
 
+// ExpectEndOfInput reports an error if the parser has exited before consuming
+// all tokens. This is called after the top-level rule has returned.
+func (p *ParserState) ExpectEndOfInput() {
+	if p.ErrorRecoveryMode {
+		// If we're already in error-recovery mode, don't report another error.
+		return
+	}
+	nextToken := p.LA(1)
+	if nextToken.Type != core.EOF {
+		// Parser has already exited, but the next token is not EOF.
+		p.ReportError(p.messages.ExpectedEndOfInput(nextToken), nextToken)
+	}
+}
+
 // ReportMatch exits error-recovery mode after a token has been successfully
 // matched (either directly or via inline recovery).
 func (p *ParserState) ReportMatch() {
@@ -153,29 +167,6 @@ func (p *ParserState) Consume(tokenType *core.TokenType) *core.Token {
 	p.ReportMatch()
 	p.Index++
 	return current
-}
-
-type ParserLookahead interface {
-	PredictionMode() PredictionMode
-	SetPredictionMode(mode PredictionMode)
-}
-
-type DefaultParserLookahead struct {
-	predictionMode PredictionMode
-}
-
-// PredictionMode returns the current prediction mode. See [PredictionMode] for more details.
-func (l *DefaultParserLookahead) PredictionMode() PredictionMode {
-	return l.predictionMode
-}
-
-// SetPredictionMode sets the prediction mode. See [PredictionMode] for more details.
-// Setting the mode will affect all adaptive lookahead decisions performed by the parser.
-// When switching to [PredictionModeLL], it might be beneficial to override the languages'
-// parser lookahead service with a custom implementation that only applies this mode to certain
-// decisions, to avoid the performance cost of full-context prediction where it is not needed.
-func (l *DefaultParserLookahead) SetPredictionMode(mode PredictionMode) {
-	l.predictionMode = mode
 }
 
 // PredictionFailure describes why an alternatives decision could not be
@@ -275,4 +266,33 @@ func (p *ParserState) FollowSet() *collections.BitSet {
 		sets[i] = p.atn.NextTokensAt(idx)
 	}
 	return collections.MergeBitSets(sets)
+}
+
+// Base interface for all generated parser lookahead services.
+// It allows the parser to query and set the prediction mode.
+type ParserLookahead interface {
+	// PredictionMode returns the current prediction mode. See [PredictionMode] for more details.
+	PredictionMode() PredictionMode
+	// SetPredictionMode sets the general prediction mode. See [PredictionMode] for more details.
+	// Setting the mode will affect all adaptive lookahead decisions performed by the parser.
+	// When switching to [PredictionModeLL], it might be beneficial to override the languages'
+	// parser lookahead service with a custom implementation that only applies this mode to certain
+	// decisions, to avoid the performance cost of full-context prediction where it is not needed.
+	SetPredictionMode(mode PredictionMode)
+}
+
+// DefaultParserLookahead is the default implementation of [ParserLookahead].
+// It is embedded in all generated default parser lookahead services.
+type DefaultParserLookahead struct {
+	predictionMode PredictionMode
+}
+
+// PredictionMode returns the current prediction mode. See [PredictionMode] for more details.
+func (l *DefaultParserLookahead) PredictionMode() PredictionMode {
+	return l.predictionMode
+}
+
+// SetPredictionMode sets the general prediction mode. See [PredictionMode] for more details.
+func (l *DefaultParserLookahead) SetPredictionMode(mode PredictionMode) {
+	l.predictionMode = mode
 }


### PR DESCRIPTION
While we are perfectly capable of telling whether an input is too short (because parsing it fails), we're currently too lenient when an input is "too long" (i.e. the parser has already exited, but there are more tokens available).

This change addresses this by adding a dedicated `ExpectEndOfInput` method to the parser state, which generates an error on the first extra token it sees after the parser exits.