### PR TITLE
Grammar improvements: validations, optional semicolons, entry rules

### DIFF
--- a/cmd/fastbelt/generate.go
+++ b/cmd/fastbelt/generate.go
@@ -106,7 +106,8 @@ func runGenerateCLI(opts generateOptions) error {
 	if !ok {
 		return fmt.Errorf("parser result is not a Grammar")
 	}
-	if err := validateEntryRule(grammar); err != nil {
+	entryRule, err := validateEntryRule(grammar)
+	if err != nil {
 		return err
 	}
 
@@ -131,11 +132,11 @@ func runGenerateCLI(opts generateOptions) error {
 	tokenTypes := generator.GenerateTokenTypes(grammar)
 	atnData := generator.BuildParserATNData(grammar, tokenTypes)
 	if err := writeFile("parser", filepath.Join(outputPath, "parser_gen.go"),
-		generator.GenerateParser(grammar, packageName, tokenTypes, atnData)); err != nil {
+		generator.GenerateParser(grammar, entryRule, packageName, tokenTypes, atnData)); err != nil {
 		return err
 	}
 	if err := writeFile("completion-parser", filepath.Join(outputPath, "completion_parser_gen.go"),
-		generator.GenerateCompletionParser(grammar, packageName, tokenTypes, atnData)); err != nil {
+		generator.GenerateCompletionParser(grammar, entryRule, packageName, tokenTypes, atnData)); err != nil {
 		return err
 	}
 	if err := writeFile("parser-lookahead", filepath.Join(outputPath, "parser_lookahead_gen.go"),
@@ -168,7 +169,7 @@ func runGenerateCLI(opts generateOptions) error {
 	return nil
 }
 
-func validateEntryRule(g grammar.Grammar) error {
+func validateEntryRule(g grammar.Grammar) (grammar.ParserRule, error) {
 	var entries []grammar.ParserRule
 	for _, rule := range g.Rules() {
 		if rule.IsEntry() {
@@ -177,15 +178,15 @@ func validateEntryRule(g grammar.Grammar) error {
 	}
 	switch len(entries) {
 	case 1:
-		return nil
+		return entries[0], nil
 	case 0:
-		return fmt.Errorf("grammar must have exactly one parser rule marked as entry, but none were found")
+		return nil, fmt.Errorf("grammar must have exactly one parser rule marked as entry, but none were found")
 	default:
 		names := make([]string, len(entries))
 		for i, rule := range entries {
 			names[i] = rule.Name()
 		}
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
 			"grammar must have exactly one parser rule marked as entry, but found %d: %s",
 			len(entries),
 			strings.Join(names, ", "),

--- a/cmd/fastbelt/generate.go
+++ b/cmd/fastbelt/generate.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	core "typefox.dev/fastbelt"
 	"typefox.dev/fastbelt/internal/generator"
@@ -105,6 +106,9 @@ func runGenerateCLI(opts generateOptions) error {
 	if !ok {
 		return fmt.Errorf("parser result is not a Grammar")
 	}
+	if err := validateEntryRule(grammar); err != nil {
+		return err
+	}
 
 	writeFile := func(name, path, content string) error {
 		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
@@ -162,4 +166,29 @@ func runGenerateCLI(opts generateOptions) error {
 	}
 
 	return nil
+}
+
+func validateEntryRule(g grammar.Grammar) error {
+	var entries []grammar.ParserRule
+	for _, rule := range g.Rules() {
+		if rule.IsEntry() {
+			entries = append(entries, rule)
+		}
+	}
+	switch len(entries) {
+	case 1:
+		return nil
+	case 0:
+		return fmt.Errorf("grammar must have exactly one parser rule marked as entry, but none were found")
+	default:
+		names := make([]string, len(entries))
+		for i, rule := range entries {
+			names[i] = rule.Name()
+		}
+		return fmt.Errorf(
+			"grammar must have exactly one parser rule marked as entry, but found %d: %s",
+			len(entries),
+			strings.Join(names, ", "),
+		)
+	}
 }

--- a/examples/arithmetics/arithmetics.fb
+++ b/examples/arithmetics/arithmetics.fb
@@ -1,4 +1,4 @@
-grammar Arithmetics;
+grammar Arithmetics
 
 interface Module {
     Name string

--- a/examples/arithmetics/arithmetics.fb
+++ b/examples/arithmetics/arithmetics.fb
@@ -42,44 +42,44 @@ interface NumberLiteral extends Expression {
 
 Module returns Module:
     "module" Name=ID
-    Statements+=Statement*;
+    Statements+=Statement*
 
 Statement returns Statement:
-    Definition | Evaluation;
+    Definition | Evaluation
 
 Definition:
     "def" Name=ID ("(" Args+=DeclaredParameter ("," Args+=DeclaredParameter)* ")")?
-    ":" Expression=Expression ";";
+    ":" Expression=Expression ";"
 
 DeclaredParameter:
-    Name=ID;
+    Name=ID
 
 Evaluation:
-    Expression=Expression ";";
+    Expression=Expression ";"
 
 Expression:
-    Addition;
+    Addition
 
 Addition returns Expression:
-    Multiplication ({BinaryExpression.Left=current} Operator=("+" | "-") Right=Multiplication)*;
+    Multiplication ({BinaryExpression.Left=current} Operator=("+" | "-") Right=Multiplication)*
 
 Multiplication returns Expression:
-    Exponentiation ({BinaryExpression.Left=current} Operator=("*" | "/") Right=Exponentiation)*;
+    Exponentiation ({BinaryExpression.Left=current} Operator=("*" | "/") Right=Exponentiation)*
 
 Exponentiation returns Expression:
-    Modulo ({BinaryExpression.Left=current} Operator="^" Right=Modulo)*;
+    Modulo ({BinaryExpression.Left=current} Operator="^" Right=Modulo)*
 
 Modulo returns Expression:
-    PrimaryExpression ({BinaryExpression.Left=current} Operator="%" Right=PrimaryExpression)*;
+    PrimaryExpression ({BinaryExpression.Left=current} Operator="%" Right=PrimaryExpression)*
 
 PrimaryExpression returns Expression:
     "(" Expression ")" |
     { NumberLiteral } Value=NUMBER |
-    {FunctionCall} Callable=[AbstractDefinition:ID] ("(" Args+=Expression ("," Args+=Expression)* ")")?;
+    {FunctionCall} Callable=[AbstractDefinition:ID] ("(" Args+=Expression ("," Args+=Expression)* ")")?
 
-token ID: /[_a-zA-Z][\w_]*/;
-token NUMBER: /[0-9]+(\.[0-9]*)?/;
+token ID: /[_a-zA-Z][\w_]*/
+token NUMBER: /[0-9]+(\.[0-9]*)?/
 
-hidden token WS: /\s+/;
-comment token ML_COMMENT: /\/\*[\s\S]*?\*\//;
-hidden token SL_COMMENT: /\/\/[^\n\r]*/;
+hidden token WS: /\s+/
+comment token ML_COMMENT: /\/\*[\s\S]*?\*\//
+hidden token SL_COMMENT: /\/\/[^\n\r]*/

--- a/examples/arithmetics/arithmetics.fb
+++ b/examples/arithmetics/arithmetics.fb
@@ -40,7 +40,7 @@ interface NumberLiteral extends Expression {
     Value string
 }
 
-Module returns Module:
+entry Module returns Module:
     "module" Name=ID
     Statements+=Statement*
 
@@ -74,7 +74,7 @@ Modulo returns Expression:
 
 PrimaryExpression returns Expression:
     "(" Expression ")" |
-    { NumberLiteral } Value=NUMBER |
+    {NumberLiteral} Value=NUMBER |
     {FunctionCall} Callable=[AbstractDefinition:ID] ("(" Args+=Expression ("," Args+=Expression)* ")")?
 
 token ID: /[_a-zA-Z][\w_]*/

--- a/examples/statemachine/statemachine.fb
+++ b/examples/statemachine/statemachine.fb
@@ -54,8 +54,8 @@ Transition returns Transition:
     Event=[Event:ID] "=>"
     State=[State:ID]
 
-token ID: /[_a-zA-Z][\w_]*/;
+token ID: /[_a-zA-Z][\w_]*/
 
-hidden token WS: /\s+/;
-comment token ML_COMMENT: /\/\*[\s\S]*?\*\//;
-comment token SL_COMMENT: /\/\/[^\n\r]*/;
+hidden token WS: /\s+/
+comment token ML_COMMENT: /\/\*[\s\S]*?\*\//
+comment token SL_COMMENT: /\/\/[^\n\r]*/

--- a/examples/statemachine/statemachine.fb
+++ b/examples/statemachine/statemachine.fb
@@ -1,4 +1,4 @@
-grammar StatemachineModel;
+grammar StatemachineModel
 
 interface Statemachine {
     Name string
@@ -17,21 +17,21 @@ Statemachine returns Statemachine:
       Commands+=Command+)?
     "initialState"
     Init=[State:ID]
-    States+=State*;
+    States+=State*
 
 interface Event {
     Name string
 }
 
 Event returns Event:
-    Name=ID;
+    Name=ID
 
 interface Command {
     Name string
 }
 
 Command returns Command:
-    Name=ID;
+    Name=ID
 
 interface State {
     Name string
@@ -43,7 +43,7 @@ State returns State:
     "state" Name=ID
         ("actions" "{" Actions+=[Command:ID]+ "}")?
         Transitions+=Transition*
-    "end";
+    "end"
 
 interface Transition {
     Event *Event
@@ -52,7 +52,7 @@ interface Transition {
 
 Transition returns Transition:
     Event=[Event:ID] "=>"
-    State=[State:ID];
+    State=[State:ID]
 
 token ID: /[_a-zA-Z][\w_]*/;
 

--- a/examples/statemachine/statemachine.fb
+++ b/examples/statemachine/statemachine.fb
@@ -8,7 +8,7 @@ interface Statemachine {
     States []State
 }
 
-Statemachine returns Statemachine:
+entry Statemachine returns Statemachine:
     "statemachine"
     Name=ID
     ("events"

--- a/grammar/doc.go
+++ b/grammar/doc.go
@@ -12,12 +12,14 @@
 // See [typefox.dev/fastbelt] for the toolchain overview and the
 // [typefox.dev/fastbelt/cmd/fastbelt] command for code generation.
 //
+// Semicolons are optional at the end of each statement and can generally
+// be omitted.
+//
 // # Language Declaration
 //
-// Every grammar file begins with the grammar keyword, the language name,
-// and a semicolon:
+// Every grammar file begins with the grammar keyword and the language name.
 //
-//	grammar MyLanguage;
+//	grammar MyLanguage
 //
 // The name is used by Fastbelt when naming the generated package and
 // language server.
@@ -107,8 +109,8 @@
 // assigns it a name. Token rule names are conventionally written in upper
 // case:
 //
-//	token ID:  /[_a-zA-Z][\w_]*/;
-//	token INT: /[0-9]+/;
+//	token ID:  /[_a-zA-Z][\w_]*/
+//	token INT: /[0-9]+/
 //
 // The lexer returns the first, longest match. If multiple token rules
 // match the same text with equal length, the token rule declared first wins.
@@ -119,9 +121,9 @@
 // Tokens that should be silently consumed — whitespace, comments — are
 // declared with the hidden modifier:
 //
-//	hidden token WS:         /\s+/;
-//	hidden token ML_COMMENT: /\/\*[\s\S]*?\*\//;
-//	hidden token SL_COMMENT: /\/\/[^\r\n]*/;
+//	hidden token WS:         /\s+/
+//	hidden token ML_COMMENT: /\/\*[\s\S]*?\*\//
+//	hidden token SL_COMMENT: /\/\/[^\r\n]*/
 //
 // Hidden tokens are global and apply to the entire grammar. They may
 // appear anywhere without interrupting assignment groups.
@@ -131,7 +133,7 @@
 // Documentation comments attached to the grammar element that follows them
 // are declared with the comment modifier:
 //
-//	comment token SL_COMMENT: /\/\/[^\r\n]*/;
+//	comment token SL_COMMENT: /\/\/[^\r\n]*/
 //
 // Parsed comment tokens are stored in the document's `Comments []Token`
 // slice, where tooling can access them.
@@ -145,14 +147,14 @@
 //	token group Operator { "+" "-" "*" "/" }
 //
 //	Expr:
-//	    Left=INT Op=Operator Right=INT;
+//	    Left=INT Op=Operator Right=INT
 //
 // A token group may contain token rule names, double-quoted keywords, and
 // other token group names. Keywords inside a group are matched the same way as
 // keywords anywhere else in the grammar:
 //
-//	token ID:  /[_a-zA-Z][\w]*/;
-//	token INT: /[0-9]+/;
+//	token ID:  /[_a-zA-Z][\w]*/
+//	token INT: /[0-9]+/
 //
 //	token group Literal { ID INT "null" "true" "false" }
 //
@@ -173,7 +175,7 @@
 // problem of parsing keywords as identifiers:
 //
 //	token group Identifier { ID keywords /^\w+$/ }
-//	NamedElement: Name=Identifier;
+//	NamedElement: Name=Identifier
 //
 // Two constraints apply: hidden and comment tokens may not appear inside a
 // group, and token groups must not be recursive (directly or transitively).
@@ -185,13 +187,19 @@
 // is the entry rule: the starting point of the parse.
 //
 // A parser rule starts with its name, an optional returns clause naming the
-// interface type it creates, a colon, the rule body, and a semicolon:
+// interface type it creates, a colon, and the rule body:
 //
 //	Person returns Person:
-//	    "person" Name=ID;
+//	    "person" Name=ID
 //
 // When the rule name matches a declared interface the returns clause may be
 // omitted and Fastbelt resolves the type by name.
+//
+// A parser rule that is used as entry rule for a language must be marked
+// with the entry modifier:
+//
+//	entry PersonModel:
+//	    Persons+=Person*
 //
 // # Cardinalities
 //
@@ -207,14 +215,14 @@
 // Elements in sequence form a group and must appear in the declared order:
 //
 //	Person returns Person:
-//	    "person" Name=ID Address=Address;
+//	    "person" Name=ID Address=Address
 //
 // Parentheses create a sub-group that can carry its own cardinality:
 //
 //	State returns State:
 //	    "state" Name=ID
 //	        ("actions" "{" Actions+=[Command:ID]+ "}")?
-//	    "end";
+//	    "end"
 //
 // # Alternatives
 //
@@ -222,7 +230,7 @@
 // parentheses can carry a cardinality:
 //
 //	Model returns Model:
-//	    (Persons+=Person | Greetings+=Greeting)*;
+//	    (Persons+=Person | Greetings+=Greeting)*
 //
 // # Keywords
 //
@@ -230,7 +238,7 @@
 // and provide visible structure to the language. They must not be empty:
 //
 //	Person returns Person:
-//	    "person" Name=ID "age" Age=INT;
+//	    "person" Name=ID "age" Age=INT
 //
 // Keywords help the parser disambiguate between alternatives that would
 // otherwise be identical:
@@ -239,13 +247,13 @@
 //	interface Teacher { Name string }
 //
 //	Student returns Student:
-//	    "student" Name=ID;
+//	    "student" Name=ID
 //
 //	Teacher returns Teacher:
-//	    "teacher" Name=ID;
+//	    "teacher" Name=ID
 //
 //	Person:
-//	    Student | Teacher;
+//	    Student | Teacher
 //
 // Without the "student" and "teacher" keywords the grammar would be
 // ambiguous and the parser could not distinguish the two rules.
@@ -259,18 +267,18 @@
 // Single-value assignment (=) stores one parsed value in the field:
 //
 //	Person returns Person:
-//	    "person" Name=ID;
+//	    "person" Name=ID
 //
 // Array assignment (+=) appends each matched value to a slice field:
 //
 //	Model returns Model:
-//	    Events+=Event*;
+//	    Events+=Event*
 //
 // Boolean assignment (?=) sets a bool field to true when the right side is
 // consumed; the field remains false otherwise:
 //
 //	Employee returns Employee:
-//	    "employee" Name=ID (Remote?="remote")?;
+//	    "employee" Name=ID (Remote?="remote")?
 //
 // Assignments with cardinality + or * form a contiguous group: the sequence
 // of matched values must not be interrupted by elements belonging to a
@@ -298,7 +306,7 @@
 //	}
 //
 //	Transition returns Transition:
-//	    Event=[Event:ID] "=>" State=[State:ID];
+//	    Event=[Event:ID] "=>" State=[State:ID]
 //
 // The linker resolves cross-references after parsing. If no object matching
 // the token value is found in scope, a diagnostic error is reported.
@@ -310,7 +318,7 @@
 // for producing the object:
 //
 //	AbstractDefinition:
-//	    Definition | DeclaredParameter;
+//	    Definition | DeclaredParameter
 //
 // The parser rule AbstractDefinition does not create an object of its own.
 // Instead it calls either Definition or DeclaredParameter, and whichever
@@ -335,7 +343,7 @@
 //	interface TypeTwo extends TypeOne {}
 //
 //	RuleOne returns TypeOne:
-//	    "one" Name=ID | {TypeTwo} "two" Name=ID;
+//	    "one" Name=ID | {TypeTwo} "two" Name=ID
 //
 // A tree-rewriting action creates a new object of the named type and assigns
 // the object built so far to one of its properties. This technique handles
@@ -343,7 +351,7 @@
 // current object is referred to by the keyword current:
 //
 //	Addition returns Expression:
-//	    SimpleExpr ({Addition.Left=current} "+" Right=SimpleExpr)*;
+//	    SimpleExpr ({Addition.Left=current} "+" Right=SimpleExpr)*
 //
 // When the "+" keyword is found, a new Addition object is created, the
 // object parsed so far is stored in its Left property, and that new Addition
@@ -360,7 +368,7 @@
 // Composite rules support keywords, rule calls, parenthesized alternatives,
 // and cardinalities, but not assignments or cross-references:
 //
-//	composite QualifiedName: ID ("." ID)*;
+//	composite QualifiedName: ID ("." ID)*
 //
 // Composite values can also be used to define object names and resolve
 // cross-references:
@@ -372,6 +380,6 @@
 //	    Item *Type
 //	}
 //
-//	Type: Name=QualifiedName;
-//	TypeRef: Item=[Type:QualifiedName];
+//	Type: Name=QualifiedName
+//	TypeRef: Item=[Type:QualifiedName]
 package grammar

--- a/internal/atn/atn_test.go
+++ b/internal/atn/atn_test.go
@@ -152,7 +152,7 @@ func TestThreePaths(t *testing.T) {
 
 func TestCompositeRuleRef(t *testing.T) {
 	atn, rules, tokenTypes := FixtureATN(t, `
-		interface Start { Name string }
+		interface Start { Name composite }
 		composite SimpleComposite: ID;
 		Start: Name=SimpleComposite;
 	`, false)
@@ -161,7 +161,7 @@ func TestCompositeRuleRef(t *testing.T) {
 
 func TestCompositeRuleWithAlternativesRef(t *testing.T) {
 	atn, rules, tokenTypes := FixtureATN(t, `
-		interface Start { Name string }
+		interface Start { Name composite }
 		composite IDOrNumber: ID | NUMBER;
 		Start: Name=IDOrNumber;
 	`, false)

--- a/internal/generator/parser_generator.go
+++ b/internal/generator/parser_generator.go
@@ -371,7 +371,7 @@ func decisionConstName(methodName string) string {
 	return "Decision" + methodName
 }
 
-func GenerateParser(grammr grammar.Grammar, packageName string, tokenTypes GenerateTokenTypesResult, atnData *parserATNData) string {
+func GenerateParser(grammr grammar.Grammar, entryRule grammar.ParserRule, packageName string, tokenTypes GenerateTokenTypesResult, atnData *parserATNData) string {
 	context := &ParserGeneratorContext{
 		grammar:      grammr,
 		lookaheads:   make(map[core.AstNode]LookaheadValue),
@@ -402,12 +402,6 @@ func GenerateParser(grammr grammar.Grammar, packageName string, tokenTypes Gener
 	node.AppendLine("}")
 	node.AppendLine()
 
-	rules := grammr.Rules()
-	if len(rules) == 0 {
-		return FormatIfPossible(node.String())
-	}
-
-	firstRule := rules[0]
 	node.AppendLine("func (p *Parser) Parse(document *core.Document) *parser.ParseResult {")
 	node.Indent(func(n codegen.Node) {
 		n.AppendLine("recovery := service.MustGet[parser.ErrorRecoveryStrategy](p.sc)")
@@ -415,7 +409,7 @@ func GenerateParser(grammr grammar.Grammar, packageName string, tokenTypes Gener
 		n.AppendLine("referencesConstructor := service.MustGet[", grammr.Name(), "ReferencesConstructor](p.sc)")
 		n.AppendLine("lookahead := service.MustGet[", grammr.Name(), "ParserLookahead](p.sc)")
 		n.AppendLine("cp := &Parser{sc: p.sc, referencesConstructor: referencesConstructor, lookahead: lookahead, state: parser.NewParserState(document.Tokens, ATN(), recovery, messages)}")
-		n.AppendLine("result := cp.Parse", firstRule.Name(), "()")
+		n.AppendLine("result := cp.Parse", entryRule.Name(), "()")
 		n.AppendLine("cp.state.ExpectEndOfInput()")
 		n.AppendLine("core.AssignContainers(document, result)")
 		n.AppendLine("return &parser.ParseResult{Node: result, Errors: cp.state.Errors()}")
@@ -448,7 +442,7 @@ func GenerateParser(grammr grammar.Grammar, packageName string, tokenTypes Gener
 //
 // The generated file reuses the lookahead tables and ATN builder defined by
 // GenerateParser/EmitGoSource, so it must be emitted into the same package.
-func GenerateCompletionParser(grammr grammar.Grammar, packageName string, tokenTypes GenerateTokenTypesResult, atnData *parserATNData) string {
+func GenerateCompletionParser(grammr grammar.Grammar, entryRule grammar.ParserRule, packageName string, tokenTypes GenerateTokenTypesResult, atnData *parserATNData) string {
 	context := &ParserGeneratorContext{
 		grammar:      grammr,
 		lookaheads:   make(map[core.AstNode]LookaheadValue),
@@ -482,12 +476,6 @@ func GenerateCompletionParser(grammr grammar.Grammar, packageName string, tokenT
 	node.AppendLine("}")
 	node.AppendLine()
 
-	rules := grammr.Rules()
-	if len(rules) == 0 {
-		return FormatIfPossible(node.String())
-	}
-	firstRule := rules[0]
-
 	node.AppendLine("func NewCompletionParser(sc *service.Container) *CompletionParser {")
 	node.Indent(func(n codegen.Node) {
 		n.AppendLine("return &CompletionParser{")
@@ -510,7 +498,7 @@ func GenerateCompletionParser(grammr grammar.Grammar, packageName string, tokenT
 		n.AppendLine("cp := &CompletionParser{sc: p.sc, atn: p.atn, lookahead: lookahead}")
 		n.AppendLine("cp.state = parser.NewParserState(tokens, p.atn(), recovery, messages)")
 		n.AppendLine("cp.cp = parser.NewCompletionParserState(cp.state)")
-		n.AppendLine("cp.Parse", firstRule.Name(), "()")
+		n.AppendLine("cp.Parse", entryRule.Name(), "()")
 		n.AppendLine("return cp.cp.Result(tokens)")
 	})
 	node.AppendLine("}")

--- a/internal/grammar/atn.md
+++ b/internal/grammar/atn.md
@@ -10,7 +10,7 @@ flowchart TD
     q53["Grammar_Name_ID (53)<br/>Basic<br/>"]
     q54["Grammar_Semicolon (54)<br/>Basic<br/>"]
     q55["Grammar__Basic_0 (55)<br/>Basic<br/>"]
-    q56["Grammar__Basic_1 (56)<br/>Basic<br/>"]
+    q56{"Grammar__Basic_1 (56)<br/>Basic<br/><br/>dec=0"}
     q57["Grammar__Basic_2 (57)<br/>Basic<br/>"]
     q58["Grammar__Basic_3 (58)<br/>Basic<br/>"]
     q59["Grammar__Basic_4 (59)<br/>Basic<br/>"]
@@ -19,36 +19,41 @@ flowchart TD
     q62["Grammar__Basic_7 (62)<br/>Basic<br/>"]
     q63["Grammar__Basic_8 (63)<br/>Basic<br/>"]
     q64["Grammar__Basic_9 (64)<br/>Basic<br/>"]
-    q65{"Grammar__Basic_10 (65)<br/>Basic<br/><br/>dec=0"}
-    q66["Grammar__BlockEnd (66)<br/>BlockEnd<br/>"]
-    q67{"Grammar__LoopEntry (67)<br/>LoopEntry<br/><br/>dec=1"}
-    q68["Grammar__LoopEnd (68)<br/>LoopEnd<br/>"]
-    q69["Grammar__LoopBack (69)<br/>LoopBack<br/>"]
+    q65["Grammar__Basic_10 (65)<br/>Basic<br/>"]
+    q66["Grammar__Basic_11 (66)<br/>Basic<br/>"]
+    q67{"Grammar__Basic_12 (67)<br/>Basic<br/><br/>dec=1"}
+    q68["Grammar__BlockEnd (68)<br/>BlockEnd<br/>"]
+    q69{"Grammar__LoopEntry (69)<br/>LoopEntry<br/><br/>dec=2"}
+    q70["Grammar__LoopEnd (70)<br/>LoopEnd<br/>"]
+    q71["Grammar__LoopBack (71)<br/>LoopBack<br/>"]
 
     q0 --> q52
     q52 -->|"tok(&quot;grammar&quot;)"| q53
-    q53 -->|"tok(ID)"| q54
-    q54 -->|"tok(&quot;;&quot;)"| q67
-    q55 -.->|"[ParserRule]"| q56
-    q56 --> q66
-    q57 -.->|"[Token]"| q58
-    q58 --> q66
-    q59 -.->|"[TokenGroup]"| q60
-    q60 --> q66
-    q61 -.->|"[Interface]"| q62
-    q62 --> q66
-    q63 -.->|"[CompositeRule]"| q64
-    q64 --> q66
-    q65 --> q55
-    q65 --> q57
-    q65 --> q59
-    q65 --> q61
-    q65 --> q63
-    q66 --> q69
+    q53 -->|"tok(ID)"| q56
+    q54 -->|"tok(&quot;;&quot;)"| q55
+    q55 --> q69
+    q56 --> q54
+    q56 --> q55
+    q57 -.->|"[ParserRule]"| q58
+    q58 --> q68
+    q59 -.->|"[Token]"| q60
+    q60 --> q68
+    q61 -.->|"[TokenGroup]"| q62
+    q62 --> q68
+    q63 -.->|"[Interface]"| q64
+    q64 --> q68
+    q65 -.->|"[CompositeRule]"| q66
+    q66 --> q68
+    q67 --> q57
+    q67 --> q59
+    q67 --> q61
+    q67 --> q63
     q67 --> q65
-    q67 --> q68
-    q68 --> q1
+    q68 --> q71
     q69 --> q67
+    q69 --> q70
+    q70 --> q1
+    q71 --> q69
 ```
 
 ## Interface
@@ -57,49 +62,49 @@ flowchart TD
 flowchart TD
     q2(["Interface__Start (2)<br/>RuleStart"])
     q3(["Interface__Stop (3)<br/>RuleStop"])
-    q70["Interface_interface (70)<br/>Basic<br/>"]
-    q71["Interface_Name_ID (71)<br/>Basic<br/>"]
-    q72["Interface_extends (72)<br/>Basic<br/>"]
-    q73["Interface_Extends_ID_0 (73)<br/>Basic<br/>"]
-    q74["Interface_Comma (74)<br/>Basic<br/>"]
-    q75["Interface_Extends_ID_1 (75)<br/>Basic<br/>"]
-    q76["Interface__Basic_0 (76)<br/>Basic<br/>"]
-    q77{"Interface__LoopEntry_0 (77)<br/>LoopEntry<br/><br/>dec=2"}
-    q78["Interface__LoopEnd_0 (78)<br/>LoopEnd<br/>"]
-    q79["Interface__LoopBack_0 (79)<br/>LoopBack<br/>"]
-    q80{"Interface__Basic_1 (80)<br/>Basic<br/><br/>dec=3"}
-    q81["Interface_LeftBrace (81)<br/>Basic<br/>"]
-    q82["Interface__Basic_2 (82)<br/>Basic<br/>"]
-    q83["Interface__Basic_3 (83)<br/>Basic<br/>"]
-    q84{"Interface__LoopEntry_1 (84)<br/>LoopEntry<br/><br/>dec=4"}
-    q85["Interface__LoopEnd_1 (85)<br/>LoopEnd<br/>"]
-    q86["Interface__LoopBack_1 (86)<br/>LoopBack<br/>"]
-    q87["Interface_RightBrace (87)<br/>Basic<br/>"]
-    q88["Interface__Basic_4 (88)<br/>Basic<br/>"]
+    q72["Interface_interface (72)<br/>Basic<br/>"]
+    q73["Interface_Name_ID (73)<br/>Basic<br/>"]
+    q74["Interface_extends (74)<br/>Basic<br/>"]
+    q75["Interface_Extends_ID_0 (75)<br/>Basic<br/>"]
+    q76["Interface_Comma (76)<br/>Basic<br/>"]
+    q77["Interface_Extends_ID_1 (77)<br/>Basic<br/>"]
+    q78["Interface__Basic_0 (78)<br/>Basic<br/>"]
+    q79{"Interface__LoopEntry_0 (79)<br/>LoopEntry<br/><br/>dec=3"}
+    q80["Interface__LoopEnd_0 (80)<br/>LoopEnd<br/>"]
+    q81["Interface__LoopBack_0 (81)<br/>LoopBack<br/>"]
+    q82{"Interface__Basic_1 (82)<br/>Basic<br/><br/>dec=4"}
+    q83["Interface_LeftBrace (83)<br/>Basic<br/>"]
+    q84["Interface__Basic_2 (84)<br/>Basic<br/>"]
+    q85["Interface__Basic_3 (85)<br/>Basic<br/>"]
+    q86{"Interface__LoopEntry_1 (86)<br/>LoopEntry<br/><br/>dec=5"}
+    q87["Interface__LoopEnd_1 (87)<br/>LoopEnd<br/>"]
+    q88["Interface__LoopBack_1 (88)<br/>LoopBack<br/>"]
+    q89["Interface_RightBrace (89)<br/>Basic<br/>"]
+    q90["Interface__Basic_4 (90)<br/>Basic<br/>"]
 
-    q2 --> q70
-    q70 -->|"tok(&quot;interface&quot;)"| q71
-    q71 -->|"tok(ID)"| q80
-    q72 -->|"tok(&quot;extends&quot;)"| q73
-    q73 -->|"tok(ID)"| q77
-    q74 -->|"tok(&quot;,&quot;)"| q75
-    q75 -->|"tok(ID)"| q76
-    q76 --> q79
-    q77 --> q74
-    q77 --> q78
+    q2 --> q72
+    q72 -->|"tok(&quot;interface&quot;)"| q73
+    q73 -->|"tok(ID)"| q82
+    q74 -->|"tok(&quot;extends&quot;)"| q75
+    q75 -->|"tok(ID)"| q79
+    q76 -->|"tok(&quot;,&quot;)"| q77
+    q77 -->|"tok(ID)"| q78
     q78 --> q81
-    q79 --> q77
-    q80 --> q72
-    q80 --> q78
-    q81 -->|"tok(&quot;{&quot;)"| q84
-    q82 -.->|"[Field]"| q83
-    q83 --> q86
-    q84 --> q82
-    q84 --> q85
-    q85 --> q87
+    q79 --> q76
+    q79 --> q80
+    q80 --> q83
+    q81 --> q79
+    q82 --> q74
+    q82 --> q80
+    q83 -->|"tok(&quot;{&quot;)"| q86
+    q84 -.->|"[Field]"| q85
+    q85 --> q88
     q86 --> q84
-    q87 -->|"tok(&quot;}&quot;)"| q88
-    q88 --> q3
+    q86 --> q87
+    q87 --> q89
+    q88 --> q86
+    q89 -->|"tok(&quot;}&quot;)"| q90
+    q90 --> q3
 ```
 
 ## Field
@@ -108,14 +113,14 @@ flowchart TD
 flowchart TD
     q4(["Field__Start (4)<br/>RuleStart"])
     q5(["Field__Stop (5)<br/>RuleStop"])
-    q89["Field_Name_ID (89)<br/>Basic<br/>"]
-    q90["Field__Basic_0 (90)<br/>Basic<br/>"]
-    q91["Field__Basic_1 (91)<br/>Basic<br/>"]
+    q91["Field_Name_ID (91)<br/>Basic<br/>"]
+    q92["Field__Basic_0 (92)<br/>Basic<br/>"]
+    q93["Field__Basic_1 (93)<br/>Basic<br/>"]
 
-    q4 --> q89
-    q89 -->|"tok(ID)"| q90
-    q90 -.->|"[FieldType]"| q91
-    q91 --> q5
+    q4 --> q91
+    q91 -->|"tok(ID)"| q92
+    q92 -.->|"[FieldType]"| q93
+    q93 --> q5
 ```
 
 ## FieldType
@@ -124,31 +129,31 @@ flowchart TD
 flowchart TD
     q6(["FieldType__Start (6)<br/>RuleStart"])
     q7(["FieldType__Stop (7)<br/>RuleStop"])
-    q92["FieldType__Basic_0 (92)<br/>Basic<br/>"]
-    q93["FieldType__Basic_1 (93)<br/>Basic<br/>"]
-    q94["FieldType__Basic_2 (94)<br/>Basic<br/>"]
-    q95["FieldType__Basic_3 (95)<br/>Basic<br/>"]
-    q96["FieldType__Basic_4 (96)<br/>Basic<br/>"]
-    q97["FieldType__Basic_5 (97)<br/>Basic<br/>"]
-    q98["FieldType__Basic_6 (98)<br/>Basic<br/>"]
-    q99["FieldType__Basic_7 (99)<br/>Basic<br/>"]
-    q100{"FieldType__Basic_8 (100)<br/>Basic<br/><br/>dec=5"}
-    q101["FieldType__BlockEnd (101)<br/>BlockEnd<br/>"]
+    q94["FieldType__Basic_0 (94)<br/>Basic<br/>"]
+    q95["FieldType__Basic_1 (95)<br/>Basic<br/>"]
+    q96["FieldType__Basic_2 (96)<br/>Basic<br/>"]
+    q97["FieldType__Basic_3 (97)<br/>Basic<br/>"]
+    q98["FieldType__Basic_4 (98)<br/>Basic<br/>"]
+    q99["FieldType__Basic_5 (99)<br/>Basic<br/>"]
+    q100["FieldType__Basic_6 (100)<br/>Basic<br/>"]
+    q101["FieldType__Basic_7 (101)<br/>Basic<br/>"]
+    q102{"FieldType__Basic_8 (102)<br/>Basic<br/><br/>dec=6"}
+    q103["FieldType__BlockEnd (103)<br/>BlockEnd<br/>"]
 
-    q6 --> q100
-    q92 -.->|"[SimpleType]"| q93
-    q93 --> q101
-    q94 -.->|"[ReferenceType]"| q95
-    q95 --> q101
-    q96 -.->|"[ArrayType]"| q97
-    q97 --> q101
-    q98 -.->|"[PrimitiveType]"| q99
-    q99 --> q101
-    q100 --> q92
-    q100 --> q94
-    q100 --> q96
-    q100 --> q98
-    q101 --> q7
+    q6 --> q102
+    q94 -.->|"[SimpleType]"| q95
+    q95 --> q103
+    q96 -.->|"[ReferenceType]"| q97
+    q97 --> q103
+    q98 -.->|"[ArrayType]"| q99
+    q99 --> q103
+    q100 -.->|"[PrimitiveType]"| q101
+    q101 --> q103
+    q102 --> q94
+    q102 --> q96
+    q102 --> q98
+    q102 --> q100
+    q103 --> q7
 ```
 
 ## ArrayType
@@ -157,16 +162,16 @@ flowchart TD
 flowchart TD
     q8(["ArrayType__Start (8)<br/>RuleStart"])
     q9(["ArrayType__Stop (9)<br/>RuleStop"])
-    q102["ArrayType_LeftBracket (102)<br/>Basic<br/>"]
-    q103["ArrayType_RightBracket (103)<br/>Basic<br/>"]
-    q104["ArrayType__Basic_0 (104)<br/>Basic<br/>"]
-    q105["ArrayType__Basic_1 (105)<br/>Basic<br/>"]
+    q104["ArrayType_LeftBracket (104)<br/>Basic<br/>"]
+    q105["ArrayType_RightBracket (105)<br/>Basic<br/>"]
+    q106["ArrayType__Basic_0 (106)<br/>Basic<br/>"]
+    q107["ArrayType__Basic_1 (107)<br/>Basic<br/>"]
 
-    q8 --> q102
-    q102 -->|"tok(&quot;[&quot;)"| q103
-    q103 -->|"tok(&quot;]&quot;)"| q104
-    q104 -.->|"[FieldType]"| q105
-    q105 --> q9
+    q8 --> q104
+    q104 -->|"tok(&quot;[&quot;)"| q105
+    q105 -->|"tok(&quot;]&quot;)"| q106
+    q106 -.->|"[FieldType]"| q107
+    q107 --> q9
 ```
 
 ## ReferenceType
@@ -175,14 +180,14 @@ flowchart TD
 flowchart TD
     q10(["ReferenceType__Start (10)<br/>RuleStart"])
     q11(["ReferenceType__Stop (11)<br/>RuleStop"])
-    q106["ReferenceType_Asterisk (106)<br/>Basic<br/>"]
-    q107["ReferenceType_Type_ID (107)<br/>Basic<br/>"]
-    q108["ReferenceType__Basic (108)<br/>Basic<br/>"]
+    q108["ReferenceType_Asterisk (108)<br/>Basic<br/>"]
+    q109["ReferenceType_Type_ID (109)<br/>Basic<br/>"]
+    q110["ReferenceType__Basic (110)<br/>Basic<br/>"]
 
-    q10 --> q106
-    q106 -->|"tok(&quot;*&quot;)"| q107
-    q107 -->|"tok(ID)"| q108
-    q108 --> q11
+    q10 --> q108
+    q108 -->|"tok(&quot;*&quot;)"| q109
+    q109 -->|"tok(ID)"| q110
+    q110 --> q11
 ```
 
 ## SimpleType
@@ -191,12 +196,12 @@ flowchart TD
 flowchart TD
     q12(["SimpleType__Start (12)<br/>RuleStart"])
     q13(["SimpleType__Stop (13)<br/>RuleStop"])
-    q109["SimpleType_Type_ID (109)<br/>Basic<br/>"]
-    q110["SimpleType__Basic (110)<br/>Basic<br/>"]
+    q111["SimpleType_Type_ID (111)<br/>Basic<br/>"]
+    q112["SimpleType__Basic (112)<br/>Basic<br/>"]
 
-    q12 --> q109
-    q109 -->|"tok(ID)"| q110
-    q110 --> q13
+    q12 --> q111
+    q111 -->|"tok(ID)"| q112
+    q112 --> q13
 ```
 
 ## PrimitiveType
@@ -205,26 +210,26 @@ flowchart TD
 flowchart TD
     q14(["PrimitiveType__Start (14)<br/>RuleStart"])
     q15(["PrimitiveType__Stop (15)<br/>RuleStop"])
-    q111["PrimitiveType_Type_string (111)<br/>Basic<br/>"]
-    q112["PrimitiveType__Basic_0 (112)<br/>Basic<br/>"]
-    q113["PrimitiveType_Type_bool (113)<br/>Basic<br/>"]
-    q114["PrimitiveType__Basic_1 (114)<br/>Basic<br/>"]
-    q115["PrimitiveType_Type_composite (115)<br/>Basic<br/>"]
-    q116["PrimitiveType__Basic_2 (116)<br/>Basic<br/>"]
-    q117{"PrimitiveType__Basic_3 (117)<br/>Basic<br/><br/>dec=6"}
-    q118["PrimitiveType__BlockEnd (118)<br/>BlockEnd<br/>"]
+    q113["PrimitiveType_Type_string (113)<br/>Basic<br/>"]
+    q114["PrimitiveType__Basic_0 (114)<br/>Basic<br/>"]
+    q115["PrimitiveType_Type_bool (115)<br/>Basic<br/>"]
+    q116["PrimitiveType__Basic_1 (116)<br/>Basic<br/>"]
+    q117["PrimitiveType_Type_composite (117)<br/>Basic<br/>"]
+    q118["PrimitiveType__Basic_2 (118)<br/>Basic<br/>"]
+    q119{"PrimitiveType__Basic_3 (119)<br/>Basic<br/><br/>dec=7"}
+    q120["PrimitiveType__BlockEnd (120)<br/>BlockEnd<br/>"]
 
-    q14 --> q117
-    q111 -->|"tok(&quot;string&quot;)"| q112
-    q112 --> q118
-    q113 -->|"tok(&quot;bool&quot;)"| q114
-    q114 --> q118
-    q115 -->|"tok(&quot;composite&quot;)"| q116
-    q116 --> q118
-    q117 --> q111
-    q117 --> q113
-    q117 --> q115
-    q118 --> q15
+    q14 --> q119
+    q113 -->|"tok(&quot;string&quot;)"| q114
+    q114 --> q120
+    q115 -->|"tok(&quot;bool&quot;)"| q116
+    q116 --> q120
+    q117 -->|"tok(&quot;composite&quot;)"| q118
+    q118 --> q120
+    q119 --> q113
+    q119 --> q115
+    q119 --> q117
+    q120 --> q15
 ```
 
 ## ParserRule
@@ -233,27 +238,30 @@ flowchart TD
 flowchart TD
     q16(["ParserRule__Start (16)<br/>RuleStart"])
     q17(["ParserRule__Stop (17)<br/>RuleStop"])
-    q119["ParserRule_Name_ID (119)<br/>Basic<br/>"]
-    q120["ParserRule_returns (120)<br/>Basic<br/>"]
-    q121["ParserRule_ReturnType_ID (121)<br/>Basic<br/>"]
-    q122["ParserRule__Basic_0 (122)<br/>Basic<br/>"]
-    q123{"ParserRule__Basic_1 (123)<br/>Basic<br/><br/>dec=7"}
-    q124["ParserRule_Colon (124)<br/>Basic<br/>"]
-    q125["ParserRule__Basic_2 (125)<br/>Basic<br/>"]
-    q126["ParserRule_Semicolon (126)<br/>Basic<br/>"]
-    q127["ParserRule__Basic_3 (127)<br/>Basic<br/>"]
+    q121["ParserRule_Name_ID (121)<br/>Basic<br/>"]
+    q122["ParserRule_returns (122)<br/>Basic<br/>"]
+    q123["ParserRule_ReturnType_ID (123)<br/>Basic<br/>"]
+    q124["ParserRule__Basic_0 (124)<br/>Basic<br/>"]
+    q125{"ParserRule__Basic_1 (125)<br/>Basic<br/><br/>dec=8"}
+    q126["ParserRule_Colon (126)<br/>Basic<br/>"]
+    q127["ParserRule__Basic_2 (127)<br/>Basic<br/>"]
+    q128["ParserRule_Semicolon (128)<br/>Basic<br/>"]
+    q129["ParserRule__Basic_3 (129)<br/>Basic<br/>"]
+    q130{"ParserRule__Basic_4 (130)<br/>Basic<br/><br/>dec=9"}
 
-    q16 --> q119
-    q119 -->|"tok(ID)"| q123
-    q120 -->|"tok(&quot;returns&quot;)"| q121
-    q121 -->|"tok(ID)"| q122
-    q122 --> q124
-    q123 --> q120
-    q123 --> q122
-    q124 -->|"tok(&quot;:&quot;)"| q125
-    q125 -.->|"[Alternatives]"| q126
-    q126 -->|"tok(&quot;;&quot;)"| q127
-    q127 --> q17
+    q16 --> q121
+    q121 -->|"tok(ID)"| q125
+    q122 -->|"tok(&quot;returns&quot;)"| q123
+    q123 -->|"tok(ID)"| q124
+    q124 --> q126
+    q125 --> q122
+    q125 --> q124
+    q126 -->|"tok(&quot;:&quot;)"| q127
+    q127 -.->|"[Alternatives]"| q130
+    q128 -->|"tok(&quot;;&quot;)"| q129
+    q129 --> q17
+    q130 --> q128
+    q130 --> q129
 ```
 
 ## Token
@@ -262,36 +270,39 @@ flowchart TD
 flowchart TD
     q18(["Token__Start (18)<br/>RuleStart"])
     q19(["Token__Stop (19)<br/>RuleStop"])
-    q128["Token_Type_hidden (128)<br/>Basic<br/>"]
-    q129["Token__Basic_0 (129)<br/>Basic<br/>"]
-    q130["Token_Type_comment (130)<br/>Basic<br/>"]
-    q131["Token__Basic_1 (131)<br/>Basic<br/>"]
-    q132{"Token__Basic_2 (132)<br/>Basic<br/><br/>dec=8"}
-    q133["Token__BlockEnd (133)<br/>BlockEnd<br/>"]
-    q134{"Token__Basic_3 (134)<br/>Basic<br/><br/>dec=9"}
-    q135["Token_token (135)<br/>Basic<br/>"]
-    q136["Token_Name_ID (136)<br/>Basic<br/>"]
-    q137["Token_Colon (137)<br/>Basic<br/>"]
-    q138["Token_Regexp_RegexLiteral (138)<br/>Basic<br/>"]
-    q139["Token_Semicolon (139)<br/>Basic<br/>"]
-    q140["Token__Basic_4 (140)<br/>Basic<br/>"]
+    q131["Token_Type_hidden (131)<br/>Basic<br/>"]
+    q132["Token__Basic_0 (132)<br/>Basic<br/>"]
+    q133["Token_Type_comment (133)<br/>Basic<br/>"]
+    q134["Token__Basic_1 (134)<br/>Basic<br/>"]
+    q135{"Token__Basic_2 (135)<br/>Basic<br/><br/>dec=10"}
+    q136["Token__BlockEnd (136)<br/>BlockEnd<br/>"]
+    q137{"Token__Basic_3 (137)<br/>Basic<br/><br/>dec=11"}
+    q138["Token_token (138)<br/>Basic<br/>"]
+    q139["Token_Name_ID (139)<br/>Basic<br/>"]
+    q140["Token_Colon (140)<br/>Basic<br/>"]
+    q141["Token_Regexp_RegexLiteral (141)<br/>Basic<br/>"]
+    q142["Token_Semicolon (142)<br/>Basic<br/>"]
+    q143["Token__Basic_4 (143)<br/>Basic<br/>"]
+    q144{"Token__Basic_5 (144)<br/>Basic<br/><br/>dec=12"}
 
-    q18 --> q134
-    q128 -->|"tok(&quot;hidden&quot;)"| q129
-    q129 --> q133
-    q130 -->|"tok(&quot;comment&quot;)"| q131
-    q131 --> q133
-    q132 --> q128
-    q132 --> q130
-    q133 --> q135
-    q134 --> q132
-    q134 --> q133
-    q135 -->|"tok(&quot;token&quot;)"| q136
-    q136 -->|"tok(ID)"| q137
-    q137 -->|"tok(&quot;:&quot;)"| q138
-    q138 -->|"tok(RegexLiteral)"| q139
-    q139 -->|"tok(&quot;;&quot;)"| q140
-    q140 --> q19
+    q18 --> q137
+    q131 -->|"tok(&quot;hidden&quot;)"| q132
+    q132 --> q136
+    q133 -->|"tok(&quot;comment&quot;)"| q134
+    q134 --> q136
+    q135 --> q131
+    q135 --> q133
+    q136 --> q138
+    q137 --> q135
+    q137 --> q136
+    q138 -->|"tok(&quot;token&quot;)"| q139
+    q139 -->|"tok(ID)"| q140
+    q140 -->|"tok(&quot;:&quot;)"| q141
+    q141 -->|"tok(RegexLiteral)"| q144
+    q142 -->|"tok(&quot;;&quot;)"| q143
+    q143 --> q19
+    q144 --> q142
+    q144 --> q143
 ```
 
 ## TokenGroup
@@ -300,47 +311,47 @@ flowchart TD
 flowchart TD
     q20(["TokenGroup__Start (20)<br/>RuleStart"])
     q21(["TokenGroup__Stop (21)<br/>RuleStop"])
-    q141["TokenGroup_token (141)<br/>Basic<br/>"]
-    q142["TokenGroup_group (142)<br/>Basic<br/>"]
-    q143["TokenGroup_Name_ID (143)<br/>Basic<br/>"]
-    q144["TokenGroup_LeftBrace (144)<br/>Basic<br/>"]
-    q145["TokenGroup_TokenRefs_ID (145)<br/>Basic<br/>"]
-    q146["TokenGroup__Basic_0 (146)<br/>Basic<br/>"]
-    q147["TokenGroup_keywords (147)<br/>Basic<br/>"]
-    q148["TokenGroup_Regexps_RegexLiteral (148)<br/>Basic<br/>"]
-    q149["TokenGroup__Basic_1 (149)<br/>Basic<br/>"]
-    q150["TokenGroup__Basic_2 (150)<br/>Basic<br/>"]
-    q151["TokenGroup__Basic_3 (151)<br/>Basic<br/>"]
-    q152{"TokenGroup__Basic_4 (152)<br/>Basic<br/><br/>dec=10"}
-    q153["TokenGroup__BlockEnd (153)<br/>BlockEnd<br/>"]
-    q154{"TokenGroup__LoopEntry (154)<br/>LoopEntry<br/><br/>dec=11"}
-    q155["TokenGroup__LoopEnd (155)<br/>LoopEnd<br/>"]
-    q156["TokenGroup__LoopBack (156)<br/>LoopBack<br/>"]
-    q157["TokenGroup_RightBrace (157)<br/>Basic<br/>"]
-    q158["TokenGroup__Basic_5 (158)<br/>Basic<br/>"]
+    q145["TokenGroup_token (145)<br/>Basic<br/>"]
+    q146["TokenGroup_group (146)<br/>Basic<br/>"]
+    q147["TokenGroup_Name_ID (147)<br/>Basic<br/>"]
+    q148["TokenGroup_LeftBrace (148)<br/>Basic<br/>"]
+    q149["TokenGroup_TokenRefs_ID (149)<br/>Basic<br/>"]
+    q150["TokenGroup__Basic_0 (150)<br/>Basic<br/>"]
+    q151["TokenGroup_keywords (151)<br/>Basic<br/>"]
+    q152["TokenGroup_Regexps_RegexLiteral (152)<br/>Basic<br/>"]
+    q153["TokenGroup__Basic_1 (153)<br/>Basic<br/>"]
+    q154["TokenGroup__Basic_2 (154)<br/>Basic<br/>"]
+    q155["TokenGroup__Basic_3 (155)<br/>Basic<br/>"]
+    q156{"TokenGroup__Basic_4 (156)<br/>Basic<br/><br/>dec=13"}
+    q157["TokenGroup__BlockEnd (157)<br/>BlockEnd<br/>"]
+    q158{"TokenGroup__LoopEntry (158)<br/>LoopEntry<br/><br/>dec=14"}
+    q159["TokenGroup__LoopEnd (159)<br/>LoopEnd<br/>"]
+    q160["TokenGroup__LoopBack (160)<br/>LoopBack<br/>"]
+    q161["TokenGroup_RightBrace (161)<br/>Basic<br/>"]
+    q162["TokenGroup__Basic_5 (162)<br/>Basic<br/>"]
 
-    q20 --> q141
-    q141 -->|"tok(&quot;token&quot;)"| q142
-    q142 -->|"tok(&quot;group&quot;)"| q143
-    q143 -->|"tok(ID)"| q144
-    q144 -->|"tok(&quot;{&quot;)"| q154
-    q145 -->|"tok(ID)"| q146
-    q146 --> q153
-    q147 -->|"tok(&quot;keywords&quot;)"| q148
-    q148 -->|"tok(RegexLiteral)"| q149
-    q149 --> q153
-    q150 -.->|"[Keyword]"| q151
-    q151 --> q153
-    q152 --> q145
-    q152 --> q147
-    q152 --> q150
-    q153 --> q156
-    q154 --> q152
-    q154 --> q155
+    q20 --> q145
+    q145 -->|"tok(&quot;token&quot;)"| q146
+    q146 -->|"tok(&quot;group&quot;)"| q147
+    q147 -->|"tok(ID)"| q148
+    q148 -->|"tok(&quot;{&quot;)"| q158
+    q149 -->|"tok(ID)"| q150
+    q150 --> q157
+    q151 -->|"tok(&quot;keywords&quot;)"| q152
+    q152 -->|"tok(RegexLiteral)"| q153
+    q153 --> q157
+    q154 -.->|"[Keyword]"| q155
     q155 --> q157
+    q156 --> q149
+    q156 --> q151
     q156 --> q154
-    q157 -->|"tok(&quot;}&quot;)"| q158
-    q158 --> q21
+    q157 --> q160
+    q158 --> q156
+    q158 --> q159
+    q159 --> q161
+    q160 --> q158
+    q161 -->|"tok(&quot;}&quot;)"| q162
+    q162 --> q21
 ```
 
 ## Alternatives
@@ -349,24 +360,24 @@ flowchart TD
 flowchart TD
     q22(["Alternatives__Start (22)<br/>RuleStart"])
     q23(["Alternatives__Stop (23)<br/>RuleStop"])
-    q159["Alternatives__Basic_0 (159)<br/>Basic<br/>"]
-    q160["Alternatives_Pipe (160)<br/>Basic<br/>"]
-    q161["Alternatives__Basic_1 (161)<br/>Basic<br/>"]
-    q162["Alternatives__Basic_2 (162)<br/>Basic<br/>"]
-    q163{"Alternatives__LoopBack (163)<br/>LoopBack<br/><br/>dec=12"}
-    q164["Alternatives__LoopEnd (164)<br/>LoopEnd<br/>"]
-    q165{"Alternatives__Basic_3 (165)<br/>Basic<br/><br/>dec=13"}
+    q163["Alternatives__Basic_0 (163)<br/>Basic<br/>"]
+    q164["Alternatives_Pipe (164)<br/>Basic<br/>"]
+    q165["Alternatives__Basic_1 (165)<br/>Basic<br/>"]
+    q166["Alternatives__Basic_2 (166)<br/>Basic<br/>"]
+    q167{"Alternatives__LoopBack (167)<br/>LoopBack<br/><br/>dec=15"}
+    q168["Alternatives__LoopEnd (168)<br/>LoopEnd<br/>"]
+    q169{"Alternatives__Basic_3 (169)<br/>Basic<br/><br/>dec=16"}
 
-    q22 --> q159
-    q159 -.->|"[Group]"| q165
-    q160 -->|"tok(&quot;|&quot;)"| q161
-    q161 -.->|"[Group]"| q162
-    q162 --> q163
-    q163 --> q160
-    q163 --> q164
-    q164 --> q23
-    q165 --> q160
-    q165 --> q164
+    q22 --> q163
+    q163 -.->|"[Group]"| q169
+    q164 -->|"tok(&quot;|&quot;)"| q165
+    q165 -.->|"[Group]"| q166
+    q166 --> q167
+    q167 --> q164
+    q167 --> q168
+    q168 --> q23
+    q169 --> q164
+    q169 --> q168
 ```
 
 ## Group
@@ -375,22 +386,22 @@ flowchart TD
 flowchart TD
     q24(["Group__Start (24)<br/>RuleStart"])
     q25(["Group__Stop (25)<br/>RuleStop"])
-    q166["Group__Basic_0 (166)<br/>Basic<br/>"]
-    q167["Group__Basic_1 (167)<br/>Basic<br/>"]
-    q168["Group__Basic_2 (168)<br/>Basic<br/>"]
-    q169{"Group__LoopBack (169)<br/>LoopBack<br/><br/>dec=14"}
-    q170["Group__LoopEnd (170)<br/>LoopEnd<br/>"]
-    q171{"Group__Basic_3 (171)<br/>Basic<br/><br/>dec=15"}
+    q170["Group__Basic_0 (170)<br/>Basic<br/>"]
+    q171["Group__Basic_1 (171)<br/>Basic<br/>"]
+    q172["Group__Basic_2 (172)<br/>Basic<br/>"]
+    q173{"Group__LoopBack (173)<br/>LoopBack<br/><br/>dec=17"}
+    q174["Group__LoopEnd (174)<br/>LoopEnd<br/>"]
+    q175{"Group__Basic_3 (175)<br/>Basic<br/><br/>dec=18"}
 
-    q24 --> q166
-    q166 -.->|"[Element]"| q171
-    q167 -.->|"[Element]"| q168
-    q168 --> q169
-    q169 --> q167
-    q169 --> q170
-    q170 --> q25
-    q171 --> q167
-    q171 --> q170
+    q24 --> q170
+    q170 -.->|"[Element]"| q175
+    q171 -.->|"[Element]"| q172
+    q172 --> q173
+    q173 --> q171
+    q173 --> q174
+    q174 --> q25
+    q175 --> q171
+    q175 --> q174
 ```
 
 ## Element
@@ -399,61 +410,61 @@ flowchart TD
 flowchart TD
     q26(["Element__Start (26)<br/>RuleStart"])
     q27(["Element__Stop (27)<br/>RuleStop"])
-    q172["Element__Basic_0 (172)<br/>Basic<br/>"]
-    q173["Element__Basic_1 (173)<br/>Basic<br/>"]
-    q174["Element__Basic_2 (174)<br/>Basic<br/>"]
-    q175["Element__Basic_3 (175)<br/>Basic<br/>"]
-    q176["Element__Basic_4 (176)<br/>Basic<br/>"]
-    q177["Element__Basic_5 (177)<br/>Basic<br/>"]
-    q178["Element__Basic_6 (178)<br/>Basic<br/>"]
-    q179["Element__Basic_7 (179)<br/>Basic<br/>"]
-    q180["Element_LeftParen (180)<br/>Basic<br/>"]
-    q181["Element__Basic_8 (181)<br/>Basic<br/>"]
-    q182["Element_RightParen (182)<br/>Basic<br/>"]
-    q183["Element__Basic_9 (183)<br/>Basic<br/>"]
-    q184{"Element__Basic_10 (184)<br/>Basic<br/><br/>dec=16"}
-    q185["Element__BlockEnd_0 (185)<br/>BlockEnd<br/>"]
-    q186["Element_Cardinality_Asterisk (186)<br/>Basic<br/>"]
-    q187["Element__Basic_11 (187)<br/>Basic<br/>"]
-    q188["Element_Cardinality_Plus (188)<br/>Basic<br/>"]
-    q189["Element__Basic_12 (189)<br/>Basic<br/>"]
-    q190["Element_Cardinality_Question (190)<br/>Basic<br/>"]
-    q191["Element__Basic_13 (191)<br/>Basic<br/>"]
-    q192{"Element__Basic_14 (192)<br/>Basic<br/><br/>dec=17"}
-    q193["Element__BlockEnd_1 (193)<br/>BlockEnd<br/>"]
-    q194{"Element__Basic_15 (194)<br/>Basic<br/><br/>dec=18"}
+    q176["Element__Basic_0 (176)<br/>Basic<br/>"]
+    q177["Element__Basic_1 (177)<br/>Basic<br/>"]
+    q178["Element__Basic_2 (178)<br/>Basic<br/>"]
+    q179["Element__Basic_3 (179)<br/>Basic<br/>"]
+    q180["Element__Basic_4 (180)<br/>Basic<br/>"]
+    q181["Element__Basic_5 (181)<br/>Basic<br/>"]
+    q182["Element__Basic_6 (182)<br/>Basic<br/>"]
+    q183["Element__Basic_7 (183)<br/>Basic<br/>"]
+    q184["Element_LeftParen (184)<br/>Basic<br/>"]
+    q185["Element__Basic_8 (185)<br/>Basic<br/>"]
+    q186["Element_RightParen (186)<br/>Basic<br/>"]
+    q187["Element__Basic_9 (187)<br/>Basic<br/>"]
+    q188{"Element__Basic_10 (188)<br/>Basic<br/><br/>dec=19"}
+    q189["Element__BlockEnd_0 (189)<br/>BlockEnd<br/>"]
+    q190["Element_Cardinality_Asterisk (190)<br/>Basic<br/>"]
+    q191["Element__Basic_11 (191)<br/>Basic<br/>"]
+    q192["Element_Cardinality_Plus (192)<br/>Basic<br/>"]
+    q193["Element__Basic_12 (193)<br/>Basic<br/>"]
+    q194["Element_Cardinality_Question (194)<br/>Basic<br/>"]
+    q195["Element__Basic_13 (195)<br/>Basic<br/>"]
+    q196{"Element__Basic_14 (196)<br/>Basic<br/><br/>dec=20"}
+    q197["Element__BlockEnd_1 (197)<br/>BlockEnd<br/>"]
+    q198{"Element__Basic_15 (198)<br/>Basic<br/><br/>dec=21"}
 
-    q26 --> q184
-    q172 -.->|"[Keyword]"| q173
-    q173 --> q185
-    q174 -.->|"[Assignment]"| q175
-    q175 --> q185
-    q176 -.->|"[RuleCall]"| q177
-    q177 --> q185
-    q178 -.->|"[Action]"| q179
-    q179 --> q185
-    q180 -->|"tok(&quot;(&quot;)"| q181
-    q181 -.->|"[Alternatives]"| q182
-    q182 -->|"tok(&quot;)&quot;)"| q183
-    q183 --> q185
-    q184 --> q172
-    q184 --> q174
-    q184 --> q176
-    q184 --> q178
-    q184 --> q180
-    q185 --> q194
-    q186 -->|"tok(&quot;*&quot;)"| q187
-    q187 --> q193
-    q188 -->|"tok(&quot;+&quot;)"| q189
-    q189 --> q193
-    q190 -->|"tok(&quot;?&quot;)"| q191
-    q191 --> q193
-    q192 --> q186
-    q192 --> q188
-    q192 --> q190
-    q193 --> q27
-    q194 --> q192
-    q194 --> q193
+    q26 --> q188
+    q176 -.->|"[Keyword]"| q177
+    q177 --> q189
+    q178 -.->|"[Assignment]"| q179
+    q179 --> q189
+    q180 -.->|"[RuleCall]"| q181
+    q181 --> q189
+    q182 -.->|"[Action]"| q183
+    q183 --> q189
+    q184 -->|"tok(&quot;(&quot;)"| q185
+    q185 -.->|"[Alternatives]"| q186
+    q186 -->|"tok(&quot;)&quot;)"| q187
+    q187 --> q189
+    q188 --> q176
+    q188 --> q178
+    q188 --> q180
+    q188 --> q182
+    q188 --> q184
+    q189 --> q198
+    q190 -->|"tok(&quot;*&quot;)"| q191
+    q191 --> q197
+    q192 -->|"tok(&quot;+&quot;)"| q193
+    q193 --> q197
+    q194 -->|"tok(&quot;?&quot;)"| q195
+    q195 --> q197
+    q196 --> q190
+    q196 --> q192
+    q196 --> q194
+    q197 --> q27
+    q198 --> q196
+    q198 --> q197
 ```
 
 ## Keyword
@@ -462,12 +473,12 @@ flowchart TD
 flowchart TD
     q28(["Keyword__Start (28)<br/>RuleStart"])
     q29(["Keyword__Stop (29)<br/>RuleStop"])
-    q195["Keyword_Value_StringLiteral (195)<br/>Basic<br/>"]
-    q196["Keyword__Basic (196)<br/>Basic<br/>"]
+    q199["Keyword_Value_StringLiteral (199)<br/>Basic<br/>"]
+    q200["Keyword__Basic (200)<br/>Basic<br/>"]
 
-    q28 --> q195
-    q195 -->|"tok(StringLiteral)"| q196
-    q196 --> q29
+    q28 --> q199
+    q199 -->|"tok(StringLiteral)"| q200
+    q200 --> q29
 ```
 
 ## Assignment
@@ -476,32 +487,32 @@ flowchart TD
 flowchart TD
     q30(["Assignment__Start (30)<br/>RuleStart"])
     q31(["Assignment__Stop (31)<br/>RuleStop"])
-    q197["Assignment_Property_ID (197)<br/>Basic<br/>"]
-    q198["Assignment_Operator_PlusEquals (198)<br/>Basic<br/>"]
-    q199["Assignment__Basic_0 (199)<br/>Basic<br/>"]
-    q200["Assignment_Operator_Equals (200)<br/>Basic<br/>"]
-    q201["Assignment__Basic_1 (201)<br/>Basic<br/>"]
-    q202["Assignment_Operator_QuestionEquals (202)<br/>Basic<br/>"]
-    q203["Assignment__Basic_2 (203)<br/>Basic<br/>"]
-    q204{"Assignment__Basic_3 (204)<br/>Basic<br/><br/>dec=19"}
-    q205["Assignment__BlockEnd (205)<br/>BlockEnd<br/>"]
-    q206["Assignment__Basic_4 (206)<br/>Basic<br/>"]
-    q207["Assignment__Basic_5 (207)<br/>Basic<br/>"]
+    q201["Assignment_Property_ID (201)<br/>Basic<br/>"]
+    q202["Assignment_Operator_PlusEquals (202)<br/>Basic<br/>"]
+    q203["Assignment__Basic_0 (203)<br/>Basic<br/>"]
+    q204["Assignment_Operator_Equals (204)<br/>Basic<br/>"]
+    q205["Assignment__Basic_1 (205)<br/>Basic<br/>"]
+    q206["Assignment_Operator_QuestionEquals (206)<br/>Basic<br/>"]
+    q207["Assignment__Basic_2 (207)<br/>Basic<br/>"]
+    q208{"Assignment__Basic_3 (208)<br/>Basic<br/><br/>dec=22"}
+    q209["Assignment__BlockEnd (209)<br/>BlockEnd<br/>"]
+    q210["Assignment__Basic_4 (210)<br/>Basic<br/>"]
+    q211["Assignment__Basic_5 (211)<br/>Basic<br/>"]
 
-    q30 --> q197
-    q197 -->|"tok(ID)"| q204
-    q198 -->|"tok(&quot;+=&quot;)"| q199
-    q199 --> q205
-    q200 -->|"tok(&quot;=&quot;)"| q201
-    q201 --> q205
-    q202 -->|"tok(&quot;?=&quot;)"| q203
-    q203 --> q205
-    q204 --> q198
-    q204 --> q200
-    q204 --> q202
-    q205 --> q206
-    q206 -.->|"[Assignable]"| q207
-    q207 --> q31
+    q30 --> q201
+    q201 -->|"tok(ID)"| q208
+    q202 -->|"tok(&quot;+=&quot;)"| q203
+    q203 --> q209
+    q204 -->|"tok(&quot;=&quot;)"| q205
+    q205 --> q209
+    q206 -->|"tok(&quot;?=&quot;)"| q207
+    q207 --> q209
+    q208 --> q202
+    q208 --> q204
+    q208 --> q206
+    q209 --> q210
+    q210 -.->|"[Assignable]"| q211
+    q211 --> q31
 ```
 
 ## Assignable
@@ -510,35 +521,35 @@ flowchart TD
 flowchart TD
     q32(["Assignable__Start (32)<br/>RuleStart"])
     q33(["Assignable__Stop (33)<br/>RuleStop"])
-    q208["Assignable__Basic_0 (208)<br/>Basic<br/>"]
-    q209["Assignable__Basic_1 (209)<br/>Basic<br/>"]
-    q210["Assignable__Basic_2 (210)<br/>Basic<br/>"]
-    q211["Assignable__Basic_3 (211)<br/>Basic<br/>"]
-    q212["Assignable__Basic_4 (212)<br/>Basic<br/>"]
-    q213["Assignable__Basic_5 (213)<br/>Basic<br/>"]
-    q214["Assignable_LeftParen (214)<br/>Basic<br/>"]
-    q215["Assignable__Basic_6 (215)<br/>Basic<br/>"]
-    q216["Assignable_RightParen (216)<br/>Basic<br/>"]
-    q217["Assignable__Basic_7 (217)<br/>Basic<br/>"]
-    q218{"Assignable__Basic_8 (218)<br/>Basic<br/><br/>dec=20"}
-    q219["Assignable__BlockEnd (219)<br/>BlockEnd<br/>"]
+    q212["Assignable__Basic_0 (212)<br/>Basic<br/>"]
+    q213["Assignable__Basic_1 (213)<br/>Basic<br/>"]
+    q214["Assignable__Basic_2 (214)<br/>Basic<br/>"]
+    q215["Assignable__Basic_3 (215)<br/>Basic<br/>"]
+    q216["Assignable__Basic_4 (216)<br/>Basic<br/>"]
+    q217["Assignable__Basic_5 (217)<br/>Basic<br/>"]
+    q218["Assignable_LeftParen (218)<br/>Basic<br/>"]
+    q219["Assignable__Basic_6 (219)<br/>Basic<br/>"]
+    q220["Assignable_RightParen (220)<br/>Basic<br/>"]
+    q221["Assignable__Basic_7 (221)<br/>Basic<br/>"]
+    q222{"Assignable__Basic_8 (222)<br/>Basic<br/><br/>dec=23"}
+    q223["Assignable__BlockEnd (223)<br/>BlockEnd<br/>"]
 
-    q32 --> q218
-    q208 -.->|"[Keyword]"| q209
-    q209 --> q219
-    q210 -.->|"[RuleCall]"| q211
-    q211 --> q219
-    q212 -.->|"[CrossRef]"| q213
-    q213 --> q219
-    q214 -->|"tok(&quot;(&quot;)"| q215
-    q215 -.->|"[AssignableAlternatives]"| q216
-    q216 -->|"tok(&quot;)&quot;)"| q217
-    q217 --> q219
-    q218 --> q208
-    q218 --> q210
-    q218 --> q212
-    q218 --> q214
-    q219 --> q33
+    q32 --> q222
+    q212 -.->|"[Keyword]"| q213
+    q213 --> q223
+    q214 -.->|"[RuleCall]"| q215
+    q215 --> q223
+    q216 -.->|"[CrossRef]"| q217
+    q217 --> q223
+    q218 -->|"tok(&quot;(&quot;)"| q219
+    q219 -.->|"[AssignableAlternatives]"| q220
+    q220 -->|"tok(&quot;)&quot;)"| q221
+    q221 --> q223
+    q222 --> q212
+    q222 --> q214
+    q222 --> q216
+    q222 --> q218
+    q223 --> q33
 ```
 
 ## AssignableWithoutAlts
@@ -547,26 +558,26 @@ flowchart TD
 flowchart TD
     q34(["AssignableWithoutAlts__Start (34)<br/>RuleStart"])
     q35(["AssignableWithoutAlts__Stop (35)<br/>RuleStop"])
-    q220["AssignableWithoutAlts__Basic_0 (220)<br/>Basic<br/>"]
-    q221["AssignableWithoutAlts__Basic_1 (221)<br/>Basic<br/>"]
-    q222["AssignableWithoutAlts__Basic_2 (222)<br/>Basic<br/>"]
-    q223["AssignableWithoutAlts__Basic_3 (223)<br/>Basic<br/>"]
-    q224["AssignableWithoutAlts__Basic_4 (224)<br/>Basic<br/>"]
-    q225["AssignableWithoutAlts__Basic_5 (225)<br/>Basic<br/>"]
-    q226{"AssignableWithoutAlts__Basic_6 (226)<br/>Basic<br/><br/>dec=21"}
-    q227["AssignableWithoutAlts__BlockEnd (227)<br/>BlockEnd<br/>"]
+    q224["AssignableWithoutAlts__Basic_0 (224)<br/>Basic<br/>"]
+    q225["AssignableWithoutAlts__Basic_1 (225)<br/>Basic<br/>"]
+    q226["AssignableWithoutAlts__Basic_2 (226)<br/>Basic<br/>"]
+    q227["AssignableWithoutAlts__Basic_3 (227)<br/>Basic<br/>"]
+    q228["AssignableWithoutAlts__Basic_4 (228)<br/>Basic<br/>"]
+    q229["AssignableWithoutAlts__Basic_5 (229)<br/>Basic<br/>"]
+    q230{"AssignableWithoutAlts__Basic_6 (230)<br/>Basic<br/><br/>dec=24"}
+    q231["AssignableWithoutAlts__BlockEnd (231)<br/>BlockEnd<br/>"]
 
-    q34 --> q226
-    q220 -.->|"[Keyword]"| q221
-    q221 --> q227
-    q222 -.->|"[RuleCall]"| q223
-    q223 --> q227
-    q224 -.->|"[CrossRef]"| q225
-    q225 --> q227
-    q226 --> q220
-    q226 --> q222
-    q226 --> q224
-    q227 --> q35
+    q34 --> q230
+    q224 -.->|"[Keyword]"| q225
+    q225 --> q231
+    q226 -.->|"[RuleCall]"| q227
+    q227 --> q231
+    q228 -.->|"[CrossRef]"| q229
+    q229 --> q231
+    q230 --> q224
+    q230 --> q226
+    q230 --> q228
+    q231 --> q35
 ```
 
 ## AssignableAlternatives
@@ -575,24 +586,24 @@ flowchart TD
 flowchart TD
     q36(["AssignableAlternatives__Start (36)<br/>RuleStart"])
     q37(["AssignableAlternatives__Stop (37)<br/>RuleStop"])
-    q228["AssignableAlternatives__Basic_0 (228)<br/>Basic<br/>"]
-    q229["AssignableAlternatives_Pipe (229)<br/>Basic<br/>"]
-    q230["AssignableAlternatives__Basic_1 (230)<br/>Basic<br/>"]
-    q231["AssignableAlternatives__Basic_2 (231)<br/>Basic<br/>"]
-    q232{"AssignableAlternatives__LoopBack (232)<br/>LoopBack<br/><br/>dec=22"}
-    q233["AssignableAlternatives__LoopEnd (233)<br/>LoopEnd<br/>"]
-    q234{"AssignableAlternatives__Basic_3 (234)<br/>Basic<br/><br/>dec=23"}
+    q232["AssignableAlternatives__Basic_0 (232)<br/>Basic<br/>"]
+    q233["AssignableAlternatives_Pipe (233)<br/>Basic<br/>"]
+    q234["AssignableAlternatives__Basic_1 (234)<br/>Basic<br/>"]
+    q235["AssignableAlternatives__Basic_2 (235)<br/>Basic<br/>"]
+    q236{"AssignableAlternatives__LoopBack (236)<br/>LoopBack<br/><br/>dec=25"}
+    q237["AssignableAlternatives__LoopEnd (237)<br/>LoopEnd<br/>"]
+    q238{"AssignableAlternatives__Basic_3 (238)<br/>Basic<br/><br/>dec=26"}
 
-    q36 --> q228
-    q228 -.->|"[AssignableWithoutAlts]"| q234
-    q229 -->|"tok(&quot;|&quot;)"| q230
-    q230 -.->|"[AssignableWithoutAlts]"| q231
-    q231 --> q232
-    q232 --> q229
-    q232 --> q233
-    q233 --> q37
-    q234 --> q229
-    q234 --> q233
+    q36 --> q232
+    q232 -.->|"[AssignableWithoutAlts]"| q238
+    q233 -->|"tok(&quot;|&quot;)"| q234
+    q234 -.->|"[AssignableWithoutAlts]"| q235
+    q235 --> q236
+    q236 --> q233
+    q236 --> q237
+    q237 --> q37
+    q238 --> q233
+    q238 --> q237
 ```
 
 ## CrossRef
@@ -601,25 +612,25 @@ flowchart TD
 flowchart TD
     q38(["CrossRef__Start (38)<br/>RuleStart"])
     q39(["CrossRef__Stop (39)<br/>RuleStop"])
-    q235["CrossRef_LeftBracket (235)<br/>Basic<br/>"]
-    q236["CrossRef_Type_ID (236)<br/>Basic<br/>"]
-    q237["CrossRef_Colon (237)<br/>Basic<br/>"]
-    q238["CrossRef__Basic_0 (238)<br/>Basic<br/>"]
-    q239["CrossRef__Basic_1 (239)<br/>Basic<br/>"]
-    q240{"CrossRef__Basic_2 (240)<br/>Basic<br/><br/>dec=24"}
-    q241["CrossRef_RightBracket (241)<br/>Basic<br/>"]
-    q242["CrossRef__Basic_3 (242)<br/>Basic<br/>"]
+    q239["CrossRef_LeftBracket (239)<br/>Basic<br/>"]
+    q240["CrossRef_Type_ID (240)<br/>Basic<br/>"]
+    q241["CrossRef_Colon (241)<br/>Basic<br/>"]
+    q242["CrossRef__Basic_0 (242)<br/>Basic<br/>"]
+    q243["CrossRef__Basic_1 (243)<br/>Basic<br/>"]
+    q244{"CrossRef__Basic_2 (244)<br/>Basic<br/><br/>dec=27"}
+    q245["CrossRef_RightBracket (245)<br/>Basic<br/>"]
+    q246["CrossRef__Basic_3 (246)<br/>Basic<br/>"]
 
-    q38 --> q235
-    q235 -->|"tok(&quot;[&quot;)"| q236
-    q236 -->|"tok(ID)"| q240
-    q237 -->|"tok(&quot;:&quot;)"| q238
-    q238 -.->|"[RuleCall]"| q239
-    q239 --> q241
-    q240 --> q237
-    q240 --> q239
-    q241 -->|"tok(&quot;]&quot;)"| q242
-    q242 --> q39
+    q38 --> q239
+    q239 -->|"tok(&quot;[&quot;)"| q240
+    q240 -->|"tok(ID)"| q244
+    q241 -->|"tok(&quot;:&quot;)"| q242
+    q242 -.->|"[RuleCall]"| q243
+    q243 --> q245
+    q244 --> q241
+    q244 --> q243
+    q245 -->|"tok(&quot;]&quot;)"| q246
+    q246 --> q39
 ```
 
 ## RuleCall
@@ -628,12 +639,12 @@ flowchart TD
 flowchart TD
     q40(["RuleCall__Start (40)<br/>RuleStart"])
     q41(["RuleCall__Stop (41)<br/>RuleStop"])
-    q243["RuleCall_Rule_ID (243)<br/>Basic<br/>"]
-    q244["RuleCall__Basic (244)<br/>Basic<br/>"]
+    q247["RuleCall_Rule_ID (247)<br/>Basic<br/>"]
+    q248["RuleCall__Basic (248)<br/>Basic<br/>"]
 
-    q40 --> q243
-    q243 -->|"tok(ID)"| q244
-    q244 --> q41
+    q40 --> q247
+    q247 -->|"tok(ID)"| q248
+    q248 --> q41
 ```
 
 ## Action
@@ -642,40 +653,40 @@ flowchart TD
 flowchart TD
     q42(["Action__Start (42)<br/>RuleStart"])
     q43(["Action__Stop (43)<br/>RuleStop"])
-    q245["Action_LeftBrace (245)<br/>Basic<br/>"]
-    q246["Action_Type_ID (246)<br/>Basic<br/>"]
-    q247["Action_Dot (247)<br/>Basic<br/>"]
-    q248["Action_Property_ID (248)<br/>Basic<br/>"]
-    q249["Action_Operator_PlusEquals (249)<br/>Basic<br/>"]
-    q250["Action__Basic_0 (250)<br/>Basic<br/>"]
-    q251["Action_Operator_Equals (251)<br/>Basic<br/>"]
-    q252["Action__Basic_1 (252)<br/>Basic<br/>"]
-    q253{"Action__Basic_2 (253)<br/>Basic<br/><br/>dec=25"}
-    q254["Action__BlockEnd (254)<br/>BlockEnd<br/>"]
-    q255["Action_current (255)<br/>Basic<br/>"]
-    q256["Action__Basic_3 (256)<br/>Basic<br/>"]
-    q257{"Action__Basic_4 (257)<br/>Basic<br/><br/>dec=26"}
-    q258["Action_RightBrace (258)<br/>Basic<br/>"]
-    q259["Action__Basic_5 (259)<br/>Basic<br/>"]
+    q249["Action_LeftBrace (249)<br/>Basic<br/>"]
+    q250["Action_Type_ID (250)<br/>Basic<br/>"]
+    q251["Action_Dot (251)<br/>Basic<br/>"]
+    q252["Action_Property_ID (252)<br/>Basic<br/>"]
+    q253["Action_Operator_PlusEquals (253)<br/>Basic<br/>"]
+    q254["Action__Basic_0 (254)<br/>Basic<br/>"]
+    q255["Action_Operator_Equals (255)<br/>Basic<br/>"]
+    q256["Action__Basic_1 (256)<br/>Basic<br/>"]
+    q257{"Action__Basic_2 (257)<br/>Basic<br/><br/>dec=28"}
+    q258["Action__BlockEnd (258)<br/>BlockEnd<br/>"]
+    q259["Action_current (259)<br/>Basic<br/>"]
+    q260["Action__Basic_3 (260)<br/>Basic<br/>"]
+    q261{"Action__Basic_4 (261)<br/>Basic<br/><br/>dec=29"}
+    q262["Action_RightBrace (262)<br/>Basic<br/>"]
+    q263["Action__Basic_5 (263)<br/>Basic<br/>"]
 
-    q42 --> q245
-    q245 -->|"tok(&quot;{&quot;)"| q246
-    q246 -->|"tok(ID)"| q257
-    q247 -->|"tok(&quot;.&quot;)"| q248
-    q248 -->|"tok(ID)"| q253
-    q249 -->|"tok(&quot;+=&quot;)"| q250
-    q250 --> q254
-    q251 -->|"tok(&quot;=&quot;)"| q252
-    q252 --> q254
-    q253 --> q249
-    q253 --> q251
-    q254 --> q255
-    q255 -->|"tok(&quot;current&quot;)"| q256
+    q42 --> q249
+    q249 -->|"tok(&quot;{&quot;)"| q250
+    q250 -->|"tok(ID)"| q261
+    q251 -->|"tok(&quot;.&quot;)"| q252
+    q252 -->|"tok(ID)"| q257
+    q253 -->|"tok(&quot;+=&quot;)"| q254
+    q254 --> q258
+    q255 -->|"tok(&quot;=&quot;)"| q256
     q256 --> q258
-    q257 --> q247
-    q257 --> q256
-    q258 -->|"tok(&quot;}&quot;)"| q259
-    q259 --> q43
+    q257 --> q253
+    q257 --> q255
+    q258 --> q259
+    q259 -->|"tok(&quot;current&quot;)"| q260
+    q260 --> q262
+    q261 --> q251
+    q261 --> q260
+    q262 -->|"tok(&quot;}&quot;)"| q263
+    q263 --> q43
 ```
 
 ## CompositeRule
@@ -684,20 +695,23 @@ flowchart TD
 flowchart TD
     q44(["CompositeRule__Start (44)<br/>RuleStart"])
     q45(["CompositeRule__Stop (45)<br/>RuleStop"])
-    q260["CompositeRule_composite (260)<br/>Basic<br/>"]
-    q261["CompositeRule_Name_ID (261)<br/>Basic<br/>"]
-    q262["CompositeRule_Colon (262)<br/>Basic<br/>"]
-    q263["CompositeRule__Basic_0 (263)<br/>Basic<br/>"]
-    q264["CompositeRule_Semicolon (264)<br/>Basic<br/>"]
-    q265["CompositeRule__Basic_1 (265)<br/>Basic<br/>"]
+    q264["CompositeRule_composite (264)<br/>Basic<br/>"]
+    q265["CompositeRule_Name_ID (265)<br/>Basic<br/>"]
+    q266["CompositeRule_Colon (266)<br/>Basic<br/>"]
+    q267["CompositeRule__Basic_0 (267)<br/>Basic<br/>"]
+    q268["CompositeRule_Semicolon (268)<br/>Basic<br/>"]
+    q269["CompositeRule__Basic_1 (269)<br/>Basic<br/>"]
+    q270{"CompositeRule__Basic_2 (270)<br/>Basic<br/><br/>dec=30"}
 
-    q44 --> q260
-    q260 -->|"tok(&quot;composite&quot;)"| q261
-    q261 -->|"tok(ID)"| q262
-    q262 -->|"tok(&quot;:&quot;)"| q263
-    q263 -.->|"[CompositeAlternatives]"| q264
-    q264 -->|"tok(&quot;;&quot;)"| q265
-    q265 --> q45
+    q44 --> q264
+    q264 -->|"tok(&quot;composite&quot;)"| q265
+    q265 -->|"tok(ID)"| q266
+    q266 -->|"tok(&quot;:&quot;)"| q267
+    q267 -.->|"[CompositeAlternatives]"| q270
+    q268 -->|"tok(&quot;;&quot;)"| q269
+    q269 --> q45
+    q270 --> q268
+    q270 --> q269
 ```
 
 ## CompositeAlternatives
@@ -706,24 +720,24 @@ flowchart TD
 flowchart TD
     q46(["CompositeAlternatives__Start (46)<br/>RuleStart"])
     q47(["CompositeAlternatives__Stop (47)<br/>RuleStop"])
-    q266["CompositeAlternatives__Basic_0 (266)<br/>Basic<br/>"]
-    q267["CompositeAlternatives_Pipe (267)<br/>Basic<br/>"]
-    q268["CompositeAlternatives__Basic_1 (268)<br/>Basic<br/>"]
-    q269["CompositeAlternatives__Basic_2 (269)<br/>Basic<br/>"]
-    q270{"CompositeAlternatives__LoopBack (270)<br/>LoopBack<br/><br/>dec=27"}
-    q271["CompositeAlternatives__LoopEnd (271)<br/>LoopEnd<br/>"]
-    q272{"CompositeAlternatives__Basic_3 (272)<br/>Basic<br/><br/>dec=28"}
+    q271["CompositeAlternatives__Basic_0 (271)<br/>Basic<br/>"]
+    q272["CompositeAlternatives_Pipe (272)<br/>Basic<br/>"]
+    q273["CompositeAlternatives__Basic_1 (273)<br/>Basic<br/>"]
+    q274["CompositeAlternatives__Basic_2 (274)<br/>Basic<br/>"]
+    q275{"CompositeAlternatives__LoopBack (275)<br/>LoopBack<br/><br/>dec=31"}
+    q276["CompositeAlternatives__LoopEnd (276)<br/>LoopEnd<br/>"]
+    q277{"CompositeAlternatives__Basic_3 (277)<br/>Basic<br/><br/>dec=32"}
 
-    q46 --> q266
-    q266 -.->|"[CompositeGroup]"| q272
-    q267 -->|"tok(&quot;|&quot;)"| q268
-    q268 -.->|"[CompositeGroup]"| q269
-    q269 --> q270
-    q270 --> q267
-    q270 --> q271
-    q271 --> q47
-    q272 --> q267
-    q272 --> q271
+    q46 --> q271
+    q271 -.->|"[CompositeGroup]"| q277
+    q272 -->|"tok(&quot;|&quot;)"| q273
+    q273 -.->|"[CompositeGroup]"| q274
+    q274 --> q275
+    q275 --> q272
+    q275 --> q276
+    q276 --> q47
+    q277 --> q272
+    q277 --> q276
 ```
 
 ## CompositeGroup
@@ -732,22 +746,22 @@ flowchart TD
 flowchart TD
     q48(["CompositeGroup__Start (48)<br/>RuleStart"])
     q49(["CompositeGroup__Stop (49)<br/>RuleStop"])
-    q273["CompositeGroup__Basic_0 (273)<br/>Basic<br/>"]
-    q274["CompositeGroup__Basic_1 (274)<br/>Basic<br/>"]
-    q275["CompositeGroup__Basic_2 (275)<br/>Basic<br/>"]
-    q276{"CompositeGroup__LoopBack (276)<br/>LoopBack<br/><br/>dec=29"}
-    q277["CompositeGroup__LoopEnd (277)<br/>LoopEnd<br/>"]
-    q278{"CompositeGroup__Basic_3 (278)<br/>Basic<br/><br/>dec=30"}
+    q278["CompositeGroup__Basic_0 (278)<br/>Basic<br/>"]
+    q279["CompositeGroup__Basic_1 (279)<br/>Basic<br/>"]
+    q280["CompositeGroup__Basic_2 (280)<br/>Basic<br/>"]
+    q281{"CompositeGroup__LoopBack (281)<br/>LoopBack<br/><br/>dec=33"}
+    q282["CompositeGroup__LoopEnd (282)<br/>LoopEnd<br/>"]
+    q283{"CompositeGroup__Basic_3 (283)<br/>Basic<br/><br/>dec=34"}
 
-    q48 --> q273
-    q273 -.->|"[CompositeElement]"| q278
-    q274 -.->|"[CompositeElement]"| q275
-    q275 --> q276
-    q276 --> q274
-    q276 --> q277
-    q277 --> q49
-    q278 --> q274
-    q278 --> q277
+    q48 --> q278
+    q278 -.->|"[CompositeElement]"| q283
+    q279 -.->|"[CompositeElement]"| q280
+    q280 --> q281
+    q281 --> q279
+    q281 --> q282
+    q282 --> q49
+    q283 --> q279
+    q283 --> q282
 ```
 
 ## CompositeElement
@@ -756,50 +770,50 @@ flowchart TD
 flowchart TD
     q50(["CompositeElement__Start (50)<br/>RuleStart"])
     q51(["CompositeElement__Stop (51)<br/>RuleStop"])
-    q279["CompositeElement__Basic_0 (279)<br/>Basic<br/>"]
-    q280["CompositeElement__Basic_1 (280)<br/>Basic<br/>"]
-    q281["CompositeElement__Basic_2 (281)<br/>Basic<br/>"]
-    q282["CompositeElement__Basic_3 (282)<br/>Basic<br/>"]
-    q283["CompositeElement_LeftParen (283)<br/>Basic<br/>"]
-    q284["CompositeElement__Basic_4 (284)<br/>Basic<br/>"]
-    q285["CompositeElement_RightParen (285)<br/>Basic<br/>"]
-    q286["CompositeElement__Basic_5 (286)<br/>Basic<br/>"]
-    q287{"CompositeElement__Basic_6 (287)<br/>Basic<br/><br/>dec=31"}
-    q288["CompositeElement__BlockEnd_0 (288)<br/>BlockEnd<br/>"]
-    q289["CompositeElement_Cardinality_Asterisk (289)<br/>Basic<br/>"]
-    q290["CompositeElement__Basic_7 (290)<br/>Basic<br/>"]
-    q291["CompositeElement_Cardinality_Plus (291)<br/>Basic<br/>"]
-    q292["CompositeElement__Basic_8 (292)<br/>Basic<br/>"]
-    q293["CompositeElement_Cardinality_Question (293)<br/>Basic<br/>"]
-    q294["CompositeElement__Basic_9 (294)<br/>Basic<br/>"]
-    q295{"CompositeElement__Basic_10 (295)<br/>Basic<br/><br/>dec=32"}
-    q296["CompositeElement__BlockEnd_1 (296)<br/>BlockEnd<br/>"]
-    q297{"CompositeElement__Basic_11 (297)<br/>Basic<br/><br/>dec=33"}
+    q284["CompositeElement__Basic_0 (284)<br/>Basic<br/>"]
+    q285["CompositeElement__Basic_1 (285)<br/>Basic<br/>"]
+    q286["CompositeElement__Basic_2 (286)<br/>Basic<br/>"]
+    q287["CompositeElement__Basic_3 (287)<br/>Basic<br/>"]
+    q288["CompositeElement_LeftParen (288)<br/>Basic<br/>"]
+    q289["CompositeElement__Basic_4 (289)<br/>Basic<br/>"]
+    q290["CompositeElement_RightParen (290)<br/>Basic<br/>"]
+    q291["CompositeElement__Basic_5 (291)<br/>Basic<br/>"]
+    q292{"CompositeElement__Basic_6 (292)<br/>Basic<br/><br/>dec=35"}
+    q293["CompositeElement__BlockEnd_0 (293)<br/>BlockEnd<br/>"]
+    q294["CompositeElement_Cardinality_Asterisk (294)<br/>Basic<br/>"]
+    q295["CompositeElement__Basic_7 (295)<br/>Basic<br/>"]
+    q296["CompositeElement_Cardinality_Plus (296)<br/>Basic<br/>"]
+    q297["CompositeElement__Basic_8 (297)<br/>Basic<br/>"]
+    q298["CompositeElement_Cardinality_Question (298)<br/>Basic<br/>"]
+    q299["CompositeElement__Basic_9 (299)<br/>Basic<br/>"]
+    q300{"CompositeElement__Basic_10 (300)<br/>Basic<br/><br/>dec=36"}
+    q301["CompositeElement__BlockEnd_1 (301)<br/>BlockEnd<br/>"]
+    q302{"CompositeElement__Basic_11 (302)<br/>Basic<br/><br/>dec=37"}
 
-    q50 --> q287
-    q279 -.->|"[Keyword]"| q280
-    q280 --> q288
-    q281 -.->|"[RuleCall]"| q282
-    q282 --> q288
-    q283 -->|"tok(&quot;(&quot;)"| q284
-    q284 -.->|"[CompositeAlternatives]"| q285
-    q285 -->|"tok(&quot;)&quot;)"| q286
-    q286 --> q288
-    q287 --> q279
-    q287 --> q281
-    q287 --> q283
-    q288 --> q297
-    q289 -->|"tok(&quot;*&quot;)"| q290
-    q290 --> q296
-    q291 -->|"tok(&quot;+&quot;)"| q292
-    q292 --> q296
-    q293 -->|"tok(&quot;?&quot;)"| q294
-    q294 --> q296
-    q295 --> q289
-    q295 --> q291
-    q295 --> q293
-    q296 --> q51
-    q297 --> q295
-    q297 --> q296
+    q50 --> q292
+    q284 -.->|"[Keyword]"| q285
+    q285 --> q293
+    q286 -.->|"[RuleCall]"| q287
+    q287 --> q293
+    q288 -->|"tok(&quot;(&quot;)"| q289
+    q289 -.->|"[CompositeAlternatives]"| q290
+    q290 -->|"tok(&quot;)&quot;)"| q291
+    q291 --> q293
+    q292 --> q284
+    q292 --> q286
+    q292 --> q288
+    q293 --> q302
+    q294 -->|"tok(&quot;*&quot;)"| q295
+    q295 --> q301
+    q296 -->|"tok(&quot;+&quot;)"| q297
+    q297 --> q301
+    q298 -->|"tok(&quot;?&quot;)"| q299
+    q299 --> q301
+    q300 --> q294
+    q300 --> q296
+    q300 --> q298
+    q301 --> q51
+    q302 --> q300
+    q302 --> q301
 ```
 

--- a/internal/grammar/atn.md
+++ b/internal/grammar/atn.md
@@ -238,30 +238,37 @@ flowchart TD
 flowchart TD
     q16(["ParserRule__Start (16)<br/>RuleStart"])
     q17(["ParserRule__Stop (17)<br/>RuleStop"])
-    q121["ParserRule_Name_ID (121)<br/>Basic<br/>"]
-    q122["ParserRule_returns (122)<br/>Basic<br/>"]
-    q123["ParserRule_ReturnType_ID (123)<br/>Basic<br/>"]
-    q124["ParserRule__Basic_0 (124)<br/>Basic<br/>"]
-    q125{"ParserRule__Basic_1 (125)<br/>Basic<br/><br/>dec=8"}
-    q126["ParserRule_Colon (126)<br/>Basic<br/>"]
+    q121["ParserRule_Entry_entry (121)<br/>Basic<br/>"]
+    q122["ParserRule__Basic_0 (122)<br/>Basic<br/>"]
+    q123{"ParserRule__Basic_1 (123)<br/>Basic<br/><br/>dec=8"}
+    q124["ParserRule_Name_ID (124)<br/>Basic<br/>"]
+    q125["ParserRule_returns (125)<br/>Basic<br/>"]
+    q126["ParserRule_ReturnType_ID (126)<br/>Basic<br/>"]
     q127["ParserRule__Basic_2 (127)<br/>Basic<br/>"]
-    q128["ParserRule_Semicolon (128)<br/>Basic<br/>"]
-    q129["ParserRule__Basic_3 (129)<br/>Basic<br/>"]
-    q130{"ParserRule__Basic_4 (130)<br/>Basic<br/><br/>dec=9"}
+    q128{"ParserRule__Basic_3 (128)<br/>Basic<br/><br/>dec=9"}
+    q129["ParserRule_Colon (129)<br/>Basic<br/>"]
+    q130["ParserRule__Basic_4 (130)<br/>Basic<br/>"]
+    q131["ParserRule_Semicolon (131)<br/>Basic<br/>"]
+    q132["ParserRule__Basic_5 (132)<br/>Basic<br/>"]
+    q133{"ParserRule__Basic_6 (133)<br/>Basic<br/><br/>dec=10"}
 
-    q16 --> q121
-    q121 -->|"tok(ID)"| q125
-    q122 -->|"tok(&quot;returns&quot;)"| q123
-    q123 -->|"tok(ID)"| q124
-    q124 --> q126
-    q125 --> q122
-    q125 --> q124
-    q126 -->|"tok(&quot;:&quot;)"| q127
-    q127 -.->|"[Alternatives]"| q130
-    q128 -->|"tok(&quot;;&quot;)"| q129
-    q129 --> q17
-    q130 --> q128
-    q130 --> q129
+    q16 --> q123
+    q121 -->|"tok(&quot;entry&quot;)"| q122
+    q122 --> q124
+    q123 --> q121
+    q123 --> q122
+    q124 -->|"tok(ID)"| q128
+    q125 -->|"tok(&quot;returns&quot;)"| q126
+    q126 -->|"tok(ID)"| q127
+    q127 --> q129
+    q128 --> q125
+    q128 --> q127
+    q129 -->|"tok(&quot;:&quot;)"| q130
+    q130 -.->|"[Alternatives]"| q133
+    q131 -->|"tok(&quot;;&quot;)"| q132
+    q132 --> q17
+    q133 --> q131
+    q133 --> q132
 ```
 
 ## Token
@@ -270,39 +277,39 @@ flowchart TD
 flowchart TD
     q18(["Token__Start (18)<br/>RuleStart"])
     q19(["Token__Stop (19)<br/>RuleStop"])
-    q131["Token_Type_hidden (131)<br/>Basic<br/>"]
-    q132["Token__Basic_0 (132)<br/>Basic<br/>"]
-    q133["Token_Type_comment (133)<br/>Basic<br/>"]
-    q134["Token__Basic_1 (134)<br/>Basic<br/>"]
-    q135{"Token__Basic_2 (135)<br/>Basic<br/><br/>dec=10"}
-    q136["Token__BlockEnd (136)<br/>BlockEnd<br/>"]
-    q137{"Token__Basic_3 (137)<br/>Basic<br/><br/>dec=11"}
-    q138["Token_token (138)<br/>Basic<br/>"]
-    q139["Token_Name_ID (139)<br/>Basic<br/>"]
-    q140["Token_Colon (140)<br/>Basic<br/>"]
-    q141["Token_Regexp_RegexLiteral (141)<br/>Basic<br/>"]
-    q142["Token_Semicolon (142)<br/>Basic<br/>"]
-    q143["Token__Basic_4 (143)<br/>Basic<br/>"]
-    q144{"Token__Basic_5 (144)<br/>Basic<br/><br/>dec=12"}
+    q134["Token_Type_hidden (134)<br/>Basic<br/>"]
+    q135["Token__Basic_0 (135)<br/>Basic<br/>"]
+    q136["Token_Type_comment (136)<br/>Basic<br/>"]
+    q137["Token__Basic_1 (137)<br/>Basic<br/>"]
+    q138{"Token__Basic_2 (138)<br/>Basic<br/><br/>dec=11"}
+    q139["Token__BlockEnd (139)<br/>BlockEnd<br/>"]
+    q140{"Token__Basic_3 (140)<br/>Basic<br/><br/>dec=12"}
+    q141["Token_token (141)<br/>Basic<br/>"]
+    q142["Token_Name_ID (142)<br/>Basic<br/>"]
+    q143["Token_Colon (143)<br/>Basic<br/>"]
+    q144["Token_Regexp_RegexLiteral (144)<br/>Basic<br/>"]
+    q145["Token_Semicolon (145)<br/>Basic<br/>"]
+    q146["Token__Basic_4 (146)<br/>Basic<br/>"]
+    q147{"Token__Basic_5 (147)<br/>Basic<br/><br/>dec=13"}
 
-    q18 --> q137
-    q131 -->|"tok(&quot;hidden&quot;)"| q132
-    q132 --> q136
-    q133 -->|"tok(&quot;comment&quot;)"| q134
-    q134 --> q136
-    q135 --> q131
-    q135 --> q133
-    q136 --> q138
-    q137 --> q135
-    q137 --> q136
-    q138 -->|"tok(&quot;token&quot;)"| q139
-    q139 -->|"tok(ID)"| q140
-    q140 -->|"tok(&quot;:&quot;)"| q141
-    q141 -->|"tok(RegexLiteral)"| q144
-    q142 -->|"tok(&quot;;&quot;)"| q143
-    q143 --> q19
-    q144 --> q142
-    q144 --> q143
+    q18 --> q140
+    q134 -->|"tok(&quot;hidden&quot;)"| q135
+    q135 --> q139
+    q136 -->|"tok(&quot;comment&quot;)"| q137
+    q137 --> q139
+    q138 --> q134
+    q138 --> q136
+    q139 --> q141
+    q140 --> q138
+    q140 --> q139
+    q141 -->|"tok(&quot;token&quot;)"| q142
+    q142 -->|"tok(ID)"| q143
+    q143 -->|"tok(&quot;:&quot;)"| q144
+    q144 -->|"tok(RegexLiteral)"| q147
+    q145 -->|"tok(&quot;;&quot;)"| q146
+    q146 --> q19
+    q147 --> q145
+    q147 --> q146
 ```
 
 ## TokenGroup
@@ -311,47 +318,47 @@ flowchart TD
 flowchart TD
     q20(["TokenGroup__Start (20)<br/>RuleStart"])
     q21(["TokenGroup__Stop (21)<br/>RuleStop"])
-    q145["TokenGroup_token (145)<br/>Basic<br/>"]
-    q146["TokenGroup_group (146)<br/>Basic<br/>"]
-    q147["TokenGroup_Name_ID (147)<br/>Basic<br/>"]
-    q148["TokenGroup_LeftBrace (148)<br/>Basic<br/>"]
-    q149["TokenGroup_TokenRefs_ID (149)<br/>Basic<br/>"]
-    q150["TokenGroup__Basic_0 (150)<br/>Basic<br/>"]
-    q151["TokenGroup_keywords (151)<br/>Basic<br/>"]
-    q152["TokenGroup_Regexps_RegexLiteral (152)<br/>Basic<br/>"]
-    q153["TokenGroup__Basic_1 (153)<br/>Basic<br/>"]
-    q154["TokenGroup__Basic_2 (154)<br/>Basic<br/>"]
-    q155["TokenGroup__Basic_3 (155)<br/>Basic<br/>"]
-    q156{"TokenGroup__Basic_4 (156)<br/>Basic<br/><br/>dec=13"}
-    q157["TokenGroup__BlockEnd (157)<br/>BlockEnd<br/>"]
-    q158{"TokenGroup__LoopEntry (158)<br/>LoopEntry<br/><br/>dec=14"}
-    q159["TokenGroup__LoopEnd (159)<br/>LoopEnd<br/>"]
-    q160["TokenGroup__LoopBack (160)<br/>LoopBack<br/>"]
-    q161["TokenGroup_RightBrace (161)<br/>Basic<br/>"]
-    q162["TokenGroup__Basic_5 (162)<br/>Basic<br/>"]
+    q148["TokenGroup_token (148)<br/>Basic<br/>"]
+    q149["TokenGroup_group (149)<br/>Basic<br/>"]
+    q150["TokenGroup_Name_ID (150)<br/>Basic<br/>"]
+    q151["TokenGroup_LeftBrace (151)<br/>Basic<br/>"]
+    q152["TokenGroup_TokenRefs_ID (152)<br/>Basic<br/>"]
+    q153["TokenGroup__Basic_0 (153)<br/>Basic<br/>"]
+    q154["TokenGroup_keywords (154)<br/>Basic<br/>"]
+    q155["TokenGroup_Regexps_RegexLiteral (155)<br/>Basic<br/>"]
+    q156["TokenGroup__Basic_1 (156)<br/>Basic<br/>"]
+    q157["TokenGroup__Basic_2 (157)<br/>Basic<br/>"]
+    q158["TokenGroup__Basic_3 (158)<br/>Basic<br/>"]
+    q159{"TokenGroup__Basic_4 (159)<br/>Basic<br/><br/>dec=14"}
+    q160["TokenGroup__BlockEnd (160)<br/>BlockEnd<br/>"]
+    q161{"TokenGroup__LoopEntry (161)<br/>LoopEntry<br/><br/>dec=15"}
+    q162["TokenGroup__LoopEnd (162)<br/>LoopEnd<br/>"]
+    q163["TokenGroup__LoopBack (163)<br/>LoopBack<br/>"]
+    q164["TokenGroup_RightBrace (164)<br/>Basic<br/>"]
+    q165["TokenGroup__Basic_5 (165)<br/>Basic<br/>"]
 
-    q20 --> q145
-    q145 -->|"tok(&quot;token&quot;)"| q146
-    q146 -->|"tok(&quot;group&quot;)"| q147
-    q147 -->|"tok(ID)"| q148
-    q148 -->|"tok(&quot;{&quot;)"| q158
-    q149 -->|"tok(ID)"| q150
-    q150 --> q157
-    q151 -->|"tok(&quot;keywords&quot;)"| q152
-    q152 -->|"tok(RegexLiteral)"| q153
-    q153 --> q157
-    q154 -.->|"[Keyword]"| q155
-    q155 --> q157
-    q156 --> q149
-    q156 --> q151
-    q156 --> q154
-    q157 --> q160
-    q158 --> q156
-    q158 --> q159
-    q159 --> q161
-    q160 --> q158
-    q161 -->|"tok(&quot;}&quot;)"| q162
-    q162 --> q21
+    q20 --> q148
+    q148 -->|"tok(&quot;token&quot;)"| q149
+    q149 -->|"tok(&quot;group&quot;)"| q150
+    q150 -->|"tok(ID)"| q151
+    q151 -->|"tok(&quot;{&quot;)"| q161
+    q152 -->|"tok(ID)"| q153
+    q153 --> q160
+    q154 -->|"tok(&quot;keywords&quot;)"| q155
+    q155 -->|"tok(RegexLiteral)"| q156
+    q156 --> q160
+    q157 -.->|"[Keyword]"| q158
+    q158 --> q160
+    q159 --> q152
+    q159 --> q154
+    q159 --> q157
+    q160 --> q163
+    q161 --> q159
+    q161 --> q162
+    q162 --> q164
+    q163 --> q161
+    q164 -->|"tok(&quot;}&quot;)"| q165
+    q165 --> q21
 ```
 
 ## Alternatives
@@ -360,24 +367,24 @@ flowchart TD
 flowchart TD
     q22(["Alternatives__Start (22)<br/>RuleStart"])
     q23(["Alternatives__Stop (23)<br/>RuleStop"])
-    q163["Alternatives__Basic_0 (163)<br/>Basic<br/>"]
-    q164["Alternatives_Pipe (164)<br/>Basic<br/>"]
-    q165["Alternatives__Basic_1 (165)<br/>Basic<br/>"]
-    q166["Alternatives__Basic_2 (166)<br/>Basic<br/>"]
-    q167{"Alternatives__LoopBack (167)<br/>LoopBack<br/><br/>dec=15"}
-    q168["Alternatives__LoopEnd (168)<br/>LoopEnd<br/>"]
-    q169{"Alternatives__Basic_3 (169)<br/>Basic<br/><br/>dec=16"}
+    q166["Alternatives__Basic_0 (166)<br/>Basic<br/>"]
+    q167["Alternatives_Pipe (167)<br/>Basic<br/>"]
+    q168["Alternatives__Basic_1 (168)<br/>Basic<br/>"]
+    q169["Alternatives__Basic_2 (169)<br/>Basic<br/>"]
+    q170{"Alternatives__LoopBack (170)<br/>LoopBack<br/><br/>dec=16"}
+    q171["Alternatives__LoopEnd (171)<br/>LoopEnd<br/>"]
+    q172{"Alternatives__Basic_3 (172)<br/>Basic<br/><br/>dec=17"}
 
-    q22 --> q163
-    q163 -.->|"[Group]"| q169
-    q164 -->|"tok(&quot;|&quot;)"| q165
-    q165 -.->|"[Group]"| q166
-    q166 --> q167
-    q167 --> q164
-    q167 --> q168
-    q168 --> q23
-    q169 --> q164
-    q169 --> q168
+    q22 --> q166
+    q166 -.->|"[Group]"| q172
+    q167 -->|"tok(&quot;|&quot;)"| q168
+    q168 -.->|"[Group]"| q169
+    q169 --> q170
+    q170 --> q167
+    q170 --> q171
+    q171 --> q23
+    q172 --> q167
+    q172 --> q171
 ```
 
 ## Group
@@ -386,22 +393,22 @@ flowchart TD
 flowchart TD
     q24(["Group__Start (24)<br/>RuleStart"])
     q25(["Group__Stop (25)<br/>RuleStop"])
-    q170["Group__Basic_0 (170)<br/>Basic<br/>"]
-    q171["Group__Basic_1 (171)<br/>Basic<br/>"]
-    q172["Group__Basic_2 (172)<br/>Basic<br/>"]
-    q173{"Group__LoopBack (173)<br/>LoopBack<br/><br/>dec=17"}
-    q174["Group__LoopEnd (174)<br/>LoopEnd<br/>"]
-    q175{"Group__Basic_3 (175)<br/>Basic<br/><br/>dec=18"}
+    q173["Group__Basic_0 (173)<br/>Basic<br/>"]
+    q174["Group__Basic_1 (174)<br/>Basic<br/>"]
+    q175["Group__Basic_2 (175)<br/>Basic<br/>"]
+    q176{"Group__LoopBack (176)<br/>LoopBack<br/><br/>dec=18"}
+    q177["Group__LoopEnd (177)<br/>LoopEnd<br/>"]
+    q178{"Group__Basic_3 (178)<br/>Basic<br/><br/>dec=19"}
 
-    q24 --> q170
-    q170 -.->|"[Element]"| q175
-    q171 -.->|"[Element]"| q172
-    q172 --> q173
-    q173 --> q171
-    q173 --> q174
-    q174 --> q25
-    q175 --> q171
-    q175 --> q174
+    q24 --> q173
+    q173 -.->|"[Element]"| q178
+    q174 -.->|"[Element]"| q175
+    q175 --> q176
+    q176 --> q174
+    q176 --> q177
+    q177 --> q25
+    q178 --> q174
+    q178 --> q177
 ```
 
 ## Element
@@ -410,61 +417,61 @@ flowchart TD
 flowchart TD
     q26(["Element__Start (26)<br/>RuleStart"])
     q27(["Element__Stop (27)<br/>RuleStop"])
-    q176["Element__Basic_0 (176)<br/>Basic<br/>"]
-    q177["Element__Basic_1 (177)<br/>Basic<br/>"]
-    q178["Element__Basic_2 (178)<br/>Basic<br/>"]
-    q179["Element__Basic_3 (179)<br/>Basic<br/>"]
-    q180["Element__Basic_4 (180)<br/>Basic<br/>"]
-    q181["Element__Basic_5 (181)<br/>Basic<br/>"]
-    q182["Element__Basic_6 (182)<br/>Basic<br/>"]
-    q183["Element__Basic_7 (183)<br/>Basic<br/>"]
-    q184["Element_LeftParen (184)<br/>Basic<br/>"]
-    q185["Element__Basic_8 (185)<br/>Basic<br/>"]
-    q186["Element_RightParen (186)<br/>Basic<br/>"]
-    q187["Element__Basic_9 (187)<br/>Basic<br/>"]
-    q188{"Element__Basic_10 (188)<br/>Basic<br/><br/>dec=19"}
-    q189["Element__BlockEnd_0 (189)<br/>BlockEnd<br/>"]
-    q190["Element_Cardinality_Asterisk (190)<br/>Basic<br/>"]
-    q191["Element__Basic_11 (191)<br/>Basic<br/>"]
-    q192["Element_Cardinality_Plus (192)<br/>Basic<br/>"]
-    q193["Element__Basic_12 (193)<br/>Basic<br/>"]
-    q194["Element_Cardinality_Question (194)<br/>Basic<br/>"]
-    q195["Element__Basic_13 (195)<br/>Basic<br/>"]
-    q196{"Element__Basic_14 (196)<br/>Basic<br/><br/>dec=20"}
-    q197["Element__BlockEnd_1 (197)<br/>BlockEnd<br/>"]
-    q198{"Element__Basic_15 (198)<br/>Basic<br/><br/>dec=21"}
+    q179["Element__Basic_0 (179)<br/>Basic<br/>"]
+    q180["Element__Basic_1 (180)<br/>Basic<br/>"]
+    q181["Element__Basic_2 (181)<br/>Basic<br/>"]
+    q182["Element__Basic_3 (182)<br/>Basic<br/>"]
+    q183["Element__Basic_4 (183)<br/>Basic<br/>"]
+    q184["Element__Basic_5 (184)<br/>Basic<br/>"]
+    q185["Element__Basic_6 (185)<br/>Basic<br/>"]
+    q186["Element__Basic_7 (186)<br/>Basic<br/>"]
+    q187["Element_LeftParen (187)<br/>Basic<br/>"]
+    q188["Element__Basic_8 (188)<br/>Basic<br/>"]
+    q189["Element_RightParen (189)<br/>Basic<br/>"]
+    q190["Element__Basic_9 (190)<br/>Basic<br/>"]
+    q191{"Element__Basic_10 (191)<br/>Basic<br/><br/>dec=20"}
+    q192["Element__BlockEnd_0 (192)<br/>BlockEnd<br/>"]
+    q193["Element_Cardinality_Asterisk (193)<br/>Basic<br/>"]
+    q194["Element__Basic_11 (194)<br/>Basic<br/>"]
+    q195["Element_Cardinality_Plus (195)<br/>Basic<br/>"]
+    q196["Element__Basic_12 (196)<br/>Basic<br/>"]
+    q197["Element_Cardinality_Question (197)<br/>Basic<br/>"]
+    q198["Element__Basic_13 (198)<br/>Basic<br/>"]
+    q199{"Element__Basic_14 (199)<br/>Basic<br/><br/>dec=21"}
+    q200["Element__BlockEnd_1 (200)<br/>BlockEnd<br/>"]
+    q201{"Element__Basic_15 (201)<br/>Basic<br/><br/>dec=22"}
 
-    q26 --> q188
-    q176 -.->|"[Keyword]"| q177
-    q177 --> q189
-    q178 -.->|"[Assignment]"| q179
-    q179 --> q189
-    q180 -.->|"[RuleCall]"| q181
-    q181 --> q189
-    q182 -.->|"[Action]"| q183
-    q183 --> q189
-    q184 -->|"tok(&quot;(&quot;)"| q185
-    q185 -.->|"[Alternatives]"| q186
-    q186 -->|"tok(&quot;)&quot;)"| q187
-    q187 --> q189
-    q188 --> q176
-    q188 --> q178
-    q188 --> q180
-    q188 --> q182
-    q188 --> q184
-    q189 --> q198
-    q190 -->|"tok(&quot;*&quot;)"| q191
-    q191 --> q197
-    q192 -->|"tok(&quot;+&quot;)"| q193
-    q193 --> q197
-    q194 -->|"tok(&quot;?&quot;)"| q195
-    q195 --> q197
-    q196 --> q190
-    q196 --> q192
-    q196 --> q194
-    q197 --> q27
-    q198 --> q196
-    q198 --> q197
+    q26 --> q191
+    q179 -.->|"[Keyword]"| q180
+    q180 --> q192
+    q181 -.->|"[Assignment]"| q182
+    q182 --> q192
+    q183 -.->|"[RuleCall]"| q184
+    q184 --> q192
+    q185 -.->|"[Action]"| q186
+    q186 --> q192
+    q187 -->|"tok(&quot;(&quot;)"| q188
+    q188 -.->|"[Alternatives]"| q189
+    q189 -->|"tok(&quot;)&quot;)"| q190
+    q190 --> q192
+    q191 --> q179
+    q191 --> q181
+    q191 --> q183
+    q191 --> q185
+    q191 --> q187
+    q192 --> q201
+    q193 -->|"tok(&quot;*&quot;)"| q194
+    q194 --> q200
+    q195 -->|"tok(&quot;+&quot;)"| q196
+    q196 --> q200
+    q197 -->|"tok(&quot;?&quot;)"| q198
+    q198 --> q200
+    q199 --> q193
+    q199 --> q195
+    q199 --> q197
+    q200 --> q27
+    q201 --> q199
+    q201 --> q200
 ```
 
 ## Keyword
@@ -473,12 +480,12 @@ flowchart TD
 flowchart TD
     q28(["Keyword__Start (28)<br/>RuleStart"])
     q29(["Keyword__Stop (29)<br/>RuleStop"])
-    q199["Keyword_Value_StringLiteral (199)<br/>Basic<br/>"]
-    q200["Keyword__Basic (200)<br/>Basic<br/>"]
+    q202["Keyword_Value_StringLiteral (202)<br/>Basic<br/>"]
+    q203["Keyword__Basic (203)<br/>Basic<br/>"]
 
-    q28 --> q199
-    q199 -->|"tok(StringLiteral)"| q200
-    q200 --> q29
+    q28 --> q202
+    q202 -->|"tok(StringLiteral)"| q203
+    q203 --> q29
 ```
 
 ## Assignment
@@ -487,32 +494,32 @@ flowchart TD
 flowchart TD
     q30(["Assignment__Start (30)<br/>RuleStart"])
     q31(["Assignment__Stop (31)<br/>RuleStop"])
-    q201["Assignment_Property_ID (201)<br/>Basic<br/>"]
-    q202["Assignment_Operator_PlusEquals (202)<br/>Basic<br/>"]
-    q203["Assignment__Basic_0 (203)<br/>Basic<br/>"]
-    q204["Assignment_Operator_Equals (204)<br/>Basic<br/>"]
-    q205["Assignment__Basic_1 (205)<br/>Basic<br/>"]
-    q206["Assignment_Operator_QuestionEquals (206)<br/>Basic<br/>"]
-    q207["Assignment__Basic_2 (207)<br/>Basic<br/>"]
-    q208{"Assignment__Basic_3 (208)<br/>Basic<br/><br/>dec=22"}
-    q209["Assignment__BlockEnd (209)<br/>BlockEnd<br/>"]
-    q210["Assignment__Basic_4 (210)<br/>Basic<br/>"]
-    q211["Assignment__Basic_5 (211)<br/>Basic<br/>"]
+    q204["Assignment_Property_ID (204)<br/>Basic<br/>"]
+    q205["Assignment_Operator_PlusEquals (205)<br/>Basic<br/>"]
+    q206["Assignment__Basic_0 (206)<br/>Basic<br/>"]
+    q207["Assignment_Operator_Equals (207)<br/>Basic<br/>"]
+    q208["Assignment__Basic_1 (208)<br/>Basic<br/>"]
+    q209["Assignment_Operator_QuestionEquals (209)<br/>Basic<br/>"]
+    q210["Assignment__Basic_2 (210)<br/>Basic<br/>"]
+    q211{"Assignment__Basic_3 (211)<br/>Basic<br/><br/>dec=23"}
+    q212["Assignment__BlockEnd (212)<br/>BlockEnd<br/>"]
+    q213["Assignment__Basic_4 (213)<br/>Basic<br/>"]
+    q214["Assignment__Basic_5 (214)<br/>Basic<br/>"]
 
-    q30 --> q201
-    q201 -->|"tok(ID)"| q208
-    q202 -->|"tok(&quot;+=&quot;)"| q203
-    q203 --> q209
-    q204 -->|"tok(&quot;=&quot;)"| q205
-    q205 --> q209
-    q206 -->|"tok(&quot;?=&quot;)"| q207
-    q207 --> q209
-    q208 --> q202
-    q208 --> q204
-    q208 --> q206
-    q209 --> q210
-    q210 -.->|"[Assignable]"| q211
-    q211 --> q31
+    q30 --> q204
+    q204 -->|"tok(ID)"| q211
+    q205 -->|"tok(&quot;+=&quot;)"| q206
+    q206 --> q212
+    q207 -->|"tok(&quot;=&quot;)"| q208
+    q208 --> q212
+    q209 -->|"tok(&quot;?=&quot;)"| q210
+    q210 --> q212
+    q211 --> q205
+    q211 --> q207
+    q211 --> q209
+    q212 --> q213
+    q213 -.->|"[Assignable]"| q214
+    q214 --> q31
 ```
 
 ## Assignable
@@ -521,35 +528,35 @@ flowchart TD
 flowchart TD
     q32(["Assignable__Start (32)<br/>RuleStart"])
     q33(["Assignable__Stop (33)<br/>RuleStop"])
-    q212["Assignable__Basic_0 (212)<br/>Basic<br/>"]
-    q213["Assignable__Basic_1 (213)<br/>Basic<br/>"]
-    q214["Assignable__Basic_2 (214)<br/>Basic<br/>"]
-    q215["Assignable__Basic_3 (215)<br/>Basic<br/>"]
-    q216["Assignable__Basic_4 (216)<br/>Basic<br/>"]
-    q217["Assignable__Basic_5 (217)<br/>Basic<br/>"]
-    q218["Assignable_LeftParen (218)<br/>Basic<br/>"]
-    q219["Assignable__Basic_6 (219)<br/>Basic<br/>"]
-    q220["Assignable_RightParen (220)<br/>Basic<br/>"]
-    q221["Assignable__Basic_7 (221)<br/>Basic<br/>"]
-    q222{"Assignable__Basic_8 (222)<br/>Basic<br/><br/>dec=23"}
-    q223["Assignable__BlockEnd (223)<br/>BlockEnd<br/>"]
+    q215["Assignable__Basic_0 (215)<br/>Basic<br/>"]
+    q216["Assignable__Basic_1 (216)<br/>Basic<br/>"]
+    q217["Assignable__Basic_2 (217)<br/>Basic<br/>"]
+    q218["Assignable__Basic_3 (218)<br/>Basic<br/>"]
+    q219["Assignable__Basic_4 (219)<br/>Basic<br/>"]
+    q220["Assignable__Basic_5 (220)<br/>Basic<br/>"]
+    q221["Assignable_LeftParen (221)<br/>Basic<br/>"]
+    q222["Assignable__Basic_6 (222)<br/>Basic<br/>"]
+    q223["Assignable_RightParen (223)<br/>Basic<br/>"]
+    q224["Assignable__Basic_7 (224)<br/>Basic<br/>"]
+    q225{"Assignable__Basic_8 (225)<br/>Basic<br/><br/>dec=24"}
+    q226["Assignable__BlockEnd (226)<br/>BlockEnd<br/>"]
 
-    q32 --> q222
-    q212 -.->|"[Keyword]"| q213
-    q213 --> q223
-    q214 -.->|"[RuleCall]"| q215
-    q215 --> q223
-    q216 -.->|"[CrossRef]"| q217
-    q217 --> q223
-    q218 -->|"tok(&quot;(&quot;)"| q219
-    q219 -.->|"[AssignableAlternatives]"| q220
-    q220 -->|"tok(&quot;)&quot;)"| q221
-    q221 --> q223
-    q222 --> q212
-    q222 --> q214
-    q222 --> q216
-    q222 --> q218
-    q223 --> q33
+    q32 --> q225
+    q215 -.->|"[Keyword]"| q216
+    q216 --> q226
+    q217 -.->|"[RuleCall]"| q218
+    q218 --> q226
+    q219 -.->|"[CrossRef]"| q220
+    q220 --> q226
+    q221 -->|"tok(&quot;(&quot;)"| q222
+    q222 -.->|"[AssignableAlternatives]"| q223
+    q223 -->|"tok(&quot;)&quot;)"| q224
+    q224 --> q226
+    q225 --> q215
+    q225 --> q217
+    q225 --> q219
+    q225 --> q221
+    q226 --> q33
 ```
 
 ## AssignableWithoutAlts
@@ -558,26 +565,26 @@ flowchart TD
 flowchart TD
     q34(["AssignableWithoutAlts__Start (34)<br/>RuleStart"])
     q35(["AssignableWithoutAlts__Stop (35)<br/>RuleStop"])
-    q224["AssignableWithoutAlts__Basic_0 (224)<br/>Basic<br/>"]
-    q225["AssignableWithoutAlts__Basic_1 (225)<br/>Basic<br/>"]
-    q226["AssignableWithoutAlts__Basic_2 (226)<br/>Basic<br/>"]
-    q227["AssignableWithoutAlts__Basic_3 (227)<br/>Basic<br/>"]
-    q228["AssignableWithoutAlts__Basic_4 (228)<br/>Basic<br/>"]
-    q229["AssignableWithoutAlts__Basic_5 (229)<br/>Basic<br/>"]
-    q230{"AssignableWithoutAlts__Basic_6 (230)<br/>Basic<br/><br/>dec=24"}
-    q231["AssignableWithoutAlts__BlockEnd (231)<br/>BlockEnd<br/>"]
+    q227["AssignableWithoutAlts__Basic_0 (227)<br/>Basic<br/>"]
+    q228["AssignableWithoutAlts__Basic_1 (228)<br/>Basic<br/>"]
+    q229["AssignableWithoutAlts__Basic_2 (229)<br/>Basic<br/>"]
+    q230["AssignableWithoutAlts__Basic_3 (230)<br/>Basic<br/>"]
+    q231["AssignableWithoutAlts__Basic_4 (231)<br/>Basic<br/>"]
+    q232["AssignableWithoutAlts__Basic_5 (232)<br/>Basic<br/>"]
+    q233{"AssignableWithoutAlts__Basic_6 (233)<br/>Basic<br/><br/>dec=25"}
+    q234["AssignableWithoutAlts__BlockEnd (234)<br/>BlockEnd<br/>"]
 
-    q34 --> q230
-    q224 -.->|"[Keyword]"| q225
-    q225 --> q231
-    q226 -.->|"[RuleCall]"| q227
-    q227 --> q231
-    q228 -.->|"[CrossRef]"| q229
-    q229 --> q231
-    q230 --> q224
-    q230 --> q226
-    q230 --> q228
-    q231 --> q35
+    q34 --> q233
+    q227 -.->|"[Keyword]"| q228
+    q228 --> q234
+    q229 -.->|"[RuleCall]"| q230
+    q230 --> q234
+    q231 -.->|"[CrossRef]"| q232
+    q232 --> q234
+    q233 --> q227
+    q233 --> q229
+    q233 --> q231
+    q234 --> q35
 ```
 
 ## AssignableAlternatives
@@ -586,24 +593,24 @@ flowchart TD
 flowchart TD
     q36(["AssignableAlternatives__Start (36)<br/>RuleStart"])
     q37(["AssignableAlternatives__Stop (37)<br/>RuleStop"])
-    q232["AssignableAlternatives__Basic_0 (232)<br/>Basic<br/>"]
-    q233["AssignableAlternatives_Pipe (233)<br/>Basic<br/>"]
-    q234["AssignableAlternatives__Basic_1 (234)<br/>Basic<br/>"]
-    q235["AssignableAlternatives__Basic_2 (235)<br/>Basic<br/>"]
-    q236{"AssignableAlternatives__LoopBack (236)<br/>LoopBack<br/><br/>dec=25"}
-    q237["AssignableAlternatives__LoopEnd (237)<br/>LoopEnd<br/>"]
-    q238{"AssignableAlternatives__Basic_3 (238)<br/>Basic<br/><br/>dec=26"}
+    q235["AssignableAlternatives__Basic_0 (235)<br/>Basic<br/>"]
+    q236["AssignableAlternatives_Pipe (236)<br/>Basic<br/>"]
+    q237["AssignableAlternatives__Basic_1 (237)<br/>Basic<br/>"]
+    q238["AssignableAlternatives__Basic_2 (238)<br/>Basic<br/>"]
+    q239{"AssignableAlternatives__LoopBack (239)<br/>LoopBack<br/><br/>dec=26"}
+    q240["AssignableAlternatives__LoopEnd (240)<br/>LoopEnd<br/>"]
+    q241{"AssignableAlternatives__Basic_3 (241)<br/>Basic<br/><br/>dec=27"}
 
-    q36 --> q232
-    q232 -.->|"[AssignableWithoutAlts]"| q238
-    q233 -->|"tok(&quot;|&quot;)"| q234
-    q234 -.->|"[AssignableWithoutAlts]"| q235
-    q235 --> q236
-    q236 --> q233
-    q236 --> q237
-    q237 --> q37
-    q238 --> q233
-    q238 --> q237
+    q36 --> q235
+    q235 -.->|"[AssignableWithoutAlts]"| q241
+    q236 -->|"tok(&quot;|&quot;)"| q237
+    q237 -.->|"[AssignableWithoutAlts]"| q238
+    q238 --> q239
+    q239 --> q236
+    q239 --> q240
+    q240 --> q37
+    q241 --> q236
+    q241 --> q240
 ```
 
 ## CrossRef
@@ -612,25 +619,25 @@ flowchart TD
 flowchart TD
     q38(["CrossRef__Start (38)<br/>RuleStart"])
     q39(["CrossRef__Stop (39)<br/>RuleStop"])
-    q239["CrossRef_LeftBracket (239)<br/>Basic<br/>"]
-    q240["CrossRef_Type_ID (240)<br/>Basic<br/>"]
-    q241["CrossRef_Colon (241)<br/>Basic<br/>"]
-    q242["CrossRef__Basic_0 (242)<br/>Basic<br/>"]
-    q243["CrossRef__Basic_1 (243)<br/>Basic<br/>"]
-    q244{"CrossRef__Basic_2 (244)<br/>Basic<br/><br/>dec=27"}
-    q245["CrossRef_RightBracket (245)<br/>Basic<br/>"]
-    q246["CrossRef__Basic_3 (246)<br/>Basic<br/>"]
+    q242["CrossRef_LeftBracket (242)<br/>Basic<br/>"]
+    q243["CrossRef_Type_ID (243)<br/>Basic<br/>"]
+    q244["CrossRef_Colon (244)<br/>Basic<br/>"]
+    q245["CrossRef__Basic_0 (245)<br/>Basic<br/>"]
+    q246["CrossRef__Basic_1 (246)<br/>Basic<br/>"]
+    q247{"CrossRef__Basic_2 (247)<br/>Basic<br/><br/>dec=28"}
+    q248["CrossRef_RightBracket (248)<br/>Basic<br/>"]
+    q249["CrossRef__Basic_3 (249)<br/>Basic<br/>"]
 
-    q38 --> q239
-    q239 -->|"tok(&quot;[&quot;)"| q240
-    q240 -->|"tok(ID)"| q244
-    q241 -->|"tok(&quot;:&quot;)"| q242
-    q242 -.->|"[RuleCall]"| q243
-    q243 --> q245
-    q244 --> q241
-    q244 --> q243
-    q245 -->|"tok(&quot;]&quot;)"| q246
-    q246 --> q39
+    q38 --> q242
+    q242 -->|"tok(&quot;[&quot;)"| q243
+    q243 -->|"tok(ID)"| q247
+    q244 -->|"tok(&quot;:&quot;)"| q245
+    q245 -.->|"[RuleCall]"| q246
+    q246 --> q248
+    q247 --> q244
+    q247 --> q246
+    q248 -->|"tok(&quot;]&quot;)"| q249
+    q249 --> q39
 ```
 
 ## RuleCall
@@ -639,12 +646,12 @@ flowchart TD
 flowchart TD
     q40(["RuleCall__Start (40)<br/>RuleStart"])
     q41(["RuleCall__Stop (41)<br/>RuleStop"])
-    q247["RuleCall_Rule_ID (247)<br/>Basic<br/>"]
-    q248["RuleCall__Basic (248)<br/>Basic<br/>"]
+    q250["RuleCall_Rule_ID (250)<br/>Basic<br/>"]
+    q251["RuleCall__Basic (251)<br/>Basic<br/>"]
 
-    q40 --> q247
-    q247 -->|"tok(ID)"| q248
-    q248 --> q41
+    q40 --> q250
+    q250 -->|"tok(ID)"| q251
+    q251 --> q41
 ```
 
 ## Action
@@ -653,40 +660,40 @@ flowchart TD
 flowchart TD
     q42(["Action__Start (42)<br/>RuleStart"])
     q43(["Action__Stop (43)<br/>RuleStop"])
-    q249["Action_LeftBrace (249)<br/>Basic<br/>"]
-    q250["Action_Type_ID (250)<br/>Basic<br/>"]
-    q251["Action_Dot (251)<br/>Basic<br/>"]
-    q252["Action_Property_ID (252)<br/>Basic<br/>"]
-    q253["Action_Operator_PlusEquals (253)<br/>Basic<br/>"]
-    q254["Action__Basic_0 (254)<br/>Basic<br/>"]
-    q255["Action_Operator_Equals (255)<br/>Basic<br/>"]
-    q256["Action__Basic_1 (256)<br/>Basic<br/>"]
-    q257{"Action__Basic_2 (257)<br/>Basic<br/><br/>dec=28"}
-    q258["Action__BlockEnd (258)<br/>BlockEnd<br/>"]
-    q259["Action_current (259)<br/>Basic<br/>"]
-    q260["Action__Basic_3 (260)<br/>Basic<br/>"]
-    q261{"Action__Basic_4 (261)<br/>Basic<br/><br/>dec=29"}
-    q262["Action_RightBrace (262)<br/>Basic<br/>"]
-    q263["Action__Basic_5 (263)<br/>Basic<br/>"]
+    q252["Action_LeftBrace (252)<br/>Basic<br/>"]
+    q253["Action_Type_ID (253)<br/>Basic<br/>"]
+    q254["Action_Dot (254)<br/>Basic<br/>"]
+    q255["Action_Property_ID (255)<br/>Basic<br/>"]
+    q256["Action_Operator_PlusEquals (256)<br/>Basic<br/>"]
+    q257["Action__Basic_0 (257)<br/>Basic<br/>"]
+    q258["Action_Operator_Equals (258)<br/>Basic<br/>"]
+    q259["Action__Basic_1 (259)<br/>Basic<br/>"]
+    q260{"Action__Basic_2 (260)<br/>Basic<br/><br/>dec=29"}
+    q261["Action__BlockEnd (261)<br/>BlockEnd<br/>"]
+    q262["Action_current (262)<br/>Basic<br/>"]
+    q263["Action__Basic_3 (263)<br/>Basic<br/>"]
+    q264{"Action__Basic_4 (264)<br/>Basic<br/><br/>dec=30"}
+    q265["Action_RightBrace (265)<br/>Basic<br/>"]
+    q266["Action__Basic_5 (266)<br/>Basic<br/>"]
 
-    q42 --> q249
-    q249 -->|"tok(&quot;{&quot;)"| q250
-    q250 -->|"tok(ID)"| q261
-    q251 -->|"tok(&quot;.&quot;)"| q252
-    q252 -->|"tok(ID)"| q257
-    q253 -->|"tok(&quot;+=&quot;)"| q254
-    q254 --> q258
-    q255 -->|"tok(&quot;=&quot;)"| q256
-    q256 --> q258
-    q257 --> q253
-    q257 --> q255
-    q258 --> q259
-    q259 -->|"tok(&quot;current&quot;)"| q260
-    q260 --> q262
-    q261 --> q251
-    q261 --> q260
-    q262 -->|"tok(&quot;}&quot;)"| q263
-    q263 --> q43
+    q42 --> q252
+    q252 -->|"tok(&quot;{&quot;)"| q253
+    q253 -->|"tok(ID)"| q264
+    q254 -->|"tok(&quot;.&quot;)"| q255
+    q255 -->|"tok(ID)"| q260
+    q256 -->|"tok(&quot;+=&quot;)"| q257
+    q257 --> q261
+    q258 -->|"tok(&quot;=&quot;)"| q259
+    q259 --> q261
+    q260 --> q256
+    q260 --> q258
+    q261 --> q262
+    q262 -->|"tok(&quot;current&quot;)"| q263
+    q263 --> q265
+    q264 --> q254
+    q264 --> q263
+    q265 -->|"tok(&quot;}&quot;)"| q266
+    q266 --> q43
 ```
 
 ## CompositeRule
@@ -695,23 +702,23 @@ flowchart TD
 flowchart TD
     q44(["CompositeRule__Start (44)<br/>RuleStart"])
     q45(["CompositeRule__Stop (45)<br/>RuleStop"])
-    q264["CompositeRule_composite (264)<br/>Basic<br/>"]
-    q265["CompositeRule_Name_ID (265)<br/>Basic<br/>"]
-    q266["CompositeRule_Colon (266)<br/>Basic<br/>"]
-    q267["CompositeRule__Basic_0 (267)<br/>Basic<br/>"]
-    q268["CompositeRule_Semicolon (268)<br/>Basic<br/>"]
-    q269["CompositeRule__Basic_1 (269)<br/>Basic<br/>"]
-    q270{"CompositeRule__Basic_2 (270)<br/>Basic<br/><br/>dec=30"}
+    q267["CompositeRule_composite (267)<br/>Basic<br/>"]
+    q268["CompositeRule_Name_ID (268)<br/>Basic<br/>"]
+    q269["CompositeRule_Colon (269)<br/>Basic<br/>"]
+    q270["CompositeRule__Basic_0 (270)<br/>Basic<br/>"]
+    q271["CompositeRule_Semicolon (271)<br/>Basic<br/>"]
+    q272["CompositeRule__Basic_1 (272)<br/>Basic<br/>"]
+    q273{"CompositeRule__Basic_2 (273)<br/>Basic<br/><br/>dec=31"}
 
-    q44 --> q264
-    q264 -->|"tok(&quot;composite&quot;)"| q265
-    q265 -->|"tok(ID)"| q266
-    q266 -->|"tok(&quot;:&quot;)"| q267
-    q267 -.->|"[CompositeAlternatives]"| q270
-    q268 -->|"tok(&quot;;&quot;)"| q269
-    q269 --> q45
-    q270 --> q268
-    q270 --> q269
+    q44 --> q267
+    q267 -->|"tok(&quot;composite&quot;)"| q268
+    q268 -->|"tok(ID)"| q269
+    q269 -->|"tok(&quot;:&quot;)"| q270
+    q270 -.->|"[CompositeAlternatives]"| q273
+    q271 -->|"tok(&quot;;&quot;)"| q272
+    q272 --> q45
+    q273 --> q271
+    q273 --> q272
 ```
 
 ## CompositeAlternatives
@@ -720,24 +727,24 @@ flowchart TD
 flowchart TD
     q46(["CompositeAlternatives__Start (46)<br/>RuleStart"])
     q47(["CompositeAlternatives__Stop (47)<br/>RuleStop"])
-    q271["CompositeAlternatives__Basic_0 (271)<br/>Basic<br/>"]
-    q272["CompositeAlternatives_Pipe (272)<br/>Basic<br/>"]
-    q273["CompositeAlternatives__Basic_1 (273)<br/>Basic<br/>"]
-    q274["CompositeAlternatives__Basic_2 (274)<br/>Basic<br/>"]
-    q275{"CompositeAlternatives__LoopBack (275)<br/>LoopBack<br/><br/>dec=31"}
-    q276["CompositeAlternatives__LoopEnd (276)<br/>LoopEnd<br/>"]
-    q277{"CompositeAlternatives__Basic_3 (277)<br/>Basic<br/><br/>dec=32"}
+    q274["CompositeAlternatives__Basic_0 (274)<br/>Basic<br/>"]
+    q275["CompositeAlternatives_Pipe (275)<br/>Basic<br/>"]
+    q276["CompositeAlternatives__Basic_1 (276)<br/>Basic<br/>"]
+    q277["CompositeAlternatives__Basic_2 (277)<br/>Basic<br/>"]
+    q278{"CompositeAlternatives__LoopBack (278)<br/>LoopBack<br/><br/>dec=32"}
+    q279["CompositeAlternatives__LoopEnd (279)<br/>LoopEnd<br/>"]
+    q280{"CompositeAlternatives__Basic_3 (280)<br/>Basic<br/><br/>dec=33"}
 
-    q46 --> q271
-    q271 -.->|"[CompositeGroup]"| q277
-    q272 -->|"tok(&quot;|&quot;)"| q273
-    q273 -.->|"[CompositeGroup]"| q274
-    q274 --> q275
-    q275 --> q272
-    q275 --> q276
-    q276 --> q47
-    q277 --> q272
-    q277 --> q276
+    q46 --> q274
+    q274 -.->|"[CompositeGroup]"| q280
+    q275 -->|"tok(&quot;|&quot;)"| q276
+    q276 -.->|"[CompositeGroup]"| q277
+    q277 --> q278
+    q278 --> q275
+    q278 --> q279
+    q279 --> q47
+    q280 --> q275
+    q280 --> q279
 ```
 
 ## CompositeGroup
@@ -746,22 +753,22 @@ flowchart TD
 flowchart TD
     q48(["CompositeGroup__Start (48)<br/>RuleStart"])
     q49(["CompositeGroup__Stop (49)<br/>RuleStop"])
-    q278["CompositeGroup__Basic_0 (278)<br/>Basic<br/>"]
-    q279["CompositeGroup__Basic_1 (279)<br/>Basic<br/>"]
-    q280["CompositeGroup__Basic_2 (280)<br/>Basic<br/>"]
-    q281{"CompositeGroup__LoopBack (281)<br/>LoopBack<br/><br/>dec=33"}
-    q282["CompositeGroup__LoopEnd (282)<br/>LoopEnd<br/>"]
-    q283{"CompositeGroup__Basic_3 (283)<br/>Basic<br/><br/>dec=34"}
+    q281["CompositeGroup__Basic_0 (281)<br/>Basic<br/>"]
+    q282["CompositeGroup__Basic_1 (282)<br/>Basic<br/>"]
+    q283["CompositeGroup__Basic_2 (283)<br/>Basic<br/>"]
+    q284{"CompositeGroup__LoopBack (284)<br/>LoopBack<br/><br/>dec=34"}
+    q285["CompositeGroup__LoopEnd (285)<br/>LoopEnd<br/>"]
+    q286{"CompositeGroup__Basic_3 (286)<br/>Basic<br/><br/>dec=35"}
 
-    q48 --> q278
-    q278 -.->|"[CompositeElement]"| q283
-    q279 -.->|"[CompositeElement]"| q280
-    q280 --> q281
-    q281 --> q279
-    q281 --> q282
-    q282 --> q49
-    q283 --> q279
-    q283 --> q282
+    q48 --> q281
+    q281 -.->|"[CompositeElement]"| q286
+    q282 -.->|"[CompositeElement]"| q283
+    q283 --> q284
+    q284 --> q282
+    q284 --> q285
+    q285 --> q49
+    q286 --> q282
+    q286 --> q285
 ```
 
 ## CompositeElement
@@ -770,50 +777,50 @@ flowchart TD
 flowchart TD
     q50(["CompositeElement__Start (50)<br/>RuleStart"])
     q51(["CompositeElement__Stop (51)<br/>RuleStop"])
-    q284["CompositeElement__Basic_0 (284)<br/>Basic<br/>"]
-    q285["CompositeElement__Basic_1 (285)<br/>Basic<br/>"]
-    q286["CompositeElement__Basic_2 (286)<br/>Basic<br/>"]
-    q287["CompositeElement__Basic_3 (287)<br/>Basic<br/>"]
-    q288["CompositeElement_LeftParen (288)<br/>Basic<br/>"]
-    q289["CompositeElement__Basic_4 (289)<br/>Basic<br/>"]
-    q290["CompositeElement_RightParen (290)<br/>Basic<br/>"]
-    q291["CompositeElement__Basic_5 (291)<br/>Basic<br/>"]
-    q292{"CompositeElement__Basic_6 (292)<br/>Basic<br/><br/>dec=35"}
-    q293["CompositeElement__BlockEnd_0 (293)<br/>BlockEnd<br/>"]
-    q294["CompositeElement_Cardinality_Asterisk (294)<br/>Basic<br/>"]
-    q295["CompositeElement__Basic_7 (295)<br/>Basic<br/>"]
-    q296["CompositeElement_Cardinality_Plus (296)<br/>Basic<br/>"]
-    q297["CompositeElement__Basic_8 (297)<br/>Basic<br/>"]
-    q298["CompositeElement_Cardinality_Question (298)<br/>Basic<br/>"]
-    q299["CompositeElement__Basic_9 (299)<br/>Basic<br/>"]
-    q300{"CompositeElement__Basic_10 (300)<br/>Basic<br/><br/>dec=36"}
-    q301["CompositeElement__BlockEnd_1 (301)<br/>BlockEnd<br/>"]
-    q302{"CompositeElement__Basic_11 (302)<br/>Basic<br/><br/>dec=37"}
+    q287["CompositeElement__Basic_0 (287)<br/>Basic<br/>"]
+    q288["CompositeElement__Basic_1 (288)<br/>Basic<br/>"]
+    q289["CompositeElement__Basic_2 (289)<br/>Basic<br/>"]
+    q290["CompositeElement__Basic_3 (290)<br/>Basic<br/>"]
+    q291["CompositeElement_LeftParen (291)<br/>Basic<br/>"]
+    q292["CompositeElement__Basic_4 (292)<br/>Basic<br/>"]
+    q293["CompositeElement_RightParen (293)<br/>Basic<br/>"]
+    q294["CompositeElement__Basic_5 (294)<br/>Basic<br/>"]
+    q295{"CompositeElement__Basic_6 (295)<br/>Basic<br/><br/>dec=36"}
+    q296["CompositeElement__BlockEnd_0 (296)<br/>BlockEnd<br/>"]
+    q297["CompositeElement_Cardinality_Asterisk (297)<br/>Basic<br/>"]
+    q298["CompositeElement__Basic_7 (298)<br/>Basic<br/>"]
+    q299["CompositeElement_Cardinality_Plus (299)<br/>Basic<br/>"]
+    q300["CompositeElement__Basic_8 (300)<br/>Basic<br/>"]
+    q301["CompositeElement_Cardinality_Question (301)<br/>Basic<br/>"]
+    q302["CompositeElement__Basic_9 (302)<br/>Basic<br/>"]
+    q303{"CompositeElement__Basic_10 (303)<br/>Basic<br/><br/>dec=37"}
+    q304["CompositeElement__BlockEnd_1 (304)<br/>BlockEnd<br/>"]
+    q305{"CompositeElement__Basic_11 (305)<br/>Basic<br/><br/>dec=38"}
 
-    q50 --> q292
-    q284 -.->|"[Keyword]"| q285
-    q285 --> q293
-    q286 -.->|"[RuleCall]"| q287
-    q287 --> q293
-    q288 -->|"tok(&quot;(&quot;)"| q289
-    q289 -.->|"[CompositeAlternatives]"| q290
-    q290 -->|"tok(&quot;)&quot;)"| q291
-    q291 --> q293
-    q292 --> q284
-    q292 --> q286
-    q292 --> q288
-    q293 --> q302
-    q294 -->|"tok(&quot;*&quot;)"| q295
-    q295 --> q301
-    q296 -->|"tok(&quot;+&quot;)"| q297
-    q297 --> q301
-    q298 -->|"tok(&quot;?&quot;)"| q299
-    q299 --> q301
-    q300 --> q294
-    q300 --> q296
-    q300 --> q298
-    q301 --> q51
-    q302 --> q300
-    q302 --> q301
+    q50 --> q295
+    q287 -.->|"[Keyword]"| q288
+    q288 --> q296
+    q289 -.->|"[RuleCall]"| q290
+    q290 --> q296
+    q291 -->|"tok(&quot;(&quot;)"| q292
+    q292 -.->|"[CompositeAlternatives]"| q293
+    q293 -->|"tok(&quot;)&quot;)"| q294
+    q294 --> q296
+    q295 --> q287
+    q295 --> q289
+    q295 --> q291
+    q296 --> q305
+    q297 -->|"tok(&quot;*&quot;)"| q298
+    q298 --> q304
+    q299 -->|"tok(&quot;+&quot;)"| q300
+    q300 --> q304
+    q301 -->|"tok(&quot;?&quot;)"| q302
+    q302 --> q304
+    q303 --> q297
+    q303 --> q299
+    q303 --> q301
+    q304 --> q51
+    q305 --> q303
+    q305 --> q304
 ```
 

--- a/internal/grammar/atn_gen.go
+++ b/internal/grammar/atn_gen.go
@@ -129,16 +129,19 @@ const (
 	PrimitiveType__Basic_2
 	PrimitiveType__Basic_3
 	PrimitiveType__BlockEnd
+	ParserRule_Entry_entry
+	ParserRule__Basic_0
+	ParserRule__Basic_1
 	ParserRule_Name_ID
 	ParserRule_returns
 	ParserRule_ReturnType_ID
-	ParserRule__Basic_0
-	ParserRule__Basic_1
-	ParserRule_Colon
 	ParserRule__Basic_2
-	ParserRule_Semicolon
 	ParserRule__Basic_3
+	ParserRule_Colon
 	ParserRule__Basic_4
+	ParserRule_Semicolon
+	ParserRule__Basic_5
+	ParserRule__Basic_6
 	Token_Type_hidden
 	Token__Basic_0
 	Token_Type_comment
@@ -323,7 +326,7 @@ func ATN() *parser.RuntimeATN {
 	return atn
 }
 func BuildATN() *parser.RuntimeATN {
-	states := make([]*parser.RuntimeATNState, 303)
+	states := make([]*parser.RuntimeATNState, 306)
 	states[Grammar__Start] = parser.NewATNState(Grammar__Start, parser.ATNRuleStart, true)
 	states[Grammar__Stop] = parser.NewATNState(Grammar__Stop, parser.ATNRuleStop, false)
 	states[Interface__Start] = parser.NewATNState(Interface__Start, parser.ATNRuleStart, true)
@@ -445,30 +448,33 @@ func BuildATN() *parser.RuntimeATN {
 	states[PrimitiveType__Basic_2] = parser.NewATNState(PrimitiveType__Basic_2, parser.ATNBasic, true)
 	states[PrimitiveType__Basic_3] = parser.NewATNState(PrimitiveType__Basic_3, parser.ATNBasic, true).SetDecision(7)
 	states[PrimitiveType__BlockEnd] = parser.NewATNState(PrimitiveType__BlockEnd, parser.ATNBlockEnd, true)
+	states[ParserRule_Entry_entry] = parser.NewATNState(ParserRule_Entry_entry, parser.ATNBasic, false)
+	states[ParserRule__Basic_0] = parser.NewATNState(ParserRule__Basic_0, parser.ATNBasic, true)
+	states[ParserRule__Basic_1] = parser.NewATNState(ParserRule__Basic_1, parser.ATNBasic, true).SetDecision(8)
 	states[ParserRule_Name_ID] = parser.NewATNState(ParserRule_Name_ID, parser.ATNBasic, false)
 	states[ParserRule_returns] = parser.NewATNState(ParserRule_returns, parser.ATNBasic, false)
 	states[ParserRule_ReturnType_ID] = parser.NewATNState(ParserRule_ReturnType_ID, parser.ATNBasic, false)
-	states[ParserRule__Basic_0] = parser.NewATNState(ParserRule__Basic_0, parser.ATNBasic, true)
-	states[ParserRule__Basic_1] = parser.NewATNState(ParserRule__Basic_1, parser.ATNBasic, true).SetDecision(8)
-	states[ParserRule_Colon] = parser.NewATNState(ParserRule_Colon, parser.ATNBasic, false)
 	states[ParserRule__Basic_2] = parser.NewATNState(ParserRule__Basic_2, parser.ATNBasic, true)
+	states[ParserRule__Basic_3] = parser.NewATNState(ParserRule__Basic_3, parser.ATNBasic, true).SetDecision(9)
+	states[ParserRule_Colon] = parser.NewATNState(ParserRule_Colon, parser.ATNBasic, false)
+	states[ParserRule__Basic_4] = parser.NewATNState(ParserRule__Basic_4, parser.ATNBasic, true)
 	states[ParserRule_Semicolon] = parser.NewATNState(ParserRule_Semicolon, parser.ATNBasic, false)
-	states[ParserRule__Basic_3] = parser.NewATNState(ParserRule__Basic_3, parser.ATNBasic, true)
-	states[ParserRule__Basic_4] = parser.NewATNState(ParserRule__Basic_4, parser.ATNBasic, true).SetDecision(9)
+	states[ParserRule__Basic_5] = parser.NewATNState(ParserRule__Basic_5, parser.ATNBasic, true)
+	states[ParserRule__Basic_6] = parser.NewATNState(ParserRule__Basic_6, parser.ATNBasic, true).SetDecision(10)
 	states[Token_Type_hidden] = parser.NewATNState(Token_Type_hidden, parser.ATNBasic, false)
 	states[Token__Basic_0] = parser.NewATNState(Token__Basic_0, parser.ATNBasic, true)
 	states[Token_Type_comment] = parser.NewATNState(Token_Type_comment, parser.ATNBasic, false)
 	states[Token__Basic_1] = parser.NewATNState(Token__Basic_1, parser.ATNBasic, true)
-	states[Token__Basic_2] = parser.NewATNState(Token__Basic_2, parser.ATNBasic, true).SetDecision(10)
+	states[Token__Basic_2] = parser.NewATNState(Token__Basic_2, parser.ATNBasic, true).SetDecision(11)
 	states[Token__BlockEnd] = parser.NewATNState(Token__BlockEnd, parser.ATNBlockEnd, true)
-	states[Token__Basic_3] = parser.NewATNState(Token__Basic_3, parser.ATNBasic, true).SetDecision(11)
+	states[Token__Basic_3] = parser.NewATNState(Token__Basic_3, parser.ATNBasic, true).SetDecision(12)
 	states[Token_token] = parser.NewATNState(Token_token, parser.ATNBasic, false)
 	states[Token_Name_ID] = parser.NewATNState(Token_Name_ID, parser.ATNBasic, false)
 	states[Token_Colon] = parser.NewATNState(Token_Colon, parser.ATNBasic, false)
 	states[Token_Regexp_RegexLiteral] = parser.NewATNState(Token_Regexp_RegexLiteral, parser.ATNBasic, false)
 	states[Token_Semicolon] = parser.NewATNState(Token_Semicolon, parser.ATNBasic, false)
 	states[Token__Basic_4] = parser.NewATNState(Token__Basic_4, parser.ATNBasic, true)
-	states[Token__Basic_5] = parser.NewATNState(Token__Basic_5, parser.ATNBasic, true).SetDecision(12)
+	states[Token__Basic_5] = parser.NewATNState(Token__Basic_5, parser.ATNBasic, true).SetDecision(13)
 	states[TokenGroup_token] = parser.NewATNState(TokenGroup_token, parser.ATNBasic, false)
 	states[TokenGroup_group] = parser.NewATNState(TokenGroup_group, parser.ATNBasic, false)
 	states[TokenGroup_Name_ID] = parser.NewATNState(TokenGroup_Name_ID, parser.ATNBasic, false)
@@ -480,9 +486,9 @@ func BuildATN() *parser.RuntimeATN {
 	states[TokenGroup__Basic_1] = parser.NewATNState(TokenGroup__Basic_1, parser.ATNBasic, true)
 	states[TokenGroup__Basic_2] = parser.NewATNState(TokenGroup__Basic_2, parser.ATNBasic, true)
 	states[TokenGroup__Basic_3] = parser.NewATNState(TokenGroup__Basic_3, parser.ATNBasic, true)
-	states[TokenGroup__Basic_4] = parser.NewATNState(TokenGroup__Basic_4, parser.ATNBasic, true).SetDecision(13)
+	states[TokenGroup__Basic_4] = parser.NewATNState(TokenGroup__Basic_4, parser.ATNBasic, true).SetDecision(14)
 	states[TokenGroup__BlockEnd] = parser.NewATNState(TokenGroup__BlockEnd, parser.ATNBlockEnd, true)
-	states[TokenGroup__LoopEntry] = parser.NewATNState(TokenGroup__LoopEntry, parser.ATNLoopEntry, true).SetDecision(14)
+	states[TokenGroup__LoopEntry] = parser.NewATNState(TokenGroup__LoopEntry, parser.ATNLoopEntry, true).SetDecision(15)
 	states[TokenGroup__LoopEnd] = parser.NewATNState(TokenGroup__LoopEnd, parser.ATNLoopEnd, true)
 	states[TokenGroup__LoopBack] = parser.NewATNState(TokenGroup__LoopBack, parser.ATNLoopBack, true)
 	states[TokenGroup_RightBrace] = parser.NewATNState(TokenGroup_RightBrace, parser.ATNBasic, false)
@@ -491,15 +497,15 @@ func BuildATN() *parser.RuntimeATN {
 	states[Alternatives_Pipe] = parser.NewATNState(Alternatives_Pipe, parser.ATNBasic, false)
 	states[Alternatives__Basic_1] = parser.NewATNState(Alternatives__Basic_1, parser.ATNBasic, true)
 	states[Alternatives__Basic_2] = parser.NewATNState(Alternatives__Basic_2, parser.ATNBasic, true)
-	states[Alternatives__LoopBack] = parser.NewATNState(Alternatives__LoopBack, parser.ATNLoopBack, true).SetDecision(15)
+	states[Alternatives__LoopBack] = parser.NewATNState(Alternatives__LoopBack, parser.ATNLoopBack, true).SetDecision(16)
 	states[Alternatives__LoopEnd] = parser.NewATNState(Alternatives__LoopEnd, parser.ATNLoopEnd, true)
-	states[Alternatives__Basic_3] = parser.NewATNState(Alternatives__Basic_3, parser.ATNBasic, true).SetDecision(16)
+	states[Alternatives__Basic_3] = parser.NewATNState(Alternatives__Basic_3, parser.ATNBasic, true).SetDecision(17)
 	states[Group__Basic_0] = parser.NewATNState(Group__Basic_0, parser.ATNBasic, true)
 	states[Group__Basic_1] = parser.NewATNState(Group__Basic_1, parser.ATNBasic, true)
 	states[Group__Basic_2] = parser.NewATNState(Group__Basic_2, parser.ATNBasic, true)
-	states[Group__LoopBack] = parser.NewATNState(Group__LoopBack, parser.ATNLoopBack, true).SetDecision(17)
+	states[Group__LoopBack] = parser.NewATNState(Group__LoopBack, parser.ATNLoopBack, true).SetDecision(18)
 	states[Group__LoopEnd] = parser.NewATNState(Group__LoopEnd, parser.ATNLoopEnd, true)
-	states[Group__Basic_3] = parser.NewATNState(Group__Basic_3, parser.ATNBasic, true).SetDecision(18)
+	states[Group__Basic_3] = parser.NewATNState(Group__Basic_3, parser.ATNBasic, true).SetDecision(19)
 	states[Element__Basic_0] = parser.NewATNState(Element__Basic_0, parser.ATNBasic, true)
 	states[Element__Basic_1] = parser.NewATNState(Element__Basic_1, parser.ATNBasic, true)
 	states[Element__Basic_2] = parser.NewATNState(Element__Basic_2, parser.ATNBasic, true)
@@ -512,7 +518,7 @@ func BuildATN() *parser.RuntimeATN {
 	states[Element__Basic_8] = parser.NewATNState(Element__Basic_8, parser.ATNBasic, true)
 	states[Element_RightParen] = parser.NewATNState(Element_RightParen, parser.ATNBasic, false)
 	states[Element__Basic_9] = parser.NewATNState(Element__Basic_9, parser.ATNBasic, true)
-	states[Element__Basic_10] = parser.NewATNState(Element__Basic_10, parser.ATNBasic, true).SetDecision(19)
+	states[Element__Basic_10] = parser.NewATNState(Element__Basic_10, parser.ATNBasic, true).SetDecision(20)
 	states[Element__BlockEnd_0] = parser.NewATNState(Element__BlockEnd_0, parser.ATNBlockEnd, true)
 	states[Element_Cardinality_Asterisk] = parser.NewATNState(Element_Cardinality_Asterisk, parser.ATNBasic, false)
 	states[Element__Basic_11] = parser.NewATNState(Element__Basic_11, parser.ATNBasic, true)
@@ -520,9 +526,9 @@ func BuildATN() *parser.RuntimeATN {
 	states[Element__Basic_12] = parser.NewATNState(Element__Basic_12, parser.ATNBasic, true)
 	states[Element_Cardinality_Question] = parser.NewATNState(Element_Cardinality_Question, parser.ATNBasic, false)
 	states[Element__Basic_13] = parser.NewATNState(Element__Basic_13, parser.ATNBasic, true)
-	states[Element__Basic_14] = parser.NewATNState(Element__Basic_14, parser.ATNBasic, true).SetDecision(20)
+	states[Element__Basic_14] = parser.NewATNState(Element__Basic_14, parser.ATNBasic, true).SetDecision(21)
 	states[Element__BlockEnd_1] = parser.NewATNState(Element__BlockEnd_1, parser.ATNBlockEnd, true)
-	states[Element__Basic_15] = parser.NewATNState(Element__Basic_15, parser.ATNBasic, true).SetDecision(21)
+	states[Element__Basic_15] = parser.NewATNState(Element__Basic_15, parser.ATNBasic, true).SetDecision(22)
 	states[Keyword_Value_StringLiteral] = parser.NewATNState(Keyword_Value_StringLiteral, parser.ATNBasic, false)
 	states[Keyword__Basic] = parser.NewATNState(Keyword__Basic, parser.ATNBasic, true)
 	states[Assignment_Property_ID] = parser.NewATNState(Assignment_Property_ID, parser.ATNBasic, false)
@@ -532,7 +538,7 @@ func BuildATN() *parser.RuntimeATN {
 	states[Assignment__Basic_1] = parser.NewATNState(Assignment__Basic_1, parser.ATNBasic, true)
 	states[Assignment_Operator_QuestionEquals] = parser.NewATNState(Assignment_Operator_QuestionEquals, parser.ATNBasic, false)
 	states[Assignment__Basic_2] = parser.NewATNState(Assignment__Basic_2, parser.ATNBasic, true)
-	states[Assignment__Basic_3] = parser.NewATNState(Assignment__Basic_3, parser.ATNBasic, true).SetDecision(22)
+	states[Assignment__Basic_3] = parser.NewATNState(Assignment__Basic_3, parser.ATNBasic, true).SetDecision(23)
 	states[Assignment__BlockEnd] = parser.NewATNState(Assignment__BlockEnd, parser.ATNBlockEnd, true)
 	states[Assignment__Basic_4] = parser.NewATNState(Assignment__Basic_4, parser.ATNBasic, true)
 	states[Assignment__Basic_5] = parser.NewATNState(Assignment__Basic_5, parser.ATNBasic, true)
@@ -546,7 +552,7 @@ func BuildATN() *parser.RuntimeATN {
 	states[Assignable__Basic_6] = parser.NewATNState(Assignable__Basic_6, parser.ATNBasic, true)
 	states[Assignable_RightParen] = parser.NewATNState(Assignable_RightParen, parser.ATNBasic, false)
 	states[Assignable__Basic_7] = parser.NewATNState(Assignable__Basic_7, parser.ATNBasic, true)
-	states[Assignable__Basic_8] = parser.NewATNState(Assignable__Basic_8, parser.ATNBasic, true).SetDecision(23)
+	states[Assignable__Basic_8] = parser.NewATNState(Assignable__Basic_8, parser.ATNBasic, true).SetDecision(24)
 	states[Assignable__BlockEnd] = parser.NewATNState(Assignable__BlockEnd, parser.ATNBlockEnd, true)
 	states[AssignableWithoutAlts__Basic_0] = parser.NewATNState(AssignableWithoutAlts__Basic_0, parser.ATNBasic, true)
 	states[AssignableWithoutAlts__Basic_1] = parser.NewATNState(AssignableWithoutAlts__Basic_1, parser.ATNBasic, true)
@@ -554,21 +560,21 @@ func BuildATN() *parser.RuntimeATN {
 	states[AssignableWithoutAlts__Basic_3] = parser.NewATNState(AssignableWithoutAlts__Basic_3, parser.ATNBasic, true)
 	states[AssignableWithoutAlts__Basic_4] = parser.NewATNState(AssignableWithoutAlts__Basic_4, parser.ATNBasic, true)
 	states[AssignableWithoutAlts__Basic_5] = parser.NewATNState(AssignableWithoutAlts__Basic_5, parser.ATNBasic, true)
-	states[AssignableWithoutAlts__Basic_6] = parser.NewATNState(AssignableWithoutAlts__Basic_6, parser.ATNBasic, true).SetDecision(24)
+	states[AssignableWithoutAlts__Basic_6] = parser.NewATNState(AssignableWithoutAlts__Basic_6, parser.ATNBasic, true).SetDecision(25)
 	states[AssignableWithoutAlts__BlockEnd] = parser.NewATNState(AssignableWithoutAlts__BlockEnd, parser.ATNBlockEnd, true)
 	states[AssignableAlternatives__Basic_0] = parser.NewATNState(AssignableAlternatives__Basic_0, parser.ATNBasic, true)
 	states[AssignableAlternatives_Pipe] = parser.NewATNState(AssignableAlternatives_Pipe, parser.ATNBasic, false)
 	states[AssignableAlternatives__Basic_1] = parser.NewATNState(AssignableAlternatives__Basic_1, parser.ATNBasic, true)
 	states[AssignableAlternatives__Basic_2] = parser.NewATNState(AssignableAlternatives__Basic_2, parser.ATNBasic, true)
-	states[AssignableAlternatives__LoopBack] = parser.NewATNState(AssignableAlternatives__LoopBack, parser.ATNLoopBack, true).SetDecision(25)
+	states[AssignableAlternatives__LoopBack] = parser.NewATNState(AssignableAlternatives__LoopBack, parser.ATNLoopBack, true).SetDecision(26)
 	states[AssignableAlternatives__LoopEnd] = parser.NewATNState(AssignableAlternatives__LoopEnd, parser.ATNLoopEnd, true)
-	states[AssignableAlternatives__Basic_3] = parser.NewATNState(AssignableAlternatives__Basic_3, parser.ATNBasic, true).SetDecision(26)
+	states[AssignableAlternatives__Basic_3] = parser.NewATNState(AssignableAlternatives__Basic_3, parser.ATNBasic, true).SetDecision(27)
 	states[CrossRef_LeftBracket] = parser.NewATNState(CrossRef_LeftBracket, parser.ATNBasic, false)
 	states[CrossRef_Type_ID] = parser.NewATNState(CrossRef_Type_ID, parser.ATNBasic, false)
 	states[CrossRef_Colon] = parser.NewATNState(CrossRef_Colon, parser.ATNBasic, false)
 	states[CrossRef__Basic_0] = parser.NewATNState(CrossRef__Basic_0, parser.ATNBasic, true)
 	states[CrossRef__Basic_1] = parser.NewATNState(CrossRef__Basic_1, parser.ATNBasic, true)
-	states[CrossRef__Basic_2] = parser.NewATNState(CrossRef__Basic_2, parser.ATNBasic, true).SetDecision(27)
+	states[CrossRef__Basic_2] = parser.NewATNState(CrossRef__Basic_2, parser.ATNBasic, true).SetDecision(28)
 	states[CrossRef_RightBracket] = parser.NewATNState(CrossRef_RightBracket, parser.ATNBasic, false)
 	states[CrossRef__Basic_3] = parser.NewATNState(CrossRef__Basic_3, parser.ATNBasic, true)
 	states[RuleCall_Rule_ID] = parser.NewATNState(RuleCall_Rule_ID, parser.ATNBasic, false)
@@ -581,11 +587,11 @@ func BuildATN() *parser.RuntimeATN {
 	states[Action__Basic_0] = parser.NewATNState(Action__Basic_0, parser.ATNBasic, true)
 	states[Action_Operator_Equals] = parser.NewATNState(Action_Operator_Equals, parser.ATNBasic, false)
 	states[Action__Basic_1] = parser.NewATNState(Action__Basic_1, parser.ATNBasic, true)
-	states[Action__Basic_2] = parser.NewATNState(Action__Basic_2, parser.ATNBasic, true).SetDecision(28)
+	states[Action__Basic_2] = parser.NewATNState(Action__Basic_2, parser.ATNBasic, true).SetDecision(29)
 	states[Action__BlockEnd] = parser.NewATNState(Action__BlockEnd, parser.ATNBlockEnd, true)
 	states[Action_current] = parser.NewATNState(Action_current, parser.ATNBasic, false)
 	states[Action__Basic_3] = parser.NewATNState(Action__Basic_3, parser.ATNBasic, true)
-	states[Action__Basic_4] = parser.NewATNState(Action__Basic_4, parser.ATNBasic, true).SetDecision(29)
+	states[Action__Basic_4] = parser.NewATNState(Action__Basic_4, parser.ATNBasic, true).SetDecision(30)
 	states[Action_RightBrace] = parser.NewATNState(Action_RightBrace, parser.ATNBasic, false)
 	states[Action__Basic_5] = parser.NewATNState(Action__Basic_5, parser.ATNBasic, true)
 	states[CompositeRule_composite] = parser.NewATNState(CompositeRule_composite, parser.ATNBasic, false)
@@ -594,20 +600,20 @@ func BuildATN() *parser.RuntimeATN {
 	states[CompositeRule__Basic_0] = parser.NewATNState(CompositeRule__Basic_0, parser.ATNBasic, true)
 	states[CompositeRule_Semicolon] = parser.NewATNState(CompositeRule_Semicolon, parser.ATNBasic, false)
 	states[CompositeRule__Basic_1] = parser.NewATNState(CompositeRule__Basic_1, parser.ATNBasic, true)
-	states[CompositeRule__Basic_2] = parser.NewATNState(CompositeRule__Basic_2, parser.ATNBasic, true).SetDecision(30)
+	states[CompositeRule__Basic_2] = parser.NewATNState(CompositeRule__Basic_2, parser.ATNBasic, true).SetDecision(31)
 	states[CompositeAlternatives__Basic_0] = parser.NewATNState(CompositeAlternatives__Basic_0, parser.ATNBasic, true)
 	states[CompositeAlternatives_Pipe] = parser.NewATNState(CompositeAlternatives_Pipe, parser.ATNBasic, false)
 	states[CompositeAlternatives__Basic_1] = parser.NewATNState(CompositeAlternatives__Basic_1, parser.ATNBasic, true)
 	states[CompositeAlternatives__Basic_2] = parser.NewATNState(CompositeAlternatives__Basic_2, parser.ATNBasic, true)
-	states[CompositeAlternatives__LoopBack] = parser.NewATNState(CompositeAlternatives__LoopBack, parser.ATNLoopBack, true).SetDecision(31)
+	states[CompositeAlternatives__LoopBack] = parser.NewATNState(CompositeAlternatives__LoopBack, parser.ATNLoopBack, true).SetDecision(32)
 	states[CompositeAlternatives__LoopEnd] = parser.NewATNState(CompositeAlternatives__LoopEnd, parser.ATNLoopEnd, true)
-	states[CompositeAlternatives__Basic_3] = parser.NewATNState(CompositeAlternatives__Basic_3, parser.ATNBasic, true).SetDecision(32)
+	states[CompositeAlternatives__Basic_3] = parser.NewATNState(CompositeAlternatives__Basic_3, parser.ATNBasic, true).SetDecision(33)
 	states[CompositeGroup__Basic_0] = parser.NewATNState(CompositeGroup__Basic_0, parser.ATNBasic, true)
 	states[CompositeGroup__Basic_1] = parser.NewATNState(CompositeGroup__Basic_1, parser.ATNBasic, true)
 	states[CompositeGroup__Basic_2] = parser.NewATNState(CompositeGroup__Basic_2, parser.ATNBasic, true)
-	states[CompositeGroup__LoopBack] = parser.NewATNState(CompositeGroup__LoopBack, parser.ATNLoopBack, true).SetDecision(33)
+	states[CompositeGroup__LoopBack] = parser.NewATNState(CompositeGroup__LoopBack, parser.ATNLoopBack, true).SetDecision(34)
 	states[CompositeGroup__LoopEnd] = parser.NewATNState(CompositeGroup__LoopEnd, parser.ATNLoopEnd, true)
-	states[CompositeGroup__Basic_3] = parser.NewATNState(CompositeGroup__Basic_3, parser.ATNBasic, true).SetDecision(34)
+	states[CompositeGroup__Basic_3] = parser.NewATNState(CompositeGroup__Basic_3, parser.ATNBasic, true).SetDecision(35)
 	states[CompositeElement__Basic_0] = parser.NewATNState(CompositeElement__Basic_0, parser.ATNBasic, true)
 	states[CompositeElement__Basic_1] = parser.NewATNState(CompositeElement__Basic_1, parser.ATNBasic, true)
 	states[CompositeElement__Basic_2] = parser.NewATNState(CompositeElement__Basic_2, parser.ATNBasic, true)
@@ -616,7 +622,7 @@ func BuildATN() *parser.RuntimeATN {
 	states[CompositeElement__Basic_4] = parser.NewATNState(CompositeElement__Basic_4, parser.ATNBasic, true)
 	states[CompositeElement_RightParen] = parser.NewATNState(CompositeElement_RightParen, parser.ATNBasic, false)
 	states[CompositeElement__Basic_5] = parser.NewATNState(CompositeElement__Basic_5, parser.ATNBasic, true)
-	states[CompositeElement__Basic_6] = parser.NewATNState(CompositeElement__Basic_6, parser.ATNBasic, true).SetDecision(35)
+	states[CompositeElement__Basic_6] = parser.NewATNState(CompositeElement__Basic_6, parser.ATNBasic, true).SetDecision(36)
 	states[CompositeElement__BlockEnd_0] = parser.NewATNState(CompositeElement__BlockEnd_0, parser.ATNBlockEnd, true)
 	states[CompositeElement_Cardinality_Asterisk] = parser.NewATNState(CompositeElement_Cardinality_Asterisk, parser.ATNBasic, false)
 	states[CompositeElement__Basic_7] = parser.NewATNState(CompositeElement__Basic_7, parser.ATNBasic, true)
@@ -624,9 +630,9 @@ func BuildATN() *parser.RuntimeATN {
 	states[CompositeElement__Basic_8] = parser.NewATNState(CompositeElement__Basic_8, parser.ATNBasic, true)
 	states[CompositeElement_Cardinality_Question] = parser.NewATNState(CompositeElement_Cardinality_Question, parser.ATNBasic, false)
 	states[CompositeElement__Basic_9] = parser.NewATNState(CompositeElement__Basic_9, parser.ATNBasic, true)
-	states[CompositeElement__Basic_10] = parser.NewATNState(CompositeElement__Basic_10, parser.ATNBasic, true).SetDecision(36)
+	states[CompositeElement__Basic_10] = parser.NewATNState(CompositeElement__Basic_10, parser.ATNBasic, true).SetDecision(37)
 	states[CompositeElement__BlockEnd_1] = parser.NewATNState(CompositeElement__BlockEnd_1, parser.ATNBlockEnd, true)
-	states[CompositeElement__Basic_11] = parser.NewATNState(CompositeElement__Basic_11, parser.ATNBasic, true).SetDecision(37)
+	states[CompositeElement__Basic_11] = parser.NewATNState(CompositeElement__Basic_11, parser.ATNBasic, true).SetDecision(38)
 	states[Grammar__Start].AppendTransitions(
 		parser.NewEpsilonTransition(states[Grammar_grammar]),
 	)
@@ -652,7 +658,7 @@ func BuildATN() *parser.RuntimeATN {
 		parser.NewEpsilonTransition(states[PrimitiveType__Basic_3]),
 	)
 	states[ParserRule__Start].AppendTransitions(
-		parser.NewEpsilonTransition(states[ParserRule_Name_ID]),
+		parser.NewEpsilonTransition(states[ParserRule__Basic_1]),
 	)
 	states[Token__Start].AppendTransitions(
 		parser.NewEpsilonTransition(states[Token__Basic_3]),
@@ -926,37 +932,47 @@ func BuildATN() *parser.RuntimeATN {
 	states[PrimitiveType__BlockEnd].AppendTransitions(
 		parser.NewEpsilonTransition(states[PrimitiveType__Stop]),
 	)
+	states[ParserRule_Entry_entry].AppendTransitions(
+		parser.NewAtomTransition(states[ParserRule__Basic_0], Keyword_entry, nil),
+	)
+	states[ParserRule__Basic_0].AppendTransitions(
+		parser.NewEpsilonTransition(states[ParserRule_Name_ID]),
+	)
+	states[ParserRule__Basic_1].AppendTransitions(
+		parser.NewEpsilonTransition(states[ParserRule_Entry_entry]),
+		parser.NewEpsilonTransition(states[ParserRule__Basic_0]),
+	)
 	states[ParserRule_Name_ID].AppendTransitions(
-		parser.NewAtomTransition(states[ParserRule__Basic_1], Token_ID, nil),
+		parser.NewAtomTransition(states[ParserRule__Basic_3], Token_ID, nil),
 	)
 	states[ParserRule_returns].AppendTransitions(
 		parser.NewAtomTransition(states[ParserRule_ReturnType_ID], Keyword_returns, nil),
 	)
 	states[ParserRule_ReturnType_ID].AppendTransitions(
-		parser.NewAtomTransition(states[ParserRule__Basic_0], Token_ID, &parser.CompletionHint{Field: "ParserRule.ReturnType"}),
-	)
-	states[ParserRule__Basic_0].AppendTransitions(
-		parser.NewEpsilonTransition(states[ParserRule_Colon]),
-	)
-	states[ParserRule__Basic_1].AppendTransitions(
-		parser.NewEpsilonTransition(states[ParserRule_returns]),
-		parser.NewEpsilonTransition(states[ParserRule__Basic_0]),
-	)
-	states[ParserRule_Colon].AppendTransitions(
-		parser.NewAtomTransition(states[ParserRule__Basic_2], Keyword_Colon, nil),
+		parser.NewAtomTransition(states[ParserRule__Basic_2], Token_ID, &parser.CompletionHint{Field: "ParserRule.ReturnType"}),
 	)
 	states[ParserRule__Basic_2].AppendTransitions(
-		parser.NewRuleTransition(states[Alternatives__Start], states[ParserRule__Basic_4], nil),
-	)
-	states[ParserRule_Semicolon].AppendTransitions(
-		parser.NewAtomTransition(states[ParserRule__Basic_3], Keyword_Semicolon, nil),
+		parser.NewEpsilonTransition(states[ParserRule_Colon]),
 	)
 	states[ParserRule__Basic_3].AppendTransitions(
-		parser.NewEpsilonTransition(states[ParserRule__Stop]),
+		parser.NewEpsilonTransition(states[ParserRule_returns]),
+		parser.NewEpsilonTransition(states[ParserRule__Basic_2]),
+	)
+	states[ParserRule_Colon].AppendTransitions(
+		parser.NewAtomTransition(states[ParserRule__Basic_4], Keyword_Colon, nil),
 	)
 	states[ParserRule__Basic_4].AppendTransitions(
+		parser.NewRuleTransition(states[Alternatives__Start], states[ParserRule__Basic_6], nil),
+	)
+	states[ParserRule_Semicolon].AppendTransitions(
+		parser.NewAtomTransition(states[ParserRule__Basic_5], Keyword_Semicolon, nil),
+	)
+	states[ParserRule__Basic_5].AppendTransitions(
+		parser.NewEpsilonTransition(states[ParserRule__Stop]),
+	)
+	states[ParserRule__Basic_6].AppendTransitions(
 		parser.NewEpsilonTransition(states[ParserRule_Semicolon]),
-		parser.NewEpsilonTransition(states[ParserRule__Basic_3]),
+		parser.NewEpsilonTransition(states[ParserRule__Basic_5]),
 	)
 	states[Token_Type_hidden].AppendTransitions(
 		parser.NewAtomTransition(states[Token__Basic_0], Keyword_hidden, nil),
@@ -1513,7 +1529,7 @@ func BuildATN() *parser.RuntimeATN {
 		parser.NewEpsilonTransition(states[CompositeElement__Basic_10]),
 		parser.NewEpsilonTransition(states[CompositeElement__BlockEnd_1]),
 	)
-	decisionStates := make([]*parser.RuntimeATNState, 38)
+	decisionStates := make([]*parser.RuntimeATNState, 39)
 	decisionStates[0] = states[Grammar__Basic_1]
 	decisionStates[1] = states[Grammar__Basic_12]
 	decisionStates[2] = states[Grammar__LoopEntry]
@@ -1523,36 +1539,37 @@ func BuildATN() *parser.RuntimeATN {
 	decisionStates[6] = states[FieldType__Basic_8]
 	decisionStates[7] = states[PrimitiveType__Basic_3]
 	decisionStates[8] = states[ParserRule__Basic_1]
-	decisionStates[9] = states[ParserRule__Basic_4]
-	decisionStates[10] = states[Token__Basic_2]
-	decisionStates[11] = states[Token__Basic_3]
-	decisionStates[12] = states[Token__Basic_5]
-	decisionStates[13] = states[TokenGroup__Basic_4]
-	decisionStates[14] = states[TokenGroup__LoopEntry]
-	decisionStates[15] = states[Alternatives__LoopBack]
-	decisionStates[16] = states[Alternatives__Basic_3]
-	decisionStates[17] = states[Group__LoopBack]
-	decisionStates[18] = states[Group__Basic_3]
-	decisionStates[19] = states[Element__Basic_10]
-	decisionStates[20] = states[Element__Basic_14]
-	decisionStates[21] = states[Element__Basic_15]
-	decisionStates[22] = states[Assignment__Basic_3]
-	decisionStates[23] = states[Assignable__Basic_8]
-	decisionStates[24] = states[AssignableWithoutAlts__Basic_6]
-	decisionStates[25] = states[AssignableAlternatives__LoopBack]
-	decisionStates[26] = states[AssignableAlternatives__Basic_3]
-	decisionStates[27] = states[CrossRef__Basic_2]
-	decisionStates[28] = states[Action__Basic_2]
-	decisionStates[29] = states[Action__Basic_4]
-	decisionStates[30] = states[CompositeRule__Basic_2]
-	decisionStates[31] = states[CompositeAlternatives__LoopBack]
-	decisionStates[32] = states[CompositeAlternatives__Basic_3]
-	decisionStates[33] = states[CompositeGroup__LoopBack]
-	decisionStates[34] = states[CompositeGroup__Basic_3]
-	decisionStates[35] = states[CompositeElement__Basic_6]
-	decisionStates[36] = states[CompositeElement__Basic_10]
-	decisionStates[37] = states[CompositeElement__Basic_11]
-	decisionMap := make([]*parser.RuntimeATNState, 38)
+	decisionStates[9] = states[ParserRule__Basic_3]
+	decisionStates[10] = states[ParserRule__Basic_6]
+	decisionStates[11] = states[Token__Basic_2]
+	decisionStates[12] = states[Token__Basic_3]
+	decisionStates[13] = states[Token__Basic_5]
+	decisionStates[14] = states[TokenGroup__Basic_4]
+	decisionStates[15] = states[TokenGroup__LoopEntry]
+	decisionStates[16] = states[Alternatives__LoopBack]
+	decisionStates[17] = states[Alternatives__Basic_3]
+	decisionStates[18] = states[Group__LoopBack]
+	decisionStates[19] = states[Group__Basic_3]
+	decisionStates[20] = states[Element__Basic_10]
+	decisionStates[21] = states[Element__Basic_14]
+	decisionStates[22] = states[Element__Basic_15]
+	decisionStates[23] = states[Assignment__Basic_3]
+	decisionStates[24] = states[Assignable__Basic_8]
+	decisionStates[25] = states[AssignableWithoutAlts__Basic_6]
+	decisionStates[26] = states[AssignableAlternatives__LoopBack]
+	decisionStates[27] = states[AssignableAlternatives__Basic_3]
+	decisionStates[28] = states[CrossRef__Basic_2]
+	decisionStates[29] = states[Action__Basic_2]
+	decisionStates[30] = states[Action__Basic_4]
+	decisionStates[31] = states[CompositeRule__Basic_2]
+	decisionStates[32] = states[CompositeAlternatives__LoopBack]
+	decisionStates[33] = states[CompositeAlternatives__Basic_3]
+	decisionStates[34] = states[CompositeGroup__LoopBack]
+	decisionStates[35] = states[CompositeGroup__Basic_3]
+	decisionStates[36] = states[CompositeElement__Basic_6]
+	decisionStates[37] = states[CompositeElement__Basic_10]
+	decisionStates[38] = states[CompositeElement__Basic_11]
+	decisionMap := make([]*parser.RuntimeATNState, 39)
 	decisionMap[0] = states[Grammar__Basic_1]
 	decisionMap[1] = states[Grammar__Basic_12]
 	decisionMap[2] = states[Grammar__LoopEntry]
@@ -1562,34 +1579,35 @@ func BuildATN() *parser.RuntimeATN {
 	decisionMap[6] = states[FieldType__Basic_8]
 	decisionMap[7] = states[PrimitiveType__Basic_3]
 	decisionMap[8] = states[ParserRule__Basic_1]
-	decisionMap[9] = states[ParserRule__Basic_4]
-	decisionMap[10] = states[Token__Basic_2]
-	decisionMap[11] = states[Token__Basic_3]
-	decisionMap[12] = states[Token__Basic_5]
-	decisionMap[13] = states[TokenGroup__Basic_4]
-	decisionMap[14] = states[TokenGroup__LoopEntry]
-	decisionMap[15] = states[Alternatives__LoopBack]
-	decisionMap[16] = states[Alternatives__Basic_3]
-	decisionMap[17] = states[Group__LoopBack]
-	decisionMap[18] = states[Group__Basic_3]
-	decisionMap[19] = states[Element__Basic_10]
-	decisionMap[20] = states[Element__Basic_14]
-	decisionMap[21] = states[Element__Basic_15]
-	decisionMap[22] = states[Assignment__Basic_3]
-	decisionMap[23] = states[Assignable__Basic_8]
-	decisionMap[24] = states[AssignableWithoutAlts__Basic_6]
-	decisionMap[25] = states[AssignableAlternatives__LoopBack]
-	decisionMap[26] = states[AssignableAlternatives__Basic_3]
-	decisionMap[27] = states[CrossRef__Basic_2]
-	decisionMap[28] = states[Action__Basic_2]
-	decisionMap[29] = states[Action__Basic_4]
-	decisionMap[30] = states[CompositeRule__Basic_2]
-	decisionMap[31] = states[CompositeAlternatives__LoopBack]
-	decisionMap[32] = states[CompositeAlternatives__Basic_3]
-	decisionMap[33] = states[CompositeGroup__LoopBack]
-	decisionMap[34] = states[CompositeGroup__Basic_3]
-	decisionMap[35] = states[CompositeElement__Basic_6]
-	decisionMap[36] = states[CompositeElement__Basic_10]
-	decisionMap[37] = states[CompositeElement__Basic_11]
+	decisionMap[9] = states[ParserRule__Basic_3]
+	decisionMap[10] = states[ParserRule__Basic_6]
+	decisionMap[11] = states[Token__Basic_2]
+	decisionMap[12] = states[Token__Basic_3]
+	decisionMap[13] = states[Token__Basic_5]
+	decisionMap[14] = states[TokenGroup__Basic_4]
+	decisionMap[15] = states[TokenGroup__LoopEntry]
+	decisionMap[16] = states[Alternatives__LoopBack]
+	decisionMap[17] = states[Alternatives__Basic_3]
+	decisionMap[18] = states[Group__LoopBack]
+	decisionMap[19] = states[Group__Basic_3]
+	decisionMap[20] = states[Element__Basic_10]
+	decisionMap[21] = states[Element__Basic_14]
+	decisionMap[22] = states[Element__Basic_15]
+	decisionMap[23] = states[Assignment__Basic_3]
+	decisionMap[24] = states[Assignable__Basic_8]
+	decisionMap[25] = states[AssignableWithoutAlts__Basic_6]
+	decisionMap[26] = states[AssignableAlternatives__LoopBack]
+	decisionMap[27] = states[AssignableAlternatives__Basic_3]
+	decisionMap[28] = states[CrossRef__Basic_2]
+	decisionMap[29] = states[Action__Basic_2]
+	decisionMap[30] = states[Action__Basic_4]
+	decisionMap[31] = states[CompositeRule__Basic_2]
+	decisionMap[32] = states[CompositeAlternatives__LoopBack]
+	decisionMap[33] = states[CompositeAlternatives__Basic_3]
+	decisionMap[34] = states[CompositeGroup__LoopBack]
+	decisionMap[35] = states[CompositeGroup__Basic_3]
+	decisionMap[36] = states[CompositeElement__Basic_6]
+	decisionMap[37] = states[CompositeElement__Basic_10]
+	decisionMap[38] = states[CompositeElement__Basic_11]
 	return parser.NewRuntimeATN(states, decisionStates, decisionMap)
 }

--- a/internal/grammar/atn_gen.go
+++ b/internal/grammar/atn_gen.go
@@ -74,6 +74,8 @@ const (
 	Grammar__Basic_8
 	Grammar__Basic_9
 	Grammar__Basic_10
+	Grammar__Basic_11
+	Grammar__Basic_12
 	Grammar__BlockEnd
 	Grammar__LoopEntry
 	Grammar__LoopEnd
@@ -136,6 +138,7 @@ const (
 	ParserRule__Basic_2
 	ParserRule_Semicolon
 	ParserRule__Basic_3
+	ParserRule__Basic_4
 	Token_Type_hidden
 	Token__Basic_0
 	Token_Type_comment
@@ -149,6 +152,7 @@ const (
 	Token_Regexp_RegexLiteral
 	Token_Semicolon
 	Token__Basic_4
+	Token__Basic_5
 	TokenGroup_token
 	TokenGroup_group
 	TokenGroup_Name_ID
@@ -274,6 +278,7 @@ const (
 	CompositeRule__Basic_0
 	CompositeRule_Semicolon
 	CompositeRule__Basic_1
+	CompositeRule__Basic_2
 	CompositeAlternatives__Basic_0
 	CompositeAlternatives_Pipe
 	CompositeAlternatives__Basic_1
@@ -318,7 +323,7 @@ func ATN() *parser.RuntimeATN {
 	return atn
 }
 func BuildATN() *parser.RuntimeATN {
-	states := make([]*parser.RuntimeATNState, 298)
+	states := make([]*parser.RuntimeATNState, 303)
 	states[Grammar__Start] = parser.NewATNState(Grammar__Start, parser.ATNRuleStart, true)
 	states[Grammar__Stop] = parser.NewATNState(Grammar__Stop, parser.ATNRuleStop, false)
 	states[Interface__Start] = parser.NewATNState(Interface__Start, parser.ATNRuleStart, true)
@@ -375,7 +380,7 @@ func BuildATN() *parser.RuntimeATN {
 	states[Grammar_Name_ID] = parser.NewATNState(Grammar_Name_ID, parser.ATNBasic, false)
 	states[Grammar_Semicolon] = parser.NewATNState(Grammar_Semicolon, parser.ATNBasic, false)
 	states[Grammar__Basic_0] = parser.NewATNState(Grammar__Basic_0, parser.ATNBasic, true)
-	states[Grammar__Basic_1] = parser.NewATNState(Grammar__Basic_1, parser.ATNBasic, true)
+	states[Grammar__Basic_1] = parser.NewATNState(Grammar__Basic_1, parser.ATNBasic, true).SetDecision(0)
 	states[Grammar__Basic_2] = parser.NewATNState(Grammar__Basic_2, parser.ATNBasic, true)
 	states[Grammar__Basic_3] = parser.NewATNState(Grammar__Basic_3, parser.ATNBasic, true)
 	states[Grammar__Basic_4] = parser.NewATNState(Grammar__Basic_4, parser.ATNBasic, true)
@@ -384,9 +389,11 @@ func BuildATN() *parser.RuntimeATN {
 	states[Grammar__Basic_7] = parser.NewATNState(Grammar__Basic_7, parser.ATNBasic, true)
 	states[Grammar__Basic_8] = parser.NewATNState(Grammar__Basic_8, parser.ATNBasic, true)
 	states[Grammar__Basic_9] = parser.NewATNState(Grammar__Basic_9, parser.ATNBasic, true)
-	states[Grammar__Basic_10] = parser.NewATNState(Grammar__Basic_10, parser.ATNBasic, true).SetDecision(0)
+	states[Grammar__Basic_10] = parser.NewATNState(Grammar__Basic_10, parser.ATNBasic, true)
+	states[Grammar__Basic_11] = parser.NewATNState(Grammar__Basic_11, parser.ATNBasic, true)
+	states[Grammar__Basic_12] = parser.NewATNState(Grammar__Basic_12, parser.ATNBasic, true).SetDecision(1)
 	states[Grammar__BlockEnd] = parser.NewATNState(Grammar__BlockEnd, parser.ATNBlockEnd, true)
-	states[Grammar__LoopEntry] = parser.NewATNState(Grammar__LoopEntry, parser.ATNLoopEntry, true).SetDecision(1)
+	states[Grammar__LoopEntry] = parser.NewATNState(Grammar__LoopEntry, parser.ATNLoopEntry, true).SetDecision(2)
 	states[Grammar__LoopEnd] = parser.NewATNState(Grammar__LoopEnd, parser.ATNLoopEnd, true)
 	states[Grammar__LoopBack] = parser.NewATNState(Grammar__LoopBack, parser.ATNLoopBack, true)
 	states[Interface_interface] = parser.NewATNState(Interface_interface, parser.ATNBasic, false)
@@ -396,14 +403,14 @@ func BuildATN() *parser.RuntimeATN {
 	states[Interface_Comma] = parser.NewATNState(Interface_Comma, parser.ATNBasic, false)
 	states[Interface_Extends_ID_1] = parser.NewATNState(Interface_Extends_ID_1, parser.ATNBasic, false)
 	states[Interface__Basic_0] = parser.NewATNState(Interface__Basic_0, parser.ATNBasic, true)
-	states[Interface__LoopEntry_0] = parser.NewATNState(Interface__LoopEntry_0, parser.ATNLoopEntry, true).SetDecision(2)
+	states[Interface__LoopEntry_0] = parser.NewATNState(Interface__LoopEntry_0, parser.ATNLoopEntry, true).SetDecision(3)
 	states[Interface__LoopEnd_0] = parser.NewATNState(Interface__LoopEnd_0, parser.ATNLoopEnd, true)
 	states[Interface__LoopBack_0] = parser.NewATNState(Interface__LoopBack_0, parser.ATNLoopBack, true)
-	states[Interface__Basic_1] = parser.NewATNState(Interface__Basic_1, parser.ATNBasic, true).SetDecision(3)
+	states[Interface__Basic_1] = parser.NewATNState(Interface__Basic_1, parser.ATNBasic, true).SetDecision(4)
 	states[Interface_LeftBrace] = parser.NewATNState(Interface_LeftBrace, parser.ATNBasic, false)
 	states[Interface__Basic_2] = parser.NewATNState(Interface__Basic_2, parser.ATNBasic, true)
 	states[Interface__Basic_3] = parser.NewATNState(Interface__Basic_3, parser.ATNBasic, true)
-	states[Interface__LoopEntry_1] = parser.NewATNState(Interface__LoopEntry_1, parser.ATNLoopEntry, true).SetDecision(4)
+	states[Interface__LoopEntry_1] = parser.NewATNState(Interface__LoopEntry_1, parser.ATNLoopEntry, true).SetDecision(5)
 	states[Interface__LoopEnd_1] = parser.NewATNState(Interface__LoopEnd_1, parser.ATNLoopEnd, true)
 	states[Interface__LoopBack_1] = parser.NewATNState(Interface__LoopBack_1, parser.ATNLoopBack, true)
 	states[Interface_RightBrace] = parser.NewATNState(Interface_RightBrace, parser.ATNBasic, false)
@@ -419,7 +426,7 @@ func BuildATN() *parser.RuntimeATN {
 	states[FieldType__Basic_5] = parser.NewATNState(FieldType__Basic_5, parser.ATNBasic, true)
 	states[FieldType__Basic_6] = parser.NewATNState(FieldType__Basic_6, parser.ATNBasic, true)
 	states[FieldType__Basic_7] = parser.NewATNState(FieldType__Basic_7, parser.ATNBasic, true)
-	states[FieldType__Basic_8] = parser.NewATNState(FieldType__Basic_8, parser.ATNBasic, true).SetDecision(5)
+	states[FieldType__Basic_8] = parser.NewATNState(FieldType__Basic_8, parser.ATNBasic, true).SetDecision(6)
 	states[FieldType__BlockEnd] = parser.NewATNState(FieldType__BlockEnd, parser.ATNBlockEnd, true)
 	states[ArrayType_LeftBracket] = parser.NewATNState(ArrayType_LeftBracket, parser.ATNBasic, false)
 	states[ArrayType_RightBracket] = parser.NewATNState(ArrayType_RightBracket, parser.ATNBasic, false)
@@ -436,30 +443,32 @@ func BuildATN() *parser.RuntimeATN {
 	states[PrimitiveType__Basic_1] = parser.NewATNState(PrimitiveType__Basic_1, parser.ATNBasic, true)
 	states[PrimitiveType_Type_composite] = parser.NewATNState(PrimitiveType_Type_composite, parser.ATNBasic, false)
 	states[PrimitiveType__Basic_2] = parser.NewATNState(PrimitiveType__Basic_2, parser.ATNBasic, true)
-	states[PrimitiveType__Basic_3] = parser.NewATNState(PrimitiveType__Basic_3, parser.ATNBasic, true).SetDecision(6)
+	states[PrimitiveType__Basic_3] = parser.NewATNState(PrimitiveType__Basic_3, parser.ATNBasic, true).SetDecision(7)
 	states[PrimitiveType__BlockEnd] = parser.NewATNState(PrimitiveType__BlockEnd, parser.ATNBlockEnd, true)
 	states[ParserRule_Name_ID] = parser.NewATNState(ParserRule_Name_ID, parser.ATNBasic, false)
 	states[ParserRule_returns] = parser.NewATNState(ParserRule_returns, parser.ATNBasic, false)
 	states[ParserRule_ReturnType_ID] = parser.NewATNState(ParserRule_ReturnType_ID, parser.ATNBasic, false)
 	states[ParserRule__Basic_0] = parser.NewATNState(ParserRule__Basic_0, parser.ATNBasic, true)
-	states[ParserRule__Basic_1] = parser.NewATNState(ParserRule__Basic_1, parser.ATNBasic, true).SetDecision(7)
+	states[ParserRule__Basic_1] = parser.NewATNState(ParserRule__Basic_1, parser.ATNBasic, true).SetDecision(8)
 	states[ParserRule_Colon] = parser.NewATNState(ParserRule_Colon, parser.ATNBasic, false)
 	states[ParserRule__Basic_2] = parser.NewATNState(ParserRule__Basic_2, parser.ATNBasic, true)
 	states[ParserRule_Semicolon] = parser.NewATNState(ParserRule_Semicolon, parser.ATNBasic, false)
 	states[ParserRule__Basic_3] = parser.NewATNState(ParserRule__Basic_3, parser.ATNBasic, true)
+	states[ParserRule__Basic_4] = parser.NewATNState(ParserRule__Basic_4, parser.ATNBasic, true).SetDecision(9)
 	states[Token_Type_hidden] = parser.NewATNState(Token_Type_hidden, parser.ATNBasic, false)
 	states[Token__Basic_0] = parser.NewATNState(Token__Basic_0, parser.ATNBasic, true)
 	states[Token_Type_comment] = parser.NewATNState(Token_Type_comment, parser.ATNBasic, false)
 	states[Token__Basic_1] = parser.NewATNState(Token__Basic_1, parser.ATNBasic, true)
-	states[Token__Basic_2] = parser.NewATNState(Token__Basic_2, parser.ATNBasic, true).SetDecision(8)
+	states[Token__Basic_2] = parser.NewATNState(Token__Basic_2, parser.ATNBasic, true).SetDecision(10)
 	states[Token__BlockEnd] = parser.NewATNState(Token__BlockEnd, parser.ATNBlockEnd, true)
-	states[Token__Basic_3] = parser.NewATNState(Token__Basic_3, parser.ATNBasic, true).SetDecision(9)
+	states[Token__Basic_3] = parser.NewATNState(Token__Basic_3, parser.ATNBasic, true).SetDecision(11)
 	states[Token_token] = parser.NewATNState(Token_token, parser.ATNBasic, false)
 	states[Token_Name_ID] = parser.NewATNState(Token_Name_ID, parser.ATNBasic, false)
 	states[Token_Colon] = parser.NewATNState(Token_Colon, parser.ATNBasic, false)
 	states[Token_Regexp_RegexLiteral] = parser.NewATNState(Token_Regexp_RegexLiteral, parser.ATNBasic, false)
 	states[Token_Semicolon] = parser.NewATNState(Token_Semicolon, parser.ATNBasic, false)
 	states[Token__Basic_4] = parser.NewATNState(Token__Basic_4, parser.ATNBasic, true)
+	states[Token__Basic_5] = parser.NewATNState(Token__Basic_5, parser.ATNBasic, true).SetDecision(12)
 	states[TokenGroup_token] = parser.NewATNState(TokenGroup_token, parser.ATNBasic, false)
 	states[TokenGroup_group] = parser.NewATNState(TokenGroup_group, parser.ATNBasic, false)
 	states[TokenGroup_Name_ID] = parser.NewATNState(TokenGroup_Name_ID, parser.ATNBasic, false)
@@ -471,9 +480,9 @@ func BuildATN() *parser.RuntimeATN {
 	states[TokenGroup__Basic_1] = parser.NewATNState(TokenGroup__Basic_1, parser.ATNBasic, true)
 	states[TokenGroup__Basic_2] = parser.NewATNState(TokenGroup__Basic_2, parser.ATNBasic, true)
 	states[TokenGroup__Basic_3] = parser.NewATNState(TokenGroup__Basic_3, parser.ATNBasic, true)
-	states[TokenGroup__Basic_4] = parser.NewATNState(TokenGroup__Basic_4, parser.ATNBasic, true).SetDecision(10)
+	states[TokenGroup__Basic_4] = parser.NewATNState(TokenGroup__Basic_4, parser.ATNBasic, true).SetDecision(13)
 	states[TokenGroup__BlockEnd] = parser.NewATNState(TokenGroup__BlockEnd, parser.ATNBlockEnd, true)
-	states[TokenGroup__LoopEntry] = parser.NewATNState(TokenGroup__LoopEntry, parser.ATNLoopEntry, true).SetDecision(11)
+	states[TokenGroup__LoopEntry] = parser.NewATNState(TokenGroup__LoopEntry, parser.ATNLoopEntry, true).SetDecision(14)
 	states[TokenGroup__LoopEnd] = parser.NewATNState(TokenGroup__LoopEnd, parser.ATNLoopEnd, true)
 	states[TokenGroup__LoopBack] = parser.NewATNState(TokenGroup__LoopBack, parser.ATNLoopBack, true)
 	states[TokenGroup_RightBrace] = parser.NewATNState(TokenGroup_RightBrace, parser.ATNBasic, false)
@@ -482,15 +491,15 @@ func BuildATN() *parser.RuntimeATN {
 	states[Alternatives_Pipe] = parser.NewATNState(Alternatives_Pipe, parser.ATNBasic, false)
 	states[Alternatives__Basic_1] = parser.NewATNState(Alternatives__Basic_1, parser.ATNBasic, true)
 	states[Alternatives__Basic_2] = parser.NewATNState(Alternatives__Basic_2, parser.ATNBasic, true)
-	states[Alternatives__LoopBack] = parser.NewATNState(Alternatives__LoopBack, parser.ATNLoopBack, true).SetDecision(12)
+	states[Alternatives__LoopBack] = parser.NewATNState(Alternatives__LoopBack, parser.ATNLoopBack, true).SetDecision(15)
 	states[Alternatives__LoopEnd] = parser.NewATNState(Alternatives__LoopEnd, parser.ATNLoopEnd, true)
-	states[Alternatives__Basic_3] = parser.NewATNState(Alternatives__Basic_3, parser.ATNBasic, true).SetDecision(13)
+	states[Alternatives__Basic_3] = parser.NewATNState(Alternatives__Basic_3, parser.ATNBasic, true).SetDecision(16)
 	states[Group__Basic_0] = parser.NewATNState(Group__Basic_0, parser.ATNBasic, true)
 	states[Group__Basic_1] = parser.NewATNState(Group__Basic_1, parser.ATNBasic, true)
 	states[Group__Basic_2] = parser.NewATNState(Group__Basic_2, parser.ATNBasic, true)
-	states[Group__LoopBack] = parser.NewATNState(Group__LoopBack, parser.ATNLoopBack, true).SetDecision(14)
+	states[Group__LoopBack] = parser.NewATNState(Group__LoopBack, parser.ATNLoopBack, true).SetDecision(17)
 	states[Group__LoopEnd] = parser.NewATNState(Group__LoopEnd, parser.ATNLoopEnd, true)
-	states[Group__Basic_3] = parser.NewATNState(Group__Basic_3, parser.ATNBasic, true).SetDecision(15)
+	states[Group__Basic_3] = parser.NewATNState(Group__Basic_3, parser.ATNBasic, true).SetDecision(18)
 	states[Element__Basic_0] = parser.NewATNState(Element__Basic_0, parser.ATNBasic, true)
 	states[Element__Basic_1] = parser.NewATNState(Element__Basic_1, parser.ATNBasic, true)
 	states[Element__Basic_2] = parser.NewATNState(Element__Basic_2, parser.ATNBasic, true)
@@ -503,7 +512,7 @@ func BuildATN() *parser.RuntimeATN {
 	states[Element__Basic_8] = parser.NewATNState(Element__Basic_8, parser.ATNBasic, true)
 	states[Element_RightParen] = parser.NewATNState(Element_RightParen, parser.ATNBasic, false)
 	states[Element__Basic_9] = parser.NewATNState(Element__Basic_9, parser.ATNBasic, true)
-	states[Element__Basic_10] = parser.NewATNState(Element__Basic_10, parser.ATNBasic, true).SetDecision(16)
+	states[Element__Basic_10] = parser.NewATNState(Element__Basic_10, parser.ATNBasic, true).SetDecision(19)
 	states[Element__BlockEnd_0] = parser.NewATNState(Element__BlockEnd_0, parser.ATNBlockEnd, true)
 	states[Element_Cardinality_Asterisk] = parser.NewATNState(Element_Cardinality_Asterisk, parser.ATNBasic, false)
 	states[Element__Basic_11] = parser.NewATNState(Element__Basic_11, parser.ATNBasic, true)
@@ -511,9 +520,9 @@ func BuildATN() *parser.RuntimeATN {
 	states[Element__Basic_12] = parser.NewATNState(Element__Basic_12, parser.ATNBasic, true)
 	states[Element_Cardinality_Question] = parser.NewATNState(Element_Cardinality_Question, parser.ATNBasic, false)
 	states[Element__Basic_13] = parser.NewATNState(Element__Basic_13, parser.ATNBasic, true)
-	states[Element__Basic_14] = parser.NewATNState(Element__Basic_14, parser.ATNBasic, true).SetDecision(17)
+	states[Element__Basic_14] = parser.NewATNState(Element__Basic_14, parser.ATNBasic, true).SetDecision(20)
 	states[Element__BlockEnd_1] = parser.NewATNState(Element__BlockEnd_1, parser.ATNBlockEnd, true)
-	states[Element__Basic_15] = parser.NewATNState(Element__Basic_15, parser.ATNBasic, true).SetDecision(18)
+	states[Element__Basic_15] = parser.NewATNState(Element__Basic_15, parser.ATNBasic, true).SetDecision(21)
 	states[Keyword_Value_StringLiteral] = parser.NewATNState(Keyword_Value_StringLiteral, parser.ATNBasic, false)
 	states[Keyword__Basic] = parser.NewATNState(Keyword__Basic, parser.ATNBasic, true)
 	states[Assignment_Property_ID] = parser.NewATNState(Assignment_Property_ID, parser.ATNBasic, false)
@@ -523,7 +532,7 @@ func BuildATN() *parser.RuntimeATN {
 	states[Assignment__Basic_1] = parser.NewATNState(Assignment__Basic_1, parser.ATNBasic, true)
 	states[Assignment_Operator_QuestionEquals] = parser.NewATNState(Assignment_Operator_QuestionEquals, parser.ATNBasic, false)
 	states[Assignment__Basic_2] = parser.NewATNState(Assignment__Basic_2, parser.ATNBasic, true)
-	states[Assignment__Basic_3] = parser.NewATNState(Assignment__Basic_3, parser.ATNBasic, true).SetDecision(19)
+	states[Assignment__Basic_3] = parser.NewATNState(Assignment__Basic_3, parser.ATNBasic, true).SetDecision(22)
 	states[Assignment__BlockEnd] = parser.NewATNState(Assignment__BlockEnd, parser.ATNBlockEnd, true)
 	states[Assignment__Basic_4] = parser.NewATNState(Assignment__Basic_4, parser.ATNBasic, true)
 	states[Assignment__Basic_5] = parser.NewATNState(Assignment__Basic_5, parser.ATNBasic, true)
@@ -537,7 +546,7 @@ func BuildATN() *parser.RuntimeATN {
 	states[Assignable__Basic_6] = parser.NewATNState(Assignable__Basic_6, parser.ATNBasic, true)
 	states[Assignable_RightParen] = parser.NewATNState(Assignable_RightParen, parser.ATNBasic, false)
 	states[Assignable__Basic_7] = parser.NewATNState(Assignable__Basic_7, parser.ATNBasic, true)
-	states[Assignable__Basic_8] = parser.NewATNState(Assignable__Basic_8, parser.ATNBasic, true).SetDecision(20)
+	states[Assignable__Basic_8] = parser.NewATNState(Assignable__Basic_8, parser.ATNBasic, true).SetDecision(23)
 	states[Assignable__BlockEnd] = parser.NewATNState(Assignable__BlockEnd, parser.ATNBlockEnd, true)
 	states[AssignableWithoutAlts__Basic_0] = parser.NewATNState(AssignableWithoutAlts__Basic_0, parser.ATNBasic, true)
 	states[AssignableWithoutAlts__Basic_1] = parser.NewATNState(AssignableWithoutAlts__Basic_1, parser.ATNBasic, true)
@@ -545,21 +554,21 @@ func BuildATN() *parser.RuntimeATN {
 	states[AssignableWithoutAlts__Basic_3] = parser.NewATNState(AssignableWithoutAlts__Basic_3, parser.ATNBasic, true)
 	states[AssignableWithoutAlts__Basic_4] = parser.NewATNState(AssignableWithoutAlts__Basic_4, parser.ATNBasic, true)
 	states[AssignableWithoutAlts__Basic_5] = parser.NewATNState(AssignableWithoutAlts__Basic_5, parser.ATNBasic, true)
-	states[AssignableWithoutAlts__Basic_6] = parser.NewATNState(AssignableWithoutAlts__Basic_6, parser.ATNBasic, true).SetDecision(21)
+	states[AssignableWithoutAlts__Basic_6] = parser.NewATNState(AssignableWithoutAlts__Basic_6, parser.ATNBasic, true).SetDecision(24)
 	states[AssignableWithoutAlts__BlockEnd] = parser.NewATNState(AssignableWithoutAlts__BlockEnd, parser.ATNBlockEnd, true)
 	states[AssignableAlternatives__Basic_0] = parser.NewATNState(AssignableAlternatives__Basic_0, parser.ATNBasic, true)
 	states[AssignableAlternatives_Pipe] = parser.NewATNState(AssignableAlternatives_Pipe, parser.ATNBasic, false)
 	states[AssignableAlternatives__Basic_1] = parser.NewATNState(AssignableAlternatives__Basic_1, parser.ATNBasic, true)
 	states[AssignableAlternatives__Basic_2] = parser.NewATNState(AssignableAlternatives__Basic_2, parser.ATNBasic, true)
-	states[AssignableAlternatives__LoopBack] = parser.NewATNState(AssignableAlternatives__LoopBack, parser.ATNLoopBack, true).SetDecision(22)
+	states[AssignableAlternatives__LoopBack] = parser.NewATNState(AssignableAlternatives__LoopBack, parser.ATNLoopBack, true).SetDecision(25)
 	states[AssignableAlternatives__LoopEnd] = parser.NewATNState(AssignableAlternatives__LoopEnd, parser.ATNLoopEnd, true)
-	states[AssignableAlternatives__Basic_3] = parser.NewATNState(AssignableAlternatives__Basic_3, parser.ATNBasic, true).SetDecision(23)
+	states[AssignableAlternatives__Basic_3] = parser.NewATNState(AssignableAlternatives__Basic_3, parser.ATNBasic, true).SetDecision(26)
 	states[CrossRef_LeftBracket] = parser.NewATNState(CrossRef_LeftBracket, parser.ATNBasic, false)
 	states[CrossRef_Type_ID] = parser.NewATNState(CrossRef_Type_ID, parser.ATNBasic, false)
 	states[CrossRef_Colon] = parser.NewATNState(CrossRef_Colon, parser.ATNBasic, false)
 	states[CrossRef__Basic_0] = parser.NewATNState(CrossRef__Basic_0, parser.ATNBasic, true)
 	states[CrossRef__Basic_1] = parser.NewATNState(CrossRef__Basic_1, parser.ATNBasic, true)
-	states[CrossRef__Basic_2] = parser.NewATNState(CrossRef__Basic_2, parser.ATNBasic, true).SetDecision(24)
+	states[CrossRef__Basic_2] = parser.NewATNState(CrossRef__Basic_2, parser.ATNBasic, true).SetDecision(27)
 	states[CrossRef_RightBracket] = parser.NewATNState(CrossRef_RightBracket, parser.ATNBasic, false)
 	states[CrossRef__Basic_3] = parser.NewATNState(CrossRef__Basic_3, parser.ATNBasic, true)
 	states[RuleCall_Rule_ID] = parser.NewATNState(RuleCall_Rule_ID, parser.ATNBasic, false)
@@ -572,11 +581,11 @@ func BuildATN() *parser.RuntimeATN {
 	states[Action__Basic_0] = parser.NewATNState(Action__Basic_0, parser.ATNBasic, true)
 	states[Action_Operator_Equals] = parser.NewATNState(Action_Operator_Equals, parser.ATNBasic, false)
 	states[Action__Basic_1] = parser.NewATNState(Action__Basic_1, parser.ATNBasic, true)
-	states[Action__Basic_2] = parser.NewATNState(Action__Basic_2, parser.ATNBasic, true).SetDecision(25)
+	states[Action__Basic_2] = parser.NewATNState(Action__Basic_2, parser.ATNBasic, true).SetDecision(28)
 	states[Action__BlockEnd] = parser.NewATNState(Action__BlockEnd, parser.ATNBlockEnd, true)
 	states[Action_current] = parser.NewATNState(Action_current, parser.ATNBasic, false)
 	states[Action__Basic_3] = parser.NewATNState(Action__Basic_3, parser.ATNBasic, true)
-	states[Action__Basic_4] = parser.NewATNState(Action__Basic_4, parser.ATNBasic, true).SetDecision(26)
+	states[Action__Basic_4] = parser.NewATNState(Action__Basic_4, parser.ATNBasic, true).SetDecision(29)
 	states[Action_RightBrace] = parser.NewATNState(Action_RightBrace, parser.ATNBasic, false)
 	states[Action__Basic_5] = parser.NewATNState(Action__Basic_5, parser.ATNBasic, true)
 	states[CompositeRule_composite] = parser.NewATNState(CompositeRule_composite, parser.ATNBasic, false)
@@ -585,19 +594,20 @@ func BuildATN() *parser.RuntimeATN {
 	states[CompositeRule__Basic_0] = parser.NewATNState(CompositeRule__Basic_0, parser.ATNBasic, true)
 	states[CompositeRule_Semicolon] = parser.NewATNState(CompositeRule_Semicolon, parser.ATNBasic, false)
 	states[CompositeRule__Basic_1] = parser.NewATNState(CompositeRule__Basic_1, parser.ATNBasic, true)
+	states[CompositeRule__Basic_2] = parser.NewATNState(CompositeRule__Basic_2, parser.ATNBasic, true).SetDecision(30)
 	states[CompositeAlternatives__Basic_0] = parser.NewATNState(CompositeAlternatives__Basic_0, parser.ATNBasic, true)
 	states[CompositeAlternatives_Pipe] = parser.NewATNState(CompositeAlternatives_Pipe, parser.ATNBasic, false)
 	states[CompositeAlternatives__Basic_1] = parser.NewATNState(CompositeAlternatives__Basic_1, parser.ATNBasic, true)
 	states[CompositeAlternatives__Basic_2] = parser.NewATNState(CompositeAlternatives__Basic_2, parser.ATNBasic, true)
-	states[CompositeAlternatives__LoopBack] = parser.NewATNState(CompositeAlternatives__LoopBack, parser.ATNLoopBack, true).SetDecision(27)
+	states[CompositeAlternatives__LoopBack] = parser.NewATNState(CompositeAlternatives__LoopBack, parser.ATNLoopBack, true).SetDecision(31)
 	states[CompositeAlternatives__LoopEnd] = parser.NewATNState(CompositeAlternatives__LoopEnd, parser.ATNLoopEnd, true)
-	states[CompositeAlternatives__Basic_3] = parser.NewATNState(CompositeAlternatives__Basic_3, parser.ATNBasic, true).SetDecision(28)
+	states[CompositeAlternatives__Basic_3] = parser.NewATNState(CompositeAlternatives__Basic_3, parser.ATNBasic, true).SetDecision(32)
 	states[CompositeGroup__Basic_0] = parser.NewATNState(CompositeGroup__Basic_0, parser.ATNBasic, true)
 	states[CompositeGroup__Basic_1] = parser.NewATNState(CompositeGroup__Basic_1, parser.ATNBasic, true)
 	states[CompositeGroup__Basic_2] = parser.NewATNState(CompositeGroup__Basic_2, parser.ATNBasic, true)
-	states[CompositeGroup__LoopBack] = parser.NewATNState(CompositeGroup__LoopBack, parser.ATNLoopBack, true).SetDecision(29)
+	states[CompositeGroup__LoopBack] = parser.NewATNState(CompositeGroup__LoopBack, parser.ATNLoopBack, true).SetDecision(33)
 	states[CompositeGroup__LoopEnd] = parser.NewATNState(CompositeGroup__LoopEnd, parser.ATNLoopEnd, true)
-	states[CompositeGroup__Basic_3] = parser.NewATNState(CompositeGroup__Basic_3, parser.ATNBasic, true).SetDecision(30)
+	states[CompositeGroup__Basic_3] = parser.NewATNState(CompositeGroup__Basic_3, parser.ATNBasic, true).SetDecision(34)
 	states[CompositeElement__Basic_0] = parser.NewATNState(CompositeElement__Basic_0, parser.ATNBasic, true)
 	states[CompositeElement__Basic_1] = parser.NewATNState(CompositeElement__Basic_1, parser.ATNBasic, true)
 	states[CompositeElement__Basic_2] = parser.NewATNState(CompositeElement__Basic_2, parser.ATNBasic, true)
@@ -606,7 +616,7 @@ func BuildATN() *parser.RuntimeATN {
 	states[CompositeElement__Basic_4] = parser.NewATNState(CompositeElement__Basic_4, parser.ATNBasic, true)
 	states[CompositeElement_RightParen] = parser.NewATNState(CompositeElement_RightParen, parser.ATNBasic, false)
 	states[CompositeElement__Basic_5] = parser.NewATNState(CompositeElement__Basic_5, parser.ATNBasic, true)
-	states[CompositeElement__Basic_6] = parser.NewATNState(CompositeElement__Basic_6, parser.ATNBasic, true).SetDecision(31)
+	states[CompositeElement__Basic_6] = parser.NewATNState(CompositeElement__Basic_6, parser.ATNBasic, true).SetDecision(35)
 	states[CompositeElement__BlockEnd_0] = parser.NewATNState(CompositeElement__BlockEnd_0, parser.ATNBlockEnd, true)
 	states[CompositeElement_Cardinality_Asterisk] = parser.NewATNState(CompositeElement_Cardinality_Asterisk, parser.ATNBasic, false)
 	states[CompositeElement__Basic_7] = parser.NewATNState(CompositeElement__Basic_7, parser.ATNBasic, true)
@@ -614,9 +624,9 @@ func BuildATN() *parser.RuntimeATN {
 	states[CompositeElement__Basic_8] = parser.NewATNState(CompositeElement__Basic_8, parser.ATNBasic, true)
 	states[CompositeElement_Cardinality_Question] = parser.NewATNState(CompositeElement_Cardinality_Question, parser.ATNBasic, false)
 	states[CompositeElement__Basic_9] = parser.NewATNState(CompositeElement__Basic_9, parser.ATNBasic, true)
-	states[CompositeElement__Basic_10] = parser.NewATNState(CompositeElement__Basic_10, parser.ATNBasic, true).SetDecision(32)
+	states[CompositeElement__Basic_10] = parser.NewATNState(CompositeElement__Basic_10, parser.ATNBasic, true).SetDecision(36)
 	states[CompositeElement__BlockEnd_1] = parser.NewATNState(CompositeElement__BlockEnd_1, parser.ATNBlockEnd, true)
-	states[CompositeElement__Basic_11] = parser.NewATNState(CompositeElement__Basic_11, parser.ATNBasic, true).SetDecision(33)
+	states[CompositeElement__Basic_11] = parser.NewATNState(CompositeElement__Basic_11, parser.ATNBasic, true).SetDecision(37)
 	states[Grammar__Start].AppendTransitions(
 		parser.NewEpsilonTransition(states[Grammar_grammar]),
 	)
@@ -699,53 +709,60 @@ func BuildATN() *parser.RuntimeATN {
 		parser.NewAtomTransition(states[Grammar_Name_ID], Keyword_grammar, nil),
 	)
 	states[Grammar_Name_ID].AppendTransitions(
-		parser.NewAtomTransition(states[Grammar_Semicolon], Token_ID, nil),
+		parser.NewAtomTransition(states[Grammar__Basic_1], Token_ID, nil),
 	)
 	states[Grammar_Semicolon].AppendTransitions(
-		parser.NewAtomTransition(states[Grammar__LoopEntry], Keyword_Semicolon, nil),
+		parser.NewAtomTransition(states[Grammar__Basic_0], Keyword_Semicolon, nil),
 	)
 	states[Grammar__Basic_0].AppendTransitions(
-		parser.NewRuleTransition(states[ParserRule__Start], states[Grammar__Basic_1], nil),
+		parser.NewEpsilonTransition(states[Grammar__LoopEntry]),
 	)
 	states[Grammar__Basic_1].AppendTransitions(
-		parser.NewEpsilonTransition(states[Grammar__BlockEnd]),
+		parser.NewEpsilonTransition(states[Grammar_Semicolon]),
+		parser.NewEpsilonTransition(states[Grammar__Basic_0]),
 	)
 	states[Grammar__Basic_2].AppendTransitions(
-		parser.NewRuleTransition(states[Token__Start], states[Grammar__Basic_3], nil),
+		parser.NewRuleTransition(states[ParserRule__Start], states[Grammar__Basic_3], nil),
 	)
 	states[Grammar__Basic_3].AppendTransitions(
 		parser.NewEpsilonTransition(states[Grammar__BlockEnd]),
 	)
 	states[Grammar__Basic_4].AppendTransitions(
-		parser.NewRuleTransition(states[TokenGroup__Start], states[Grammar__Basic_5], nil),
+		parser.NewRuleTransition(states[Token__Start], states[Grammar__Basic_5], nil),
 	)
 	states[Grammar__Basic_5].AppendTransitions(
 		parser.NewEpsilonTransition(states[Grammar__BlockEnd]),
 	)
 	states[Grammar__Basic_6].AppendTransitions(
-		parser.NewRuleTransition(states[Interface__Start], states[Grammar__Basic_7], nil),
+		parser.NewRuleTransition(states[TokenGroup__Start], states[Grammar__Basic_7], nil),
 	)
 	states[Grammar__Basic_7].AppendTransitions(
 		parser.NewEpsilonTransition(states[Grammar__BlockEnd]),
 	)
 	states[Grammar__Basic_8].AppendTransitions(
-		parser.NewRuleTransition(states[CompositeRule__Start], states[Grammar__Basic_9], nil),
+		parser.NewRuleTransition(states[Interface__Start], states[Grammar__Basic_9], nil),
 	)
 	states[Grammar__Basic_9].AppendTransitions(
 		parser.NewEpsilonTransition(states[Grammar__BlockEnd]),
 	)
 	states[Grammar__Basic_10].AppendTransitions(
-		parser.NewEpsilonTransition(states[Grammar__Basic_0]),
+		parser.NewRuleTransition(states[CompositeRule__Start], states[Grammar__Basic_11], nil),
+	)
+	states[Grammar__Basic_11].AppendTransitions(
+		parser.NewEpsilonTransition(states[Grammar__BlockEnd]),
+	)
+	states[Grammar__Basic_12].AppendTransitions(
 		parser.NewEpsilonTransition(states[Grammar__Basic_2]),
 		parser.NewEpsilonTransition(states[Grammar__Basic_4]),
 		parser.NewEpsilonTransition(states[Grammar__Basic_6]),
 		parser.NewEpsilonTransition(states[Grammar__Basic_8]),
+		parser.NewEpsilonTransition(states[Grammar__Basic_10]),
 	)
 	states[Grammar__BlockEnd].AppendTransitions(
 		parser.NewEpsilonTransition(states[Grammar__LoopBack]),
 	)
 	states[Grammar__LoopEntry].AppendTransitions(
-		parser.NewEpsilonTransition(states[Grammar__Basic_10]),
+		parser.NewEpsilonTransition(states[Grammar__Basic_12]),
 		parser.NewEpsilonTransition(states[Grammar__LoopEnd]),
 	)
 	states[Grammar__LoopEnd].AppendTransitions(
@@ -929,13 +946,17 @@ func BuildATN() *parser.RuntimeATN {
 		parser.NewAtomTransition(states[ParserRule__Basic_2], Keyword_Colon, nil),
 	)
 	states[ParserRule__Basic_2].AppendTransitions(
-		parser.NewRuleTransition(states[Alternatives__Start], states[ParserRule_Semicolon], nil),
+		parser.NewRuleTransition(states[Alternatives__Start], states[ParserRule__Basic_4], nil),
 	)
 	states[ParserRule_Semicolon].AppendTransitions(
 		parser.NewAtomTransition(states[ParserRule__Basic_3], Keyword_Semicolon, nil),
 	)
 	states[ParserRule__Basic_3].AppendTransitions(
 		parser.NewEpsilonTransition(states[ParserRule__Stop]),
+	)
+	states[ParserRule__Basic_4].AppendTransitions(
+		parser.NewEpsilonTransition(states[ParserRule_Semicolon]),
+		parser.NewEpsilonTransition(states[ParserRule__Basic_3]),
 	)
 	states[Token_Type_hidden].AppendTransitions(
 		parser.NewAtomTransition(states[Token__Basic_0], Keyword_hidden, nil),
@@ -970,13 +991,17 @@ func BuildATN() *parser.RuntimeATN {
 		parser.NewAtomTransition(states[Token_Regexp_RegexLiteral], Keyword_Colon, nil),
 	)
 	states[Token_Regexp_RegexLiteral].AppendTransitions(
-		parser.NewAtomTransition(states[Token_Semicolon], Token_RegexLiteral, nil),
+		parser.NewAtomTransition(states[Token__Basic_5], Token_RegexLiteral, nil),
 	)
 	states[Token_Semicolon].AppendTransitions(
 		parser.NewAtomTransition(states[Token__Basic_4], Keyword_Semicolon, nil),
 	)
 	states[Token__Basic_4].AppendTransitions(
 		parser.NewEpsilonTransition(states[Token__Stop]),
+	)
+	states[Token__Basic_5].AppendTransitions(
+		parser.NewEpsilonTransition(states[Token_Semicolon]),
+		parser.NewEpsilonTransition(states[Token__Basic_4]),
 	)
 	states[TokenGroup_token].AppendTransitions(
 		parser.NewAtomTransition(states[TokenGroup_group], Keyword_token, nil),
@@ -1371,13 +1396,17 @@ func BuildATN() *parser.RuntimeATN {
 		parser.NewAtomTransition(states[CompositeRule__Basic_0], Keyword_Colon, nil),
 	)
 	states[CompositeRule__Basic_0].AppendTransitions(
-		parser.NewRuleTransition(states[CompositeAlternatives__Start], states[CompositeRule_Semicolon], nil),
+		parser.NewRuleTransition(states[CompositeAlternatives__Start], states[CompositeRule__Basic_2], nil),
 	)
 	states[CompositeRule_Semicolon].AppendTransitions(
 		parser.NewAtomTransition(states[CompositeRule__Basic_1], Keyword_Semicolon, nil),
 	)
 	states[CompositeRule__Basic_1].AppendTransitions(
 		parser.NewEpsilonTransition(states[CompositeRule__Stop]),
+	)
+	states[CompositeRule__Basic_2].AppendTransitions(
+		parser.NewEpsilonTransition(states[CompositeRule_Semicolon]),
+		parser.NewEpsilonTransition(states[CompositeRule__Basic_1]),
 	)
 	states[CompositeAlternatives__Basic_0].AppendTransitions(
 		parser.NewRuleTransition(states[CompositeGroup__Start], states[CompositeAlternatives__Basic_3], nil),
@@ -1484,75 +1513,83 @@ func BuildATN() *parser.RuntimeATN {
 		parser.NewEpsilonTransition(states[CompositeElement__Basic_10]),
 		parser.NewEpsilonTransition(states[CompositeElement__BlockEnd_1]),
 	)
-	decisionStates := make([]*parser.RuntimeATNState, 34)
-	decisionStates[0] = states[Grammar__Basic_10]
-	decisionStates[1] = states[Grammar__LoopEntry]
-	decisionStates[2] = states[Interface__LoopEntry_0]
-	decisionStates[3] = states[Interface__Basic_1]
-	decisionStates[4] = states[Interface__LoopEntry_1]
-	decisionStates[5] = states[FieldType__Basic_8]
-	decisionStates[6] = states[PrimitiveType__Basic_3]
-	decisionStates[7] = states[ParserRule__Basic_1]
-	decisionStates[8] = states[Token__Basic_2]
-	decisionStates[9] = states[Token__Basic_3]
-	decisionStates[10] = states[TokenGroup__Basic_4]
-	decisionStates[11] = states[TokenGroup__LoopEntry]
-	decisionStates[12] = states[Alternatives__LoopBack]
-	decisionStates[13] = states[Alternatives__Basic_3]
-	decisionStates[14] = states[Group__LoopBack]
-	decisionStates[15] = states[Group__Basic_3]
-	decisionStates[16] = states[Element__Basic_10]
-	decisionStates[17] = states[Element__Basic_14]
-	decisionStates[18] = states[Element__Basic_15]
-	decisionStates[19] = states[Assignment__Basic_3]
-	decisionStates[20] = states[Assignable__Basic_8]
-	decisionStates[21] = states[AssignableWithoutAlts__Basic_6]
-	decisionStates[22] = states[AssignableAlternatives__LoopBack]
-	decisionStates[23] = states[AssignableAlternatives__Basic_3]
-	decisionStates[24] = states[CrossRef__Basic_2]
-	decisionStates[25] = states[Action__Basic_2]
-	decisionStates[26] = states[Action__Basic_4]
-	decisionStates[27] = states[CompositeAlternatives__LoopBack]
-	decisionStates[28] = states[CompositeAlternatives__Basic_3]
-	decisionStates[29] = states[CompositeGroup__LoopBack]
-	decisionStates[30] = states[CompositeGroup__Basic_3]
-	decisionStates[31] = states[CompositeElement__Basic_6]
-	decisionStates[32] = states[CompositeElement__Basic_10]
-	decisionStates[33] = states[CompositeElement__Basic_11]
-	decisionMap := make([]*parser.RuntimeATNState, 34)
-	decisionMap[0] = states[Grammar__Basic_10]
-	decisionMap[1] = states[Grammar__LoopEntry]
-	decisionMap[2] = states[Interface__LoopEntry_0]
-	decisionMap[3] = states[Interface__Basic_1]
-	decisionMap[4] = states[Interface__LoopEntry_1]
-	decisionMap[5] = states[FieldType__Basic_8]
-	decisionMap[6] = states[PrimitiveType__Basic_3]
-	decisionMap[7] = states[ParserRule__Basic_1]
-	decisionMap[8] = states[Token__Basic_2]
-	decisionMap[9] = states[Token__Basic_3]
-	decisionMap[10] = states[TokenGroup__Basic_4]
-	decisionMap[11] = states[TokenGroup__LoopEntry]
-	decisionMap[12] = states[Alternatives__LoopBack]
-	decisionMap[13] = states[Alternatives__Basic_3]
-	decisionMap[14] = states[Group__LoopBack]
-	decisionMap[15] = states[Group__Basic_3]
-	decisionMap[16] = states[Element__Basic_10]
-	decisionMap[17] = states[Element__Basic_14]
-	decisionMap[18] = states[Element__Basic_15]
-	decisionMap[19] = states[Assignment__Basic_3]
-	decisionMap[20] = states[Assignable__Basic_8]
-	decisionMap[21] = states[AssignableWithoutAlts__Basic_6]
-	decisionMap[22] = states[AssignableAlternatives__LoopBack]
-	decisionMap[23] = states[AssignableAlternatives__Basic_3]
-	decisionMap[24] = states[CrossRef__Basic_2]
-	decisionMap[25] = states[Action__Basic_2]
-	decisionMap[26] = states[Action__Basic_4]
-	decisionMap[27] = states[CompositeAlternatives__LoopBack]
-	decisionMap[28] = states[CompositeAlternatives__Basic_3]
-	decisionMap[29] = states[CompositeGroup__LoopBack]
-	decisionMap[30] = states[CompositeGroup__Basic_3]
-	decisionMap[31] = states[CompositeElement__Basic_6]
-	decisionMap[32] = states[CompositeElement__Basic_10]
-	decisionMap[33] = states[CompositeElement__Basic_11]
+	decisionStates := make([]*parser.RuntimeATNState, 38)
+	decisionStates[0] = states[Grammar__Basic_1]
+	decisionStates[1] = states[Grammar__Basic_12]
+	decisionStates[2] = states[Grammar__LoopEntry]
+	decisionStates[3] = states[Interface__LoopEntry_0]
+	decisionStates[4] = states[Interface__Basic_1]
+	decisionStates[5] = states[Interface__LoopEntry_1]
+	decisionStates[6] = states[FieldType__Basic_8]
+	decisionStates[7] = states[PrimitiveType__Basic_3]
+	decisionStates[8] = states[ParserRule__Basic_1]
+	decisionStates[9] = states[ParserRule__Basic_4]
+	decisionStates[10] = states[Token__Basic_2]
+	decisionStates[11] = states[Token__Basic_3]
+	decisionStates[12] = states[Token__Basic_5]
+	decisionStates[13] = states[TokenGroup__Basic_4]
+	decisionStates[14] = states[TokenGroup__LoopEntry]
+	decisionStates[15] = states[Alternatives__LoopBack]
+	decisionStates[16] = states[Alternatives__Basic_3]
+	decisionStates[17] = states[Group__LoopBack]
+	decisionStates[18] = states[Group__Basic_3]
+	decisionStates[19] = states[Element__Basic_10]
+	decisionStates[20] = states[Element__Basic_14]
+	decisionStates[21] = states[Element__Basic_15]
+	decisionStates[22] = states[Assignment__Basic_3]
+	decisionStates[23] = states[Assignable__Basic_8]
+	decisionStates[24] = states[AssignableWithoutAlts__Basic_6]
+	decisionStates[25] = states[AssignableAlternatives__LoopBack]
+	decisionStates[26] = states[AssignableAlternatives__Basic_3]
+	decisionStates[27] = states[CrossRef__Basic_2]
+	decisionStates[28] = states[Action__Basic_2]
+	decisionStates[29] = states[Action__Basic_4]
+	decisionStates[30] = states[CompositeRule__Basic_2]
+	decisionStates[31] = states[CompositeAlternatives__LoopBack]
+	decisionStates[32] = states[CompositeAlternatives__Basic_3]
+	decisionStates[33] = states[CompositeGroup__LoopBack]
+	decisionStates[34] = states[CompositeGroup__Basic_3]
+	decisionStates[35] = states[CompositeElement__Basic_6]
+	decisionStates[36] = states[CompositeElement__Basic_10]
+	decisionStates[37] = states[CompositeElement__Basic_11]
+	decisionMap := make([]*parser.RuntimeATNState, 38)
+	decisionMap[0] = states[Grammar__Basic_1]
+	decisionMap[1] = states[Grammar__Basic_12]
+	decisionMap[2] = states[Grammar__LoopEntry]
+	decisionMap[3] = states[Interface__LoopEntry_0]
+	decisionMap[4] = states[Interface__Basic_1]
+	decisionMap[5] = states[Interface__LoopEntry_1]
+	decisionMap[6] = states[FieldType__Basic_8]
+	decisionMap[7] = states[PrimitiveType__Basic_3]
+	decisionMap[8] = states[ParserRule__Basic_1]
+	decisionMap[9] = states[ParserRule__Basic_4]
+	decisionMap[10] = states[Token__Basic_2]
+	decisionMap[11] = states[Token__Basic_3]
+	decisionMap[12] = states[Token__Basic_5]
+	decisionMap[13] = states[TokenGroup__Basic_4]
+	decisionMap[14] = states[TokenGroup__LoopEntry]
+	decisionMap[15] = states[Alternatives__LoopBack]
+	decisionMap[16] = states[Alternatives__Basic_3]
+	decisionMap[17] = states[Group__LoopBack]
+	decisionMap[18] = states[Group__Basic_3]
+	decisionMap[19] = states[Element__Basic_10]
+	decisionMap[20] = states[Element__Basic_14]
+	decisionMap[21] = states[Element__Basic_15]
+	decisionMap[22] = states[Assignment__Basic_3]
+	decisionMap[23] = states[Assignable__Basic_8]
+	decisionMap[24] = states[AssignableWithoutAlts__Basic_6]
+	decisionMap[25] = states[AssignableAlternatives__LoopBack]
+	decisionMap[26] = states[AssignableAlternatives__Basic_3]
+	decisionMap[27] = states[CrossRef__Basic_2]
+	decisionMap[28] = states[Action__Basic_2]
+	decisionMap[29] = states[Action__Basic_4]
+	decisionMap[30] = states[CompositeRule__Basic_2]
+	decisionMap[31] = states[CompositeAlternatives__LoopBack]
+	decisionMap[32] = states[CompositeAlternatives__Basic_3]
+	decisionMap[33] = states[CompositeGroup__LoopBack]
+	decisionMap[34] = states[CompositeGroup__Basic_3]
+	decisionMap[35] = states[CompositeElement__Basic_6]
+	decisionMap[36] = states[CompositeElement__Basic_10]
+	decisionMap[37] = states[CompositeElement__Basic_11]
 	return parser.NewRuntimeATN(states, decisionStates, decisionMap)
 }

--- a/internal/grammar/completion_parser_gen.go
+++ b/internal/grammar/completion_parser_gen.go
@@ -51,7 +51,9 @@ func (p *CompletionParser) ParseGrammar() {
 		p.cp.ClearAssignment()
 	}
 	{
-		p.state.Consume(Keyword_Semicolon)
+		if p.lookahead.GrammarSemicolonOptional(p.state) {
+			p.state.Consume(Keyword_Semicolon)
+		}
 	}
 	p.cp.RecordSnapshot(Grammar__LoopEntry)
 	p.state.Sync(Grammar__LoopEntry)
@@ -60,7 +62,7 @@ func (p *CompletionParser) ParseGrammar() {
 		case 0:
 			{
 				p.cp.MarkAssignment("Rules")
-				p.state.EnterRule(Grammar__Basic_1)
+				p.state.EnterRule(Grammar__Basic_3)
 				p.ParseParserRule()
 				p.state.ExitRule()
 				p.cp.ClearAssignment()
@@ -68,7 +70,7 @@ func (p *CompletionParser) ParseGrammar() {
 		case 1:
 			{
 				p.cp.MarkAssignment("Terminals")
-				p.state.EnterRule(Grammar__Basic_3)
+				p.state.EnterRule(Grammar__Basic_5)
 				p.ParseToken()
 				p.state.ExitRule()
 				p.cp.ClearAssignment()
@@ -76,7 +78,7 @@ func (p *CompletionParser) ParseGrammar() {
 		case 2:
 			{
 				p.cp.MarkAssignment("TokenGroups")
-				p.state.EnterRule(Grammar__Basic_5)
+				p.state.EnterRule(Grammar__Basic_7)
 				p.ParseTokenGroup()
 				p.state.ExitRule()
 				p.cp.ClearAssignment()
@@ -84,7 +86,7 @@ func (p *CompletionParser) ParseGrammar() {
 		case 3:
 			{
 				p.cp.MarkAssignment("Interfaces")
-				p.state.EnterRule(Grammar__Basic_7)
+				p.state.EnterRule(Grammar__Basic_9)
 				p.ParseInterface()
 				p.state.ExitRule()
 				p.cp.ClearAssignment()
@@ -92,7 +94,7 @@ func (p *CompletionParser) ParseGrammar() {
 		case 4:
 			{
 				p.cp.MarkAssignment("Composites")
-				p.state.EnterRule(Grammar__Basic_9)
+				p.state.EnterRule(Grammar__Basic_11)
 				p.ParseCompositeRule()
 				p.state.ExitRule()
 				p.cp.ClearAssignment()
@@ -296,13 +298,15 @@ func (p *CompletionParser) ParseParserRule() {
 	}
 	{
 		p.cp.MarkAssignment("Body")
-		p.state.EnterRule(ParserRule_Semicolon)
+		p.state.EnterRule(ParserRule__Basic_4)
 		p.ParseAlternatives()
 		p.state.ExitRule()
 		p.cp.ClearAssignment()
 	}
 	{
-		p.state.Consume(Keyword_Semicolon)
+		if p.lookahead.ParserRuleSemicolonOptional(p.state) {
+			p.state.Consume(Keyword_Semicolon)
+		}
 	}
 }
 
@@ -342,7 +346,9 @@ func (p *CompletionParser) ParseToken() {
 		p.cp.ClearAssignment()
 	}
 	{
-		p.state.Consume(Keyword_Semicolon)
+		if p.lookahead.TokenSemicolonOptional(p.state) {
+			p.state.Consume(Keyword_Semicolon)
+		}
 	}
 }
 
@@ -748,13 +754,15 @@ func (p *CompletionParser) ParseCompositeRule() {
 	}
 	{
 		p.cp.MarkAssignment("Body")
-		p.state.EnterRule(CompositeRule_Semicolon)
+		p.state.EnterRule(CompositeRule__Basic_2)
 		p.ParseCompositeAlternatives()
 		p.state.ExitRule()
 		p.cp.ClearAssignment()
 	}
 	{
-		p.state.Consume(Keyword_Semicolon)
+		if p.lookahead.CompositeRuleSemicolonOptional(p.state) {
+			p.state.Consume(Keyword_Semicolon)
+		}
 	}
 }
 

--- a/internal/grammar/completion_parser_gen.go
+++ b/internal/grammar/completion_parser_gen.go
@@ -277,12 +277,21 @@ func (p *CompletionParser) ParseParserRule() {
 	p.cp.EnterRule("ParserRule", ParserRule__Start)
 	defer p.cp.ExitRule()
 	{
+		p.cp.RecordSnapshot(ParserRule__Basic_1)
+		p.state.Sync(ParserRule__Basic_1)
+		if p.lookahead.ParserRuleEntryOptional(p.state) {
+			p.cp.MarkAssignment("Entry")
+			p.state.Consume(Keyword_entry)
+			p.cp.ClearAssignment()
+		}
+	}
+	{
 		p.cp.MarkAssignment("Name")
 		p.state.Consume(Token_ID)
 		p.cp.ClearAssignment()
 	}
-	p.cp.RecordSnapshot(ParserRule__Basic_1)
-	p.state.Sync(ParserRule__Basic_1)
+	p.cp.RecordSnapshot(ParserRule__Basic_3)
+	p.state.Sync(ParserRule__Basic_3)
 	if p.lookahead.ParserRuleOptional(p.state) {
 		{
 			p.state.Consume(Keyword_returns)
@@ -298,7 +307,7 @@ func (p *CompletionParser) ParseParserRule() {
 	}
 	{
 		p.cp.MarkAssignment("Body")
-		p.state.EnterRule(ParserRule__Basic_4)
+		p.state.EnterRule(ParserRule__Basic_6)
 		p.ParseAlternatives()
 		p.state.ExitRule()
 		p.cp.ClearAssignment()

--- a/internal/grammar/grammar.fb
+++ b/internal/grammar/grammar.fb
@@ -1,4 +1,4 @@
-grammar Fastbelt;
+grammar Fastbelt
 
 interface Grammar {
     Name string
@@ -9,7 +9,7 @@ interface Grammar {
     Interfaces []Interface
 }
 
-Grammar: "grammar" Name=ID ";"
+Grammar: "grammar" Name=ID ";"?
     (
         Rules+=ParserRule
         | Terminals+=Token
@@ -17,7 +17,6 @@ Grammar: "grammar" Name=ID ";"
         | Interfaces+=Interface
         | Composites+=CompositeRule
     )*
-;
 
 interface Interface {
     Name string
@@ -29,7 +28,6 @@ Interface:
     "interface" Name=ID ("extends" Extends+=[Interface:ID] ("," Extends+=[Interface:ID])*)? "{"
         Fields+=Field*
     "}"
-;
 
 interface Field {
     Name string
@@ -81,14 +79,14 @@ interface ParserRule extends AbstractRuleWithBody {
     ReturnType *Interface
 }
 
-ParserRule: Name=ID ("returns" ReturnType=[Interface:ID])? ":" Body=Alternatives ";";
+ParserRule: Name=ID ("returns" ReturnType=[Interface:ID])? ":" Body=Alternatives ";"?;
 
 interface Token extends AbstractTokenRule {
     Type string
     Regexp string
 }
 
-Token: (Type="hidden" | Type="comment")? "token" Name=ID ":" Regexp=RegexLiteral ";";
+Token: (Type="hidden" | Type="comment")? "token" Name=ID ":" Regexp=RegexLiteral ";"?;
 
 interface TokenGroup extends AbstractTokenRule {
     TokenRefs []*AbstractTokenRule
@@ -98,7 +96,7 @@ interface TokenGroup extends AbstractTokenRule {
 
 TokenGroup: "token" "group" Name=ID "{"
     (TokenRefs+=[AbstractTokenRule:ID] | "keywords" Regexps+=RegexLiteral | Keywords+=Keyword)*
-"}";
+"}"
 
 interface Element {
     Cardinality string
@@ -164,7 +162,7 @@ Action: "{" Type=[Interface:ID] ("." Property=[Field:ID] Operator=("+=" | "=") "
 interface CompositeRule extends AbstractRuleWithBody {
 }
 
-CompositeRule: "composite" Name=ID ":" Body=CompositeAlternatives ";";
+CompositeRule: "composite" Name=ID ":" Body=CompositeAlternatives ";"?;
 
 CompositeAlternatives returns Element: CompositeGroup ({Alternatives.Alts+=current} ("|" Alts+=CompositeGroup)+)?;
 

--- a/internal/grammar/grammar.fb
+++ b/internal/grammar/grammar.fb
@@ -52,17 +52,17 @@ interface PrimitiveType extends FieldType {
     Type string
 }
 
-Field: Name=ID Type=FieldType;
+Field: Name=ID Type=FieldType
 
-FieldType: SimpleType | ReferenceType | ArrayType | PrimitiveType;
+FieldType: SimpleType | ReferenceType | ArrayType | PrimitiveType
 
-ArrayType: "[" "]" InternalType=FieldType;
+ArrayType: "[" "]" InternalType=FieldType
 
-ReferenceType: "*" Type=[Interface:ID];
+ReferenceType: "*" Type=[Interface:ID]
 
-SimpleType: Type=[Interface:ID];
+SimpleType: Type=[Interface:ID]
 
-PrimitiveType: Type=("string" | "bool" | "composite");
+PrimitiveType: Type=("string" | "bool" | "composite")
 
 interface AbstractRule {
     Name string
@@ -79,14 +79,14 @@ interface ParserRule extends AbstractRuleWithBody {
     ReturnType *Interface
 }
 
-ParserRule: Name=ID ("returns" ReturnType=[Interface:ID])? ":" Body=Alternatives ";"?;
+ParserRule: Name=ID ("returns" ReturnType=[Interface:ID])? ":" Body=Alternatives ";"?
 
 interface Token extends AbstractTokenRule {
     Type string
     Regexp string
 }
 
-Token: (Type="hidden" | Type="comment")? "token" Name=ID ":" Regexp=RegexLiteral ";"?;
+Token: (Type="hidden" | Type="comment")? "token" Name=ID ":" Regexp=RegexLiteral ";"?
 
 interface TokenGroup extends AbstractTokenRule {
     TokenRefs []*AbstractTokenRule
@@ -106,21 +106,21 @@ interface Alternatives extends Assignable {
     Alts []Element
 }
 
-Alternatives returns Element: Group ({Alternatives.Alts+=current} ("|" Alts+=Group)+)?;
+Alternatives returns Element: Group ({Alternatives.Alts+=current} ("|" Alts+=Group)+)?
 
 interface Group extends Element {
     Elements []Element
 }
 
-Group returns Element: Element ({Group.Elements+=current} Elements+=Element+)?;
+Group returns Element: Element ({Group.Elements+=current} Elements+=Element+)?
 
-Element: (Keyword | Assignment | RuleCall | Action | "(" Alternatives ")") Cardinality=("*" | "+" | "?")?;
+Element: (Keyword | Assignment | RuleCall | Action | "(" Alternatives ")") Cardinality=("*" | "+" | "?")?
 
 interface Keyword extends Assignable {
     Value string
 }
 
-Keyword: Value=StringLiteral;
+Keyword: Value=StringLiteral
 
 interface Assignment extends Element {
     Property *Field
@@ -128,28 +128,28 @@ interface Assignment extends Element {
     Value Assignable
 }
 
-Assignment: Property=[Field:ID] Operator=("+=" | "=" | "?=") Value=Assignable;
+Assignment: Property=[Field:ID] Operator=("+=" | "=" | "?=") Value=Assignable
 
 interface Assignable extends Element {}
 
-Assignable: Keyword | RuleCall | CrossRef | "(" AssignableAlternatives ")";
+Assignable: Keyword | RuleCall | CrossRef | "(" AssignableAlternatives ")"
 
-AssignableWithoutAlts returns Assignable: Keyword | RuleCall | CrossRef;
+AssignableWithoutAlts returns Assignable: Keyword | RuleCall | CrossRef
 
-AssignableAlternatives returns Assignable: AssignableWithoutAlts ({Alternatives.Alts+=current} ("|" Alts+=AssignableWithoutAlts)+)?;
+AssignableAlternatives returns Assignable: AssignableWithoutAlts ({Alternatives.Alts+=current} ("|" Alts+=AssignableWithoutAlts)+)?
 
 interface CrossRef extends Assignable {
     Type *Interface
     Rule RuleCall
 }
 
-CrossRef: "[" Type=[Interface:ID] (":" Rule=RuleCall)? "]";
+CrossRef: "[" Type=[Interface:ID] (":" Rule=RuleCall)? "]"
 
 interface RuleCall extends Assignable {
     Rule *AbstractRule
 }
 
-RuleCall: Rule=[AbstractRule:ID];
+RuleCall: Rule=[AbstractRule:ID]
 
 interface Action extends Element {
     Type *Interface
@@ -157,24 +157,24 @@ interface Action extends Element {
     Property *Field
 }
 
-Action: "{" Type=[Interface:ID] ("." Property=[Field:ID] Operator=("+=" | "=") "current")? "}";
+Action: "{" Type=[Interface:ID] ("." Property=[Field:ID] Operator=("+=" | "=") "current")? "}"
 
 interface CompositeRule extends AbstractRuleWithBody {
 }
 
-CompositeRule: "composite" Name=ID ":" Body=CompositeAlternatives ";"?;
+CompositeRule: "composite" Name=ID ":" Body=CompositeAlternatives ";"?
 
-CompositeAlternatives returns Element: CompositeGroup ({Alternatives.Alts+=current} ("|" Alts+=CompositeGroup)+)?;
+CompositeAlternatives returns Element: CompositeGroup ({Alternatives.Alts+=current} ("|" Alts+=CompositeGroup)+)?
 
-CompositeGroup returns Element: CompositeElement ({Group.Elements+=current} Elements+=CompositeElement+)?;
+CompositeGroup returns Element: CompositeElement ({Group.Elements+=current} Elements+=CompositeElement+)?
 
-CompositeElement returns Element: (Keyword | RuleCall | "(" CompositeAlternatives ")") Cardinality=("*" | "+" | "?")?;
+CompositeElement returns Element: (Keyword | RuleCall | "(" CompositeAlternatives ")") Cardinality=("*" | "+" | "?")?
 
 // Move comments in front of RegexLiteral
-comment token SL_COMMENT: /\/\/[^\r\n]*/;
-comment token ML_COMMENT: /\/\*[\s\S]*?\*\//;
+comment token SL_COMMENT: /\/\/[^\r\n]*/
+comment token ML_COMMENT: /\/\*[\s\S]*?\*\//
 
-token StringLiteral: /"[^"]*"/;
-token ID: /[a-zA-Z_][a-zA-Z0-9_]*/;
-token RegexLiteral: /\/([^\r\n\[\/\\]|\\.|\[([^\r\n\]\\]|\\.)*\])+\//;
-hidden token WS: /[ \n\r\t]+/;
+token StringLiteral: /"[^"]*"/
+token ID: /[a-zA-Z_][a-zA-Z0-9_]*/
+token RegexLiteral: /\/([^\r\n\[\/\\]|\\.|\[([^\r\n\]\\]|\\.)*\])+\//
+hidden token WS: /[ \n\r\t]+/

--- a/internal/grammar/grammar.fb
+++ b/internal/grammar/grammar.fb
@@ -1,15 +1,15 @@
 grammar Fastbelt
 
 interface Grammar {
-    Name string
-    Rules []ParserRule
-    Composites []CompositeRule
-    Terminals []Token
+    Name        string
+    Rules       []ParserRule
+    Composites  []CompositeRule
+    Terminals   []Token
     TokenGroups []TokenGroup
-    Interfaces []Interface
+    Interfaces  []Interface
 }
 
-Grammar: "grammar" Name=ID ";"?
+entry Grammar: "grammar" Name=ID ";"?
     (
         Rules+=ParserRule
         | Terminals+=Token
@@ -76,13 +76,14 @@ interface AbstractRuleWithBody extends AbstractRule {
 interface AbstractTokenRule extends AbstractRule{}
 
 interface ParserRule extends AbstractRuleWithBody {
+    Entry      bool
     ReturnType *Interface
 }
 
-ParserRule: Name=ID ("returns" ReturnType=[Interface:ID])? ":" Body=Alternatives ";"?
+ParserRule: (Entry?="entry")? Name=ID ("returns" ReturnType=[Interface:ID])? ":" Body=Alternatives ";"?
 
 interface Token extends AbstractTokenRule {
-    Type string
+    Type   string
     Regexp string
 }
 
@@ -90,8 +91,8 @@ Token: (Type="hidden" | Type="comment")? "token" Name=ID ":" Regexp=RegexLiteral
 
 interface TokenGroup extends AbstractTokenRule {
     TokenRefs []*AbstractTokenRule
-    Regexps []string
-    Keywords []Keyword
+    Regexps   []string
+    Keywords  []Keyword
 }
 
 TokenGroup: "token" "group" Name=ID "{"
@@ -125,7 +126,7 @@ Keyword: Value=StringLiteral
 interface Assignment extends Element {
     Property *Field
     Operator string
-    Value Assignable
+    Value    Assignable
 }
 
 Assignment: Property=[Field:ID] Operator=("+=" | "=" | "?=") Value=Assignable
@@ -152,7 +153,7 @@ interface RuleCall extends Assignable {
 RuleCall: Rule=[AbstractRule:ID]
 
 interface Action extends Element {
-    Type *Interface
+    Type     *Interface
     Operator string
     Property *Field
 }

--- a/internal/grammar/lexer_gen.go
+++ b/internal/grammar/lexer_gen.go
@@ -351,7 +351,26 @@ var Keyword_current = core.NewTokenType(
 	[]rune{'c'},
 )
 
-const Keyword_extends_Idx = 19
+const Keyword_entry_Idx = 19
+
+var Keyword_entry = core.NewTokenType(
+	Keyword_entry_Idx,
+	"entry",
+	"entry",
+	0,
+	core.TokenKindKeyword,
+	0,
+	false,
+	func(text string, offset int) int {
+		if strings.HasPrefix(text[offset:], "entry") {
+			return 5
+		}
+		return 0
+	},
+	[]rune{'e'},
+)
+
+const Keyword_extends_Idx = 20
 
 var Keyword_extends = core.NewTokenType(
 	Keyword_extends_Idx,
@@ -370,7 +389,7 @@ var Keyword_extends = core.NewTokenType(
 	[]rune{'e'},
 )
 
-const Keyword_grammar_Idx = 20
+const Keyword_grammar_Idx = 21
 
 var Keyword_grammar = core.NewTokenType(
 	Keyword_grammar_Idx,
@@ -389,7 +408,7 @@ var Keyword_grammar = core.NewTokenType(
 	[]rune{'g'},
 )
 
-const Keyword_group_Idx = 21
+const Keyword_group_Idx = 22
 
 var Keyword_group = core.NewTokenType(
 	Keyword_group_Idx,
@@ -408,7 +427,7 @@ var Keyword_group = core.NewTokenType(
 	[]rune{'g'},
 )
 
-const Keyword_hidden_Idx = 22
+const Keyword_hidden_Idx = 23
 
 var Keyword_hidden = core.NewTokenType(
 	Keyword_hidden_Idx,
@@ -427,7 +446,7 @@ var Keyword_hidden = core.NewTokenType(
 	[]rune{'h'},
 )
 
-const Keyword_interface_Idx = 23
+const Keyword_interface_Idx = 24
 
 var Keyword_interface = core.NewTokenType(
 	Keyword_interface_Idx,
@@ -446,7 +465,7 @@ var Keyword_interface = core.NewTokenType(
 	[]rune{'i'},
 )
 
-const Keyword_keywords_Idx = 24
+const Keyword_keywords_Idx = 25
 
 var Keyword_keywords = core.NewTokenType(
 	Keyword_keywords_Idx,
@@ -465,7 +484,7 @@ var Keyword_keywords = core.NewTokenType(
 	[]rune{'k'},
 )
 
-const Keyword_returns_Idx = 25
+const Keyword_returns_Idx = 26
 
 var Keyword_returns = core.NewTokenType(
 	Keyword_returns_Idx,
@@ -484,7 +503,7 @@ var Keyword_returns = core.NewTokenType(
 	[]rune{'r'},
 )
 
-const Keyword_string_Idx = 26
+const Keyword_string_Idx = 27
 
 var Keyword_string = core.NewTokenType(
 	Keyword_string_Idx,
@@ -503,7 +522,7 @@ var Keyword_string = core.NewTokenType(
 	[]rune{'s'},
 )
 
-const Keyword_token_Idx = 27
+const Keyword_token_Idx = 28
 
 var Keyword_token = core.NewTokenType(
 	Keyword_token_Idx,
@@ -522,7 +541,7 @@ var Keyword_token = core.NewTokenType(
 	[]rune{'t'},
 )
 
-const Keyword_LeftBrace_Idx = 28
+const Keyword_LeftBrace_Idx = 29
 
 var Keyword_LeftBrace = core.NewTokenType(
 	Keyword_LeftBrace_Idx,
@@ -541,7 +560,7 @@ var Keyword_LeftBrace = core.NewTokenType(
 	[]rune{'{'},
 )
 
-const Keyword_Pipe_Idx = 29
+const Keyword_Pipe_Idx = 30
 
 var Keyword_Pipe = core.NewTokenType(
 	Keyword_Pipe_Idx,
@@ -560,7 +579,7 @@ var Keyword_Pipe = core.NewTokenType(
 	[]rune{'|'},
 )
 
-const Keyword_RightBrace_Idx = 30
+const Keyword_RightBrace_Idx = 31
 
 var Keyword_RightBrace = core.NewTokenType(
 	Keyword_RightBrace_Idx,
@@ -579,7 +598,7 @@ var Keyword_RightBrace = core.NewTokenType(
 	[]rune{'}'},
 )
 
-const Token_SL_COMMENT_Idx = 31
+const Token_SL_COMMENT_Idx = 32
 
 var Token_SL_COMMENT = core.NewTokenType(
 	Token_SL_COMMENT_Idx,
@@ -670,7 +689,7 @@ var Token_SL_COMMENT_Accepting = [3]bool{
 	2: true,
 }
 
-const Token_ML_COMMENT_Idx = 32
+const Token_ML_COMMENT_Idx = 33
 
 var Token_ML_COMMENT = core.NewTokenType(
 	Token_ML_COMMENT_Idx,
@@ -795,7 +814,7 @@ var Token_ML_COMMENT_Accepting = [5]bool{
 	4: true,
 }
 
-const Token_StringLiteral_Idx = 33
+const Token_StringLiteral_Idx = 34
 
 var Token_StringLiteral = core.NewTokenType(
 	Token_StringLiteral_Idx,
@@ -886,7 +905,7 @@ var Token_StringLiteral_Accepting = [3]bool{
 	2: true,
 }
 
-const Token_ID_Idx = 34
+const Token_ID_Idx = 35
 
 var Token_ID = core.NewTokenType(
 	Token_ID_Idx,
@@ -960,7 +979,7 @@ var Token_ID_Accepting = [2]bool{
 	1: true,
 }
 
-const Token_RegexLiteral_Idx = 35
+const Token_RegexLiteral_Idx = 36
 
 var Token_RegexLiteral = core.NewTokenType(
 	Token_RegexLiteral_Idx,
@@ -1119,7 +1138,7 @@ var Token_RegexLiteral_Accepting = [7]bool{
 	5: true,
 }
 
-const Token_WS_Idx = 36
+const Token_WS_Idx = 37
 
 var Token_WS = core.NewTokenType(
 	Token_WS_Idx,
@@ -1213,6 +1232,7 @@ func NewLexer() lexer.Lexer {
 		Keyword_comment,
 		Keyword_composite,
 		Keyword_current,
+		Keyword_entry,
 		Keyword_extends,
 		Keyword_grammar,
 		Keyword_group,

--- a/internal/grammar/parser_gen.go
+++ b/internal/grammar/parser_gen.go
@@ -347,13 +347,23 @@ func (p *Parser) ParseParserRule() ParserRule {
 	current.SetSegmentStartToken(p.state.LA(1))
 	{
 		{
+			p.state.Sync(ParserRule__Basic_1)
+			if p.lookahead.ParserRuleEntryOptional(p.state) {
+				token := p.state.Consume(Keyword_entry)
+				core.AssignToken(current, token, ParserRule_Entry_entry)
+				if token != nil {
+					current.SetEntry(token)
+				}
+			}
+		}
+		{
 			token := p.state.Consume(Token_ID)
 			core.AssignToken(current, token, ParserRule_Name_ID)
 			if token != nil {
 				current.SetName(token)
 			}
 		}
-		p.state.Sync(ParserRule__Basic_1)
+		p.state.Sync(ParserRule__Basic_3)
 		if p.lookahead.ParserRuleOptional(p.state) {
 			{
 				token := p.state.Consume(Keyword_returns)
@@ -372,7 +382,7 @@ func (p *Parser) ParseParserRule() ParserRule {
 			core.AssignToken(current, token, ParserRule_Colon)
 		}
 		{
-			p.state.EnterRule(ParserRule__Basic_4)
+			p.state.EnterRule(ParserRule__Basic_6)
 			result := p.ParseAlternatives()
 			p.state.ExitRule()
 			if result != nil {

--- a/internal/grammar/parser_gen.go
+++ b/internal/grammar/parser_gen.go
@@ -49,15 +49,17 @@ func (p *Parser) ParseGrammar() Grammar {
 			}
 		}
 		{
-			token := p.state.Consume(Keyword_Semicolon)
-			core.AssignToken(current, token, Grammar_Semicolon)
+			if p.lookahead.GrammarSemicolonOptional(p.state) {
+				token := p.state.Consume(Keyword_Semicolon)
+				core.AssignToken(current, token, Grammar_Semicolon)
+			}
 		}
 		p.state.Sync(Grammar__LoopEntry)
 		for p.lookahead.GrammarLoop(p.state) {
 			switch prediction, failure := p.lookahead.GrammarAlternatives(p.state); prediction {
 			case 0:
 				{
-					p.state.EnterRule(Grammar__Basic_1)
+					p.state.EnterRule(Grammar__Basic_3)
 					result := p.ParseParserRule()
 					p.state.ExitRule()
 					if result != nil {
@@ -66,7 +68,7 @@ func (p *Parser) ParseGrammar() Grammar {
 				}
 			case 1:
 				{
-					p.state.EnterRule(Grammar__Basic_3)
+					p.state.EnterRule(Grammar__Basic_5)
 					result := p.ParseToken()
 					p.state.ExitRule()
 					if result != nil {
@@ -75,7 +77,7 @@ func (p *Parser) ParseGrammar() Grammar {
 				}
 			case 2:
 				{
-					p.state.EnterRule(Grammar__Basic_5)
+					p.state.EnterRule(Grammar__Basic_7)
 					result := p.ParseTokenGroup()
 					p.state.ExitRule()
 					if result != nil {
@@ -84,7 +86,7 @@ func (p *Parser) ParseGrammar() Grammar {
 				}
 			case 3:
 				{
-					p.state.EnterRule(Grammar__Basic_7)
+					p.state.EnterRule(Grammar__Basic_9)
 					result := p.ParseInterface()
 					p.state.ExitRule()
 					if result != nil {
@@ -93,7 +95,7 @@ func (p *Parser) ParseGrammar() Grammar {
 				}
 			case 4:
 				{
-					p.state.EnterRule(Grammar__Basic_9)
+					p.state.EnterRule(Grammar__Basic_11)
 					result := p.ParseCompositeRule()
 					p.state.ExitRule()
 					if result != nil {
@@ -370,7 +372,7 @@ func (p *Parser) ParseParserRule() ParserRule {
 			core.AssignToken(current, token, ParserRule_Colon)
 		}
 		{
-			p.state.EnterRule(ParserRule_Semicolon)
+			p.state.EnterRule(ParserRule__Basic_4)
 			result := p.ParseAlternatives()
 			p.state.ExitRule()
 			if result != nil {
@@ -378,8 +380,10 @@ func (p *Parser) ParseParserRule() ParserRule {
 			}
 		}
 		{
-			token := p.state.Consume(Keyword_Semicolon)
-			core.AssignToken(current, token, ParserRule_Semicolon)
+			if p.lookahead.ParserRuleSemicolonOptional(p.state) {
+				token := p.state.Consume(Keyword_Semicolon)
+				core.AssignToken(current, token, ParserRule_Semicolon)
+			}
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
@@ -432,8 +436,10 @@ func (p *Parser) ParseToken() Token {
 			}
 		}
 		{
-			token := p.state.Consume(Keyword_Semicolon)
-			core.AssignToken(current, token, Token_Semicolon)
+			if p.lookahead.TokenSemicolonOptional(p.state) {
+				token := p.state.Consume(Keyword_Semicolon)
+				core.AssignToken(current, token, Token_Semicolon)
+			}
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))
@@ -1001,7 +1007,7 @@ func (p *Parser) ParseCompositeRule() CompositeRule {
 			core.AssignToken(current, token, CompositeRule_Colon)
 		}
 		{
-			p.state.EnterRule(CompositeRule_Semicolon)
+			p.state.EnterRule(CompositeRule__Basic_2)
 			result := p.ParseCompositeAlternatives()
 			p.state.ExitRule()
 			if result != nil {
@@ -1009,8 +1015,10 @@ func (p *Parser) ParseCompositeRule() CompositeRule {
 			}
 		}
 		{
-			token := p.state.Consume(Keyword_Semicolon)
-			core.AssignToken(current, token, CompositeRule_Semicolon)
+			if p.lookahead.CompositeRuleSemicolonOptional(p.state) {
+				token := p.state.Consume(Keyword_Semicolon)
+				core.AssignToken(current, token, CompositeRule_Semicolon)
+			}
 		}
 	}
 	current.SetSegmentEndToken(p.state.LA(0))

--- a/internal/grammar/parser_lookahead.go
+++ b/internal/grammar/parser_lookahead.go
@@ -1,0 +1,59 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+package grammar
+
+import "typefox.dev/fastbelt/parser"
+
+// fastbeltParserLookahead extends the generated default with disambiguation for
+// group cardinality guards inside parser and composite rules. Optional semicolons
+// between rules mean an ID can start either another element in the current rule
+// body or the next parser rule; SLL cannot distinguish those cases when only
+// LA(1) is considered. The next composite rule always starts with the "composite"
+// keyword, so no extra disambiguation is needed for that case.
+type fastbeltParserLookahead struct {
+	DefaultFastbeltParserLookahead
+}
+
+func newFastbeltParserLookahead() FastbeltParserLookahead {
+	return &fastbeltParserLookahead{}
+}
+
+// isNextParserRule reports whether the upcoming tokens start a new parser rule
+// (Name=ID ":" or Name returns Type=ID ":").
+func isNextParserRule(state *parser.ParserState) bool {
+	if state.LA(1).Type != Token_ID {
+		return false
+	}
+	switch state.LA(2).Type {
+	case Keyword_Colon, Keyword_returns:
+		return true
+	default:
+		return false
+	}
+}
+
+func (l *fastbeltParserLookahead) groupGuardContinue(state *parser.ParserState, decision int) bool {
+	if isNextParserRule(state) {
+		return false
+	}
+	prediction, _ := state.AdaptivePredict(decision, l.PredictionMode())
+	return prediction == 0
+}
+
+func (l *fastbeltParserLookahead) GroupOptional(state *parser.ParserState) bool {
+	return l.groupGuardContinue(state, DecisionGroupOptional)
+}
+
+func (l *fastbeltParserLookahead) GroupElementsLoop(state *parser.ParserState) bool {
+	return l.groupGuardContinue(state, DecisionGroupElementsLoop)
+}
+
+func (l *fastbeltParserLookahead) CompositeGroupOptional(state *parser.ParserState) bool {
+	return l.groupGuardContinue(state, DecisionCompositeGroupOptional)
+}
+
+func (l *fastbeltParserLookahead) CompositeGroupElementsLoop(state *parser.ParserState) bool {
+	return l.groupGuardContinue(state, DecisionCompositeGroupElementsLoop)
+}

--- a/internal/grammar/parser_lookahead_gen.go
+++ b/internal/grammar/parser_lookahead_gen.go
@@ -8,8 +8,12 @@ import (
 )
 
 const (
-	DecisionElementAlternatives = 16
-	DecisionGrammarAlternatives = 0
+	DecisionCompositeGroupElementsLoop = 33
+	DecisionCompositeGroupOptional     = 34
+	DecisionElementAlternatives        = 19
+	DecisionGrammarAlternatives        = 1
+	DecisionGroupElementsLoop          = 17
+	DecisionGroupOptional              = 18
 )
 
 var ActionOperatorAlternatives = parser.LL1Lookahead{
@@ -42,16 +46,6 @@ var CompositeElementCardinalityAlternatives = parser.LL1Lookahead{
 	Lookup: []int{3: 1, 4: 2, 11: 3},
 }
 
-var CompositeGroupElementsLoop = parser.LL1Lookahead{
-	Types:  []*core.TokenType{Keyword_LeftParen, Token_StringLiteral, Token_ID},
-	Lookup: []int{1: 1, 33: 1, 34: 1},
-}
-
-var CompositeGroupOptional = parser.LL1Lookahead{
-	Types:  []*core.TokenType{Keyword_LeftParen, Token_StringLiteral, Token_ID},
-	Lookup: []int{1: 1, 33: 1, 34: 1},
-}
-
 var ElementCardinalityAlternatives = parser.LL1Lookahead{
 	Types:  []*core.TokenType{Keyword_Asterisk, Keyword_Plus, Keyword_Question},
 	Lookup: []int{3: 1, 4: 2, 11: 3},
@@ -65,16 +59,6 @@ var FieldTypeAlternatives = parser.LL1Lookahead{
 var GrammarLoop = parser.LL1Lookahead{
 	Types:  []*core.TokenType{Keyword_comment, Keyword_composite, Keyword_hidden, Keyword_interface, Keyword_token, Token_ID},
 	Lookup: []int{16: 1, 17: 1, 22: 1, 23: 1, 27: 1, 34: 1},
-}
-
-var GroupElementsLoop = parser.LL1Lookahead{
-	Types:  []*core.TokenType{Keyword_LeftParen, Keyword_LeftBrace, Token_StringLiteral, Token_ID},
-	Lookup: []int{1: 1, 28: 1, 33: 1, 34: 1},
-}
-
-var GroupOptional = parser.LL1Lookahead{
-	Types:  []*core.TokenType{Keyword_LeftParen, Keyword_LeftBrace, Token_StringLiteral, Token_ID},
-	Lookup: []int{1: 1, 28: 1, 33: 1, 34: 1},
 }
 
 var PrimitiveTypeTypeAlternatives = parser.LL1Lookahead{
@@ -114,21 +98,25 @@ type FastbeltParserLookahead interface {
 	CompositeElementCardinalityAlternatives(state *parser.ParserState) (int, *parser.PredictionFailure)
 	CompositeGroupElementsLoop(state *parser.ParserState) bool
 	CompositeGroupOptional(state *parser.ParserState) bool
+	CompositeRuleSemicolonOptional(state *parser.ParserState) bool
 	CrossRefOptional(state *parser.ParserState) bool
 	ElementAlternatives(state *parser.ParserState) (int, *parser.PredictionFailure)
 	ElementCardinalityAlternatives(state *parser.ParserState) (int, *parser.PredictionFailure)
 	FieldTypeAlternatives(state *parser.ParserState) (int, *parser.PredictionFailure)
 	GrammarAlternatives(state *parser.ParserState) (int, *parser.PredictionFailure)
 	GrammarLoop(state *parser.ParserState) bool
+	GrammarSemicolonOptional(state *parser.ParserState) bool
 	GroupElementsLoop(state *parser.ParserState) bool
 	GroupOptional(state *parser.ParserState) bool
 	InterfaceFieldsLoop(state *parser.ParserState) bool
 	InterfaceLoop(state *parser.ParserState) bool
 	InterfaceOptional(state *parser.ParserState) bool
 	ParserRuleOptional(state *parser.ParserState) bool
+	ParserRuleSemicolonOptional(state *parser.ParserState) bool
 	PrimitiveTypeTypeAlternatives(state *parser.ParserState) (int, *parser.PredictionFailure)
 	TokenAlternatives(state *parser.ParserState) (int, *parser.PredictionFailure)
 	TokenGroupAlternatives(state *parser.ParserState) (int, *parser.PredictionFailure)
+	TokenSemicolonOptional(state *parser.ParserState) bool
 }
 
 // DefaultFastbeltParserLookahead resolves every decision with the parser state's built-in
@@ -194,13 +182,17 @@ func (l *DefaultFastbeltParserLookahead) CompositeElementCardinalityAlternatives
 }
 
 func (l *DefaultFastbeltParserLookahead) CompositeGroupElementsLoop(state *parser.ParserState) bool {
-	prediction, _ := state.Lookahead(CompositeGroupElementsLoop)
+	prediction, _ := state.AdaptivePredict(DecisionCompositeGroupElementsLoop, l.PredictionMode())
 	return prediction == 0
 }
 
 func (l *DefaultFastbeltParserLookahead) CompositeGroupOptional(state *parser.ParserState) bool {
-	prediction, _ := state.Lookahead(CompositeGroupOptional)
+	prediction, _ := state.AdaptivePredict(DecisionCompositeGroupOptional, l.PredictionMode())
 	return prediction == 0
+}
+
+func (l *DefaultFastbeltParserLookahead) CompositeRuleSemicolonOptional(state *parser.ParserState) bool {
+	return state.LA(1).Type == Keyword_Semicolon
 }
 
 func (l *DefaultFastbeltParserLookahead) CrossRefOptional(state *parser.ParserState) bool {
@@ -228,13 +220,17 @@ func (l *DefaultFastbeltParserLookahead) GrammarLoop(state *parser.ParserState) 
 	return prediction == 0
 }
 
+func (l *DefaultFastbeltParserLookahead) GrammarSemicolonOptional(state *parser.ParserState) bool {
+	return state.LA(1).Type == Keyword_Semicolon
+}
+
 func (l *DefaultFastbeltParserLookahead) GroupElementsLoop(state *parser.ParserState) bool {
-	prediction, _ := state.Lookahead(GroupElementsLoop)
+	prediction, _ := state.AdaptivePredict(DecisionGroupElementsLoop, l.PredictionMode())
 	return prediction == 0
 }
 
 func (l *DefaultFastbeltParserLookahead) GroupOptional(state *parser.ParserState) bool {
-	prediction, _ := state.Lookahead(GroupOptional)
+	prediction, _ := state.AdaptivePredict(DecisionGroupOptional, l.PredictionMode())
 	return prediction == 0
 }
 
@@ -254,6 +250,10 @@ func (l *DefaultFastbeltParserLookahead) ParserRuleOptional(state *parser.Parser
 	return state.LA(1).Type == Keyword_returns
 }
 
+func (l *DefaultFastbeltParserLookahead) ParserRuleSemicolonOptional(state *parser.ParserState) bool {
+	return state.LA(1).Type == Keyword_Semicolon
+}
+
 func (l *DefaultFastbeltParserLookahead) PrimitiveTypeTypeAlternatives(state *parser.ParserState) (int, *parser.PredictionFailure) {
 	return state.Lookahead(PrimitiveTypeTypeAlternatives)
 }
@@ -264,4 +264,8 @@ func (l *DefaultFastbeltParserLookahead) TokenAlternatives(state *parser.ParserS
 
 func (l *DefaultFastbeltParserLookahead) TokenGroupAlternatives(state *parser.ParserState) (int, *parser.PredictionFailure) {
 	return state.Lookahead(TokenGroupAlternatives)
+}
+
+func (l *DefaultFastbeltParserLookahead) TokenSemicolonOptional(state *parser.ParserState) bool {
+	return state.LA(1).Type == Keyword_Semicolon
 }

--- a/internal/grammar/parser_lookahead_gen.go
+++ b/internal/grammar/parser_lookahead_gen.go
@@ -8,12 +8,12 @@ import (
 )
 
 const (
-	DecisionCompositeGroupElementsLoop = 33
-	DecisionCompositeGroupOptional     = 34
-	DecisionElementAlternatives        = 19
+	DecisionCompositeGroupElementsLoop = 34
+	DecisionCompositeGroupOptional     = 35
+	DecisionElementAlternatives        = 20
 	DecisionGrammarAlternatives        = 1
-	DecisionGroupElementsLoop          = 17
-	DecisionGroupOptional              = 18
+	DecisionGroupElementsLoop          = 18
+	DecisionGroupOptional              = 19
 )
 
 var ActionOperatorAlternatives = parser.LL1Lookahead{
@@ -23,12 +23,12 @@ var ActionOperatorAlternatives = parser.LL1Lookahead{
 
 var AssignableAlternatives = parser.LL1Lookahead{
 	Types:  []*core.TokenType{Token_StringLiteral, Token_ID, Keyword_LeftBracket, Keyword_LeftParen},
-	Lookup: []int{1: 4, 13: 3, 33: 1, 34: 2},
+	Lookup: []int{1: 4, 13: 3, 34: 1, 35: 2},
 }
 
 var AssignableWithoutAltsAlternatives = parser.LL1Lookahead{
 	Types:  []*core.TokenType{Token_StringLiteral, Token_ID, Keyword_LeftBracket},
-	Lookup: []int{13: 3, 33: 1, 34: 2},
+	Lookup: []int{13: 3, 34: 1, 35: 2},
 }
 
 var AssignmentOperatorAlternatives = parser.LL1Lookahead{
@@ -38,7 +38,7 @@ var AssignmentOperatorAlternatives = parser.LL1Lookahead{
 
 var CompositeElementAlternatives = parser.LL1Lookahead{
 	Types:  []*core.TokenType{Token_StringLiteral, Token_ID, Keyword_LeftParen},
-	Lookup: []int{1: 3, 33: 1, 34: 2},
+	Lookup: []int{1: 3, 34: 1, 35: 2},
 }
 
 var CompositeElementCardinalityAlternatives = parser.LL1Lookahead{
@@ -53,27 +53,27 @@ var ElementCardinalityAlternatives = parser.LL1Lookahead{
 
 var FieldTypeAlternatives = parser.LL1Lookahead{
 	Types:  []*core.TokenType{Token_ID, Keyword_Asterisk, Keyword_LeftBracket, Keyword_bool, Keyword_composite, Keyword_string},
-	Lookup: []int{3: 2, 13: 3, 15: 4, 17: 4, 26: 4, 34: 1},
+	Lookup: []int{3: 2, 13: 3, 15: 4, 17: 4, 27: 4, 35: 1},
 }
 
 var GrammarLoop = parser.LL1Lookahead{
-	Types:  []*core.TokenType{Keyword_comment, Keyword_composite, Keyword_hidden, Keyword_interface, Keyword_token, Token_ID},
-	Lookup: []int{16: 1, 17: 1, 22: 1, 23: 1, 27: 1, 34: 1},
+	Types:  []*core.TokenType{Keyword_comment, Keyword_composite, Keyword_entry, Keyword_hidden, Keyword_interface, Keyword_token, Token_ID},
+	Lookup: []int{16: 1, 17: 1, 19: 1, 23: 1, 24: 1, 28: 1, 35: 1},
 }
 
 var PrimitiveTypeTypeAlternatives = parser.LL1Lookahead{
 	Types:  []*core.TokenType{Keyword_string, Keyword_bool, Keyword_composite},
-	Lookup: []int{15: 2, 17: 3, 26: 1},
+	Lookup: []int{15: 2, 17: 3, 27: 1},
 }
 
 var TokenAlternatives = parser.LL1Lookahead{
 	Types:  []*core.TokenType{Keyword_hidden, Keyword_comment},
-	Lookup: []int{16: 2, 22: 1},
+	Lookup: []int{16: 2, 23: 1},
 }
 
 var TokenGroupAlternatives = parser.LL1Lookahead{
 	Types:  []*core.TokenType{Token_ID, Keyword_keywords, Token_StringLiteral},
-	Lookup: []int{24: 2, 33: 3, 34: 1},
+	Lookup: []int{25: 2, 34: 3, 35: 1},
 }
 
 // FastbeltParserLookahead abstracts every lookahead/prediction decision performed by
@@ -111,6 +111,7 @@ type FastbeltParserLookahead interface {
 	InterfaceFieldsLoop(state *parser.ParserState) bool
 	InterfaceLoop(state *parser.ParserState) bool
 	InterfaceOptional(state *parser.ParserState) bool
+	ParserRuleEntryOptional(state *parser.ParserState) bool
 	ParserRuleOptional(state *parser.ParserState) bool
 	ParserRuleSemicolonOptional(state *parser.ParserState) bool
 	PrimitiveTypeTypeAlternatives(state *parser.ParserState) (int, *parser.PredictionFailure)
@@ -244,6 +245,10 @@ func (l *DefaultFastbeltParserLookahead) InterfaceLoop(state *parser.ParserState
 
 func (l *DefaultFastbeltParserLookahead) InterfaceOptional(state *parser.ParserState) bool {
 	return state.LA(1).Type == Keyword_extends
+}
+
+func (l *DefaultFastbeltParserLookahead) ParserRuleEntryOptional(state *parser.ParserState) bool {
+	return state.LA(1).Type == Keyword_entry
 }
 
 func (l *DefaultFastbeltParserLookahead) ParserRuleOptional(state *parser.ParserState) bool {

--- a/internal/grammar/parser_test.go
+++ b/internal/grammar/parser_test.go
@@ -1,0 +1,93 @@
+package grammar
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"typefox.dev/fastbelt/test"
+)
+
+func TestOptionalSemicolonBetweenParserRules(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+		interface Foo { Name string }
+		interface Bar { Name string }
+		A: Name=ID
+		B: Name=ID
+	` + commonTokens)
+	doc.AssertNoParseErrors()
+	g := doc.Document.Root.(Grammar)
+	require.Len(t, g.Rules(), 2)
+	assert.Equal(t, "A", g.Rules()[0].Name())
+	assert.Equal(t, "B", g.Rules()[1].Name())
+}
+
+func TestOptionalSemicolonBetweenCompositeRules(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+		composite A: ID
+		composite B: ID
+	` + commonTokens)
+	doc.AssertNoParseErrors()
+	g := doc.Document.Root.(Grammar)
+	require.Len(t, g.Composites(), 2)
+	assert.Equal(t, "A", g.Composites()[0].Name())
+	assert.Equal(t, "B", g.Composites()[1].Name())
+}
+
+func TestOptionalSemicolonCompositeBeforeParserRule(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+		interface Foo { Name string }
+		composite A: ID
+		B: Name=ID
+	` + commonTokens)
+	doc.AssertNoParseErrors()
+	g := doc.Document.Root.(Grammar)
+	require.Len(t, g.Composites(), 1)
+	require.Len(t, g.Rules(), 1)
+	assert.Equal(t, "B", g.Rules()[0].Name())
+}
+
+func TestOptionalSemicolonAfterStarBeforeReturnsRule(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+		interface Expression {}
+		interface BinaryExpression extends Expression {
+			Left Expression
+			Operator string
+			Right Expression
+		}
+		Addition returns Expression:
+			Multiplication ({BinaryExpression.Left=current} Operator=("+" | "-") Right=Multiplication)*
+		Multiplication returns Expression:
+			PrimaryExpression
+		PrimaryExpression returns Expression:
+			Number=ID
+	` + commonTokens)
+	doc.AssertNoParseErrors()
+	g := doc.Document.Root.(Grammar)
+	require.Len(t, g.Rules(), 3)
+	assert.Equal(t, "Addition", g.Rules()[0].Name())
+	assert.Equal(t, "Multiplication", g.Rules()[1].Name())
+}
+
+func TestOptionalSemicolonStarRuleBeforePlainRule(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+		interface Foo { Name string }
+		interface Bar { Names []string }
+		A: Names+=ID*
+		B: Name=ID
+	` + commonTokens)
+	doc.AssertNoParseErrors()
+	g := doc.Document.Root.(Grammar)
+	require.Len(t, g.Rules(), 2)
+	assert.Equal(t, "B", g.Rules()[1].Name())
+}

--- a/internal/grammar/services.go
+++ b/internal/grammar/services.go
@@ -23,9 +23,12 @@ func SetupServices(sc *service.Container) {
 	workspace.SetupDefaultServices(sc)
 	SetupGeneratedServices(sc)
 
+	// Override the default parser lookahead
+	service.Override(sc, newFastbeltParserLookahead())
+
 	// Override the default scope provider
 	service.Override[FastbeltScopeProvider](sc, newScopeProviderImpl(sc))
-	service.Override[linking.SymbolImporter](sc, newImportedSymbolsProviderImpl(sc))
+	service.Override(sc, newImportedSymbolsProviderImpl(sc))
 }
 
 // CreateServices creates a service container for the grammar language to be used in the CLI and tests.

--- a/internal/grammar/types_gen.go
+++ b/internal/grammar/types_gen.go
@@ -789,6 +789,9 @@ type ParserRule interface {
 	AbstractRuleWithBody
 
 	IsParserRule()
+	IsEntry() bool
+	EntryToken() *core.Token
+	SetEntry(value *core.Token)
 	ReturnType() *core.Reference[Interface]
 	SetReturnType(value *core.Reference[Interface])
 }
@@ -803,6 +806,7 @@ func NewParserRule() ParserRule {
 }
 
 type ParserRuleData struct {
+	entry      *core.Token
 	returnType *core.Reference[Interface]
 }
 
@@ -819,6 +823,18 @@ func (i *ParserRuleData) ForEachReference(fn func(core.UntypedReference)) {
 	if i.returnType != nil {
 		fn(i.returnType)
 	}
+}
+
+func (i *ParserRuleData) IsEntry() bool {
+	return i != nil && i.entry != nil
+}
+
+func (i *ParserRuleData) EntryToken() *core.Token {
+	return i.entry
+}
+
+func (i *ParserRuleData) SetEntry(value *core.Token) {
+	i.entry = value
 }
 
 func (i *ParserRuleData) ReturnType() *core.Reference[Interface] {

--- a/internal/grammar/validator.go
+++ b/internal/grammar/validator.go
@@ -16,24 +16,40 @@ import (
 )
 
 const (
-	ValidateUniqueRuleName         = "uniqueRuleName"
-	ValidateUniqueInterfaceName    = "uniqueInterfaceName"
-	ValidateEmptyToken             = "emptyTerminalRule"
-	ValidateEmptyKeyword           = "emptyKeyword"
-	ValidateWhitespaceOnlyKeyword  = "whitespaceOnlyKeyword"
-	ValidateKeywordWithWhitespace  = "keywordWithWhitespace"
-	ValidateRuleReturnType         = "ruleReturnType"
-	ValidateInterfaceExtends       = "interfaceExtends"
-	ValidateRuleCallReturnType     = "ruleCallReturnType"
-	ValidateRuleCallPosition       = "ruleCallPosition"
-	ValidateActionAssignmentType   = "actionAssignmentType"
-	ValidateActionPropertyType     = "actionPropertyType"
-	ValidateAssignmentType         = "assignmentType"
-	ValidateRecursiveTokenGroup    = "recursiveTokenGroup"
-	ValidateInvalidTokenInGroup    = "invalidTokenInGroup"
-	ValidateUniqueFieldName        = "uniqueFieldName"
-	ValidateFieldNameCapitalLetter = "fieldNameCapitalLetter"
+	ValidateUniqueRuleName          = "uniqueRuleName"
+	ValidateUniqueInterfaceName     = "uniqueInterfaceName"
+	ValidateEmptyToken              = "emptyTerminalRule"
+	ValidateEmptyKeyword            = "emptyKeyword"
+	ValidateWhitespaceOnlyKeyword   = "whitespaceOnlyKeyword"
+	ValidateKeywordWithWhitespace   = "keywordWithWhitespace"
+	ValidateRuleReturnType          = "ruleReturnType"
+	ValidateInterfaceExtends        = "interfaceExtends"
+	ValidateRuleCallReturnType      = "ruleCallReturnType"
+	ValidateRuleCallPosition        = "ruleCallPosition"
+	ValidateActionAssignmentType    = "actionAssignmentType"
+	ValidateActionPropertyType      = "actionPropertyType"
+	ValidateAssignmentType          = "assignmentType"
+	ValidateRecursiveTokenGroup     = "recursiveTokenGroup"
+	ValidateInvalidTokenInGroup     = "invalidTokenInGroup"
+	ValidateInvalidTokenInCrossRef  = "invalidTokenInCrossRef"
+	ValidateMissingCrossRefTerminal = "missingCrossRefTerminal"
+	ValidateUniqueFieldName         = "uniqueFieldName"
+	ValidateFieldNameCapitalLetter  = "fieldNameCapitalLetter"
+	ValidateReservedFieldName       = "reservedFieldName"
+	ValidateNestedArrayType         = "nestedArrayType"
 )
+
+// reservedFieldNames lists field names that must not be used because they
+// conflict with [core.AstNode] methods. Keep in sync with ast.go.
+var reservedFieldNames = map[string]string{
+	"Document":         "AstNode.Document",
+	"Container":        "AstNode.Container",
+	"Tokens":           "AstNode.Tokens",
+	"Segment":          "AstNode.Segment",
+	"Text":             "AstNode.Text",
+	"ForEachNode":      "AstNode.ForEachNode",
+	"ForEachReference": "AstNode.ForEachReference",
+}
 
 // GrammarImpl.Validate checks grammar-level constraints:
 //   - Rule names must be unique within the grammar.
@@ -197,6 +213,7 @@ func checkRuleReturnType(rule ParserRule, _ context.Context, accept core.Validat
 func (i *InterfaceImpl) Validate(ctx context.Context, _ string, accept core.ValidationAcceptor) {
 	checkInterfaceExtends(i, ctx, accept)
 	checkInterfaceFieldNames(i, ctx, accept)
+	checkInterfaceFieldTypes(i, accept)
 }
 
 func collectInheritedFieldNames(iface Interface, ctx context.Context, collected map[string]Interface, visited collections.Set[string]) {
@@ -228,6 +245,21 @@ func checkInterfaceFieldNames(iface Interface, ctx context.Context, accept core.
 	inherited := map[string]Interface{}
 	collectInheritedFieldNames(iface, ctx, inherited, collections.NewSet[string]())
 
+	allFields := map[string]Interface{}
+	for lower, declaringIface := range inherited {
+		allFields[lower] = declaringIface
+	}
+	for _, field := range iface.Fields() {
+		name := field.Name()
+		if name == "" {
+			continue
+		}
+		lower := strings.ToLower(name)
+		if _, exists := allFields[lower]; !exists {
+			allFields[lower] = iface
+		}
+	}
+
 	seen := collections.NewSet[string]()
 	for _, field := range iface.Fields() {
 		name := field.Name()
@@ -237,17 +269,18 @@ func checkInterfaceFieldNames(iface Interface, ctx context.Context, accept core.
 		if !unicode.IsUpper(rune(name[0])) {
 			accept(core.NewDiagnostic(
 				core.SeverityError,
-				fmt.Sprintf("Property names must start with a capital letter. '%s' does not.", name),
+				"Field names must start with a capital letter.",
 				field,
 				core.WithToken(field.NameToken()),
 				core.WithCode(ValidateFieldNameCapitalLetter),
 			))
 		}
+		checkReservedFieldName(field, iface, allFields, accept)
 		lower := strings.ToLower(name)
 		if seen.Has(lower) {
 			accept(core.NewDiagnostic(
 				core.SeverityError,
-				fmt.Sprintf("A property's name has to be unique (case-insensitively). '%s' is already used above.", name),
+				fmt.Sprintf("A field's name has to be unique (case-insensitively). '%s' is already used above.", name),
 				field,
 				core.WithToken(field.NameToken()),
 				core.WithCode(ValidateUniqueFieldName),
@@ -257,7 +290,7 @@ func checkInterfaceFieldNames(iface Interface, ctx context.Context, accept core.
 			if declaringIface, dup := inherited[lower]; dup {
 				accept(core.NewDiagnostic(
 					core.SeverityError,
-					fmt.Sprintf("A property's name has to be unique (case-insensitively). '%s' is already declared in '%s'.", name, declaringIface.Name()),
+					fmt.Sprintf("A field's name has to be unique (case-insensitively). '%s' is already declared in '%s'.", name, declaringIface.Name()),
 					field,
 					core.WithToken(field.NameToken()),
 					core.WithCode(ValidateUniqueFieldName),
@@ -265,6 +298,98 @@ func checkInterfaceFieldNames(iface Interface, ctx context.Context, accept core.
 			}
 		}
 	}
+}
+
+func checkInterfaceFieldTypes(iface Interface, accept core.ValidationAcceptor) {
+	for _, field := range iface.Fields() {
+		fieldType := field.Type()
+		if isNestedArrayType(fieldType) {
+			accept(core.NewDiagnostic(
+				core.SeverityError,
+				"Nested array types are not supported.",
+				fieldType,
+				core.WithCode(ValidateNestedArrayType),
+			))
+		}
+	}
+}
+
+func isNestedArrayType(fieldType FieldType) bool {
+	arrayType, ok := fieldType.(ArrayType)
+	if !ok {
+		return false
+	}
+	_, ok = arrayType.InternalType().(ArrayType)
+	return ok
+}
+
+func checkReservedFieldName(field Field, iface Interface, allFields map[string]Interface, accept core.ValidationAcceptor) {
+	name := field.Name()
+	if name == "" {
+		return
+	}
+
+	if strings.HasPrefix(name, "Set") {
+		accept(core.NewDiagnostic(
+			core.SeverityError,
+			"Field names must not start with 'Set' because the framework generates Set{Name}() setter methods.",
+			field,
+			core.WithToken(field.NameToken()),
+			core.WithCode(ValidateReservedFieldName),
+		))
+		return
+	}
+	if strings.HasPrefix(name, "Is") {
+		accept(core.NewDiagnostic(
+			core.SeverityError,
+			"Field names must not start with 'Is' because the framework generates Is{Name}() methods for boolean fields.",
+			field,
+			core.WithToken(field.NameToken()),
+			core.WithCode(ValidateReservedFieldName),
+		))
+		return
+	}
+	if name == iface.Name() {
+		accept(core.NewDiagnostic(
+			core.SeverityError,
+			"A field's name cannot be the same as the interface name due to potential conflicts with generated methods.",
+			field,
+			core.WithToken(field.NameToken()),
+			core.WithCode(ValidateReservedFieldName),
+		))
+		return
+	}
+	if reserved, ok := reservedFieldNames[name]; ok {
+		accept(core.NewDiagnostic(
+			core.SeverityError,
+			fmt.Sprintf("The field name '%s' is reserved by the framework and cannot be used because it would conflict with %s.", name, reserved),
+			field,
+			core.WithToken(field.NameToken()),
+			core.WithCode(ValidateReservedFieldName),
+		))
+		return
+	}
+	if base, _, ok := tokenOrNodeSuffixBase(name); ok {
+		lower := strings.ToLower(base)
+		if _, exists := allFields[lower]; exists && !strings.EqualFold(base, name) {
+			accept(core.NewDiagnostic(
+				core.SeverityError,
+				fmt.Sprintf("The field name '%s' conflicts with '%s' due to potential conflicts with generated methods.", name, base),
+				field,
+				core.WithToken(field.NameToken()),
+				core.WithCode(ValidateReservedFieldName),
+			))
+		}
+	}
+}
+
+func tokenOrNodeSuffixBase(name string) (base, suffix string, ok bool) {
+	for _, suffix := range []string{"Token", "Node"} {
+		if strings.HasSuffix(name, suffix) && len(name) > len(suffix) {
+			return name[:len(name)-len(suffix)], suffix, true
+		}
+	}
+	return "", "", false
 }
 
 func checkInterfaceExtends(iface Interface, ctx context.Context, accept core.ValidationAcceptor) {
@@ -584,6 +709,24 @@ func isAssignableTo(ctx context.Context, source Assignable, fieldType FieldType,
 					core.WithCode(ValidateAssignmentType),
 				))
 			}
+		case CompositeRule:
+			if primitiveType, ok := fieldType.(PrimitiveType); !ok || primitiveType.Type() != "composite" {
+				if primitiveType, ok := fieldType.(PrimitiveType); ok && primitiveType.Type() == "string" {
+					accept(core.NewDiagnostic(
+						core.SeverityError,
+						"Cannot assign a composite rule to a string field. Use 'composite' as the field type instead.",
+						v,
+						core.WithCode(ValidateAssignmentType),
+					))
+				} else {
+					accept(core.NewDiagnostic(
+						core.SeverityError,
+						"Cannot assign a composite rule to a non-composite field.",
+						v,
+						core.WithCode(ValidateAssignmentType),
+					))
+				}
+			}
 		}
 	case Keyword:
 		if primitiveType, ok := fieldType.(PrimitiveType); !ok || primitiveType.Type() != "string" {
@@ -660,6 +803,17 @@ func appearsInTokenGroup(target TokenGroup, current TokenGroup, ctx context.Cont
 	return false
 }
 
+func hiddenOrCommentTokenDescription(token Token) (description string, ok bool) {
+	switch token.Type() {
+	case "hidden":
+		return "hidden", true
+	case "comment":
+		return "a comment", true
+	default:
+		return "", false
+	}
+}
+
 func checkInvalidTokensInGroup(tg TokenGroup, accept core.ValidationAcceptor) {
 	for _, ext := range tg.TokenRefs() {
 		abstractToken := ext.Ref(context.Background())
@@ -667,23 +821,66 @@ func checkInvalidTokensInGroup(tg TokenGroup, accept core.ValidationAcceptor) {
 			continue
 		}
 		if token, ok := abstractToken.(Token); ok {
-			tokenType := token.Type()
-			// Hidden/comment tokens are not allowed in token groups
+			// Hidden/comment tokens are not allowed in token groups.
 			// They are not meant to be consumed in parser rules,
-			// and do not appear in the token slice
-			special := tokenType == "hidden" || tokenType == "comment"
-			if special {
-				if tokenType == "comment" {
-					tokenType = "a comment"
-				}
+			// and do not appear in the token slice.
+			if description, special := hiddenOrCommentTokenDescription(token); special {
 				accept(core.NewDiagnostic(
 					core.SeverityError,
-					fmt.Sprintf("The token '%s' cannot be used in a token group, because it is %s.", token.Name(), tokenType),
+					fmt.Sprintf("The token '%s' cannot be used in a token group because it is %s.", token.Name(), description),
 					tg,
 					core.WithReference(ext),
 					core.WithCode(ValidateInvalidTokenInGroup),
 				))
 			}
 		}
+	}
+}
+
+func (cr *CrossRefImpl) Validate(ctx context.Context, _ string, accept core.ValidationAcceptor) {
+	checkCrossRefHasTerminal(cr, ctx, accept)
+	checkCrossRefToken(cr, ctx, accept)
+}
+
+func checkCrossRefHasTerminal(cr CrossRef, ctx context.Context, accept core.ValidationAcceptor) {
+	if cr.Rule() != nil {
+		return
+	}
+	resolvedType := cr.Type().Ref(ctx)
+	if resolvedType == nil {
+		return
+	}
+	accept(core.NewDiagnostic(
+		core.SeverityError,
+		fmt.Sprintf("A cross-reference must specify a token or composite rule after ':' (e.g. [%s:ID]).", resolvedType.Name()),
+		cr,
+		core.WithReference(cr.Type()),
+		core.WithCode(ValidateMissingCrossRefTerminal),
+	))
+}
+
+func checkCrossRefToken(cr CrossRef, ctx context.Context, accept core.ValidationAcceptor) {
+	ruleCall := cr.Rule()
+	if ruleCall == nil {
+		return
+	}
+	resolved := ruleCall.Rule().Ref(ctx)
+	if resolved == nil {
+		return
+	}
+	token, ok := resolved.(Token)
+	if !ok {
+		return
+	}
+	// Hidden/comment tokens are not allowed in cross-references because they
+	// are not stored in the token slice and cannot identify named elements.
+	if description, special := hiddenOrCommentTokenDescription(token); special {
+		accept(core.NewDiagnostic(
+			core.SeverityError,
+			fmt.Sprintf("The token '%s' cannot be used in a cross-reference because it is %s.", token.Name(), description),
+			cr,
+			core.WithReference(ruleCall.Rule()),
+			core.WithCode(ValidateInvalidTokenInCrossRef),
+		))
 	}
 }

--- a/internal/grammar/validator_test.go
+++ b/internal/grammar/validator_test.go
@@ -144,6 +144,177 @@ func TestDuplicateFieldNamesCaseInsensitiveAndCapitalLetter(t *testing.T) {
 	diag.WithSeverity(core.SeverityError)
 }
 
+func TestReservedFieldNameDocument(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+		interface Foo {
+			<|1:Document|> string
+		}
+	` + commonTokens)
+	diag := doc.ExpectDiagnostic("1")
+	diag.WithSeverity(core.SeverityError)
+	diag.WithCode(ValidateReservedFieldName)
+}
+
+func TestReservedFieldNameTokens(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+		interface Foo {
+			<|1:Tokens|> string
+		}
+	` + commonTokens)
+	diag := doc.ExpectDiagnostic("1")
+	diag.WithSeverity(core.SeverityError)
+	diag.WithCode(ValidateReservedFieldName)
+}
+
+func TestReservedFieldNameSetPrefix(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+		interface Foo {
+			<|1:SetName|> string
+		}
+	` + commonTokens)
+	diag := doc.ExpectDiagnostic("1")
+	diag.WithSeverity(core.SeverityError)
+	diag.WithCode(ValidateReservedFieldName)
+}
+
+func TestReservedFieldNameIsPrefix(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+		interface Foo {
+			<|1:IsActive|> bool
+		}
+	` + commonTokens)
+	diag := doc.ExpectDiagnostic("1")
+	diag.WithSeverity(core.SeverityError)
+	diag.WithCode(ValidateReservedFieldName)
+}
+
+func TestReservedFieldNameTokenArrayAllowed(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+		interface Foo {
+			Token []string
+		}
+	` + commonTokens)
+	doc.AssertNoErrors()
+}
+
+func TestReservedFieldNameText(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+		interface Foo {
+			<|1:Text|> string
+		}
+	` + commonTokens)
+	diag := doc.ExpectDiagnostic("1")
+	diag.WithSeverity(core.SeverityError)
+	diag.WithCode(ValidateReservedFieldName)
+}
+
+func TestReservedFieldNameForEachNode(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+		interface Foo {
+			<|1:ForEachNode|> string
+		}
+	` + commonTokens)
+	diag := doc.ExpectDiagnostic("1")
+	diag.WithSeverity(core.SeverityError)
+	diag.WithCode(ValidateReservedFieldName)
+}
+
+func TestReservedFieldNameSameAsInterface(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+		interface Foo {
+			<|1:Foo|> string
+		}
+	` + commonTokens)
+	diag := doc.ExpectDiagnostic("1")
+	diag.WithSeverity(core.SeverityError)
+	diag.WithCode(ValidateReservedFieldName)
+}
+
+func TestReservedFieldNameSuffixTokenConflict(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+		interface Foo {
+			Name string
+			<|1:NameToken|> string
+		}
+	` + commonTokens)
+	diag := doc.ExpectDiagnostic("1")
+	diag.WithSeverity(core.SeverityError)
+	diag.WithCode(ValidateReservedFieldName)
+}
+
+func TestReservedFieldNameSuffixNodeConflictInherited(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+		interface Base {
+			Target composite
+		}
+		interface Derived extends Base {
+			<|1:TargetNode|> string
+		}
+	` + commonTokens)
+	diag := doc.ExpectDiagnostic("1")
+	diag.WithSeverity(core.SeverityError)
+	diag.WithCode(ValidateReservedFieldName)
+}
+
+func TestNestedArrayType(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+		interface Foo {
+			Items <|1:[][]string|>
+		}
+	` + commonTokens)
+	diag := doc.ExpectDiagnostic("1")
+	diag.WithSeverity(core.SeverityError)
+	diag.WithCode(ValidateNestedArrayType)
+}
+
+func TestNestedArrayTypeWithInterface(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+		interface Bar { Name string }
+		interface Foo {
+			Items <|1:[][]Bar|>
+		}
+	` + commonTokens)
+	diag := doc.ExpectDiagnostic("1")
+	diag.WithSeverity(core.SeverityError)
+	diag.WithCode(ValidateNestedArrayType)
+}
+
+func TestSingleArrayTypeAllowed(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+		interface Foo {
+			Items []string
+			Refs []*Foo
+		}
+	` + commonTokens)
+	doc.AssertNoErrors()
+}
+
 func TestInheritedFieldNameValid(t *testing.T) {
 	f := test.New(t, CreateServices())
 	doc := f.Parse(`
@@ -474,6 +645,43 @@ func TestKeywordAssignedToNonStringField(t *testing.T) {
 	diag.WithCode(ValidateAssignmentType)
 }
 
+func TestCompositeRuleAssignedToStringField(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+		interface Foo { Name string }
+		composite QualifiedName: ID ("." ID)*;
+		Foo: Name=<|QualifiedName|>;
+	` + commonTokens)
+	diag := doc.ExpectDiagnostic("QualifiedName")
+	diag.WithSeverity(core.SeverityError)
+	diag.WithCode(ValidateAssignmentType)
+}
+
+func TestCompositeRuleAssignedToCompositeField(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+		interface Foo { Name composite }
+		composite QualifiedName: ID ("." ID)*;
+		Foo: Name=QualifiedName;
+	` + commonTokens)
+	doc.AssertNoErrors()
+}
+
+func TestCompositeRuleAssignedToNonCompositeField(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+		interface Foo { Flag bool }
+		composite QualifiedName: ID ("." ID)*;
+		Foo: Flag=<|QualifiedName|>;
+	` + commonTokens)
+	diag := doc.ExpectDiagnostic("QualifiedName")
+	diag.WithSeverity(core.SeverityError)
+	diag.WithCode(ValidateAssignmentType)
+}
+
 // --- Token groups ---
 
 func TestTokenGroupRecursiveDirect(t *testing.T) {
@@ -520,4 +728,57 @@ func TestTokenGroupWithInvalidToken(t *testing.T) {
 	diag := doc.ExpectDiagnostic("WS")
 	diag.WithSeverity(core.SeverityError)
 	diag.WithCode(ValidateInvalidTokenInGroup)
+}
+
+// --- Cross-references ---
+
+func TestCrossRefWithHiddenToken(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+		interface Target { Name string }
+		interface Foo { Ref *Target }
+		Foo: Ref=[Target:<|WS|>];
+	` + commonTokens)
+	diag := doc.ExpectDiagnostic("WS")
+	diag.WithSeverity(core.SeverityError)
+	diag.WithCode(ValidateInvalidTokenInCrossRef)
+}
+
+func TestCrossRefWithCommentToken(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+		interface Target { Name string }
+		interface Foo { Ref *Target }
+		comment token SL_COMMENT: /\/\/[^\r\n]*/;
+		Foo: Ref=[Target:<|SL_COMMENT|>];
+	` + commonTokens)
+	diag := doc.ExpectDiagnostic("SL_COMMENT")
+	diag.WithSeverity(core.SeverityError)
+	diag.WithCode(ValidateInvalidTokenInCrossRef)
+}
+
+func TestCrossRefWithValidToken(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+		interface Target { Name string }
+		interface Foo { Ref *Target }
+		Foo: Ref=[Target:ID];
+	` + commonTokens)
+	doc.AssertNoErrors()
+}
+
+func TestCrossRefMissingTerminal(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+		interface Target { Name string }
+		interface Foo { Ref *Target }
+		Foo: Ref=[<|Target|>];
+	` + commonTokens)
+	diag := doc.ExpectDiagnostic("Target")
+	diag.WithSeverity(core.SeverityError)
+	diag.WithCode(ValidateMissingCrossRefTerminal)
 }

--- a/internal/languages/completion/completion.fb
+++ b/internal/languages/completion/completion.fb
@@ -7,7 +7,7 @@ interface Root {
     Objects []Obj
 }
 
-Root: Objects+=(Declare | A | B | C | D | E | F | G | H | I | J | K | L | M | N | O)*;
+entry Root: Objects+=(Declare | A | B | C | D | E | F | G | H | I | J | K | L | M | N | O)*;
 
 interface Declare extends Obj {
     Name composite

--- a/internal/languages/lookahead/lookahead.fb
+++ b/internal/languages/lookahead/lookahead.fb
@@ -9,7 +9,7 @@ interface Root {
     Item Obj
 }
 
-Root: Item=Obj;
+entry Root: Item=Obj;
 
 Obj: A | B | C | D | E | F | G | H | I;
 

--- a/internal/languages/token_groups/token_groups.fb
+++ b/internal/languages/token_groups/token_groups.fb
@@ -4,7 +4,7 @@ interface Model {
     Item Item
 }
 
-Model: Item=(A | B | C | D | E | F | G | H);
+entry Model: Item=(A | B | C | D | E | F | G | H);
 
 interface Item {
     Value string

--- a/internal/scaffold/templates/grammar.fb.tmpl
+++ b/internal/scaffold/templates/grammar.fb.tmpl
@@ -6,7 +6,7 @@ interface Document {
 }
 
 entry Document returns Document:
-	"hello" Message=ID;
+	"hello" Message=ID
 
-token ID: /[_a-zA-Z][\w_]*/;
-hidden token WS: /\s+/;
+token ID: /[_a-zA-Z][\w_]*/
+hidden token WS: /\s+/

--- a/internal/scaffold/templates/grammar.fb.tmpl
+++ b/internal/scaffold/templates/grammar.fb.tmpl
@@ -5,7 +5,7 @@ interface Document {
 	Message string
 }
 
-Document returns Document:
+entry Document returns Document:
 	"hello" Message=ID;
 
 token ID: /[_a-zA-Z][\w_]*/;

--- a/internal/vscode-extensions/fastbelt/data/fastbelt.tmLanguage.json
+++ b/internal/vscode-extensions/fastbelt/data/fastbelt.tmLanguage.json
@@ -13,7 +13,7 @@
         },
         {
             "name": "keyword.control.fastbelt",
-            "match": "\\b(string|bool|composite|current|extends|fragment|grammar|hidden|import|interface|returns|token|group|keywords|comment|type)\\b"
+            "match": "\\b(bool|comment|composite|current|entry|extends|fragment|grammar|group|hidden|import|interface|keywords|returns|string|token|type)\\b"
         },
         {
             "name": "constant.language.fastbelt",

--- a/workspace/document_validator.go
+++ b/workspace/document_validator.go
@@ -56,5 +56,26 @@ func (s *DefaultDocumentValidator) Validate(ctx context.Context, doc *core.Docum
 			validator.Validate(ctx, level, accept)
 		}
 	}
+	setDiagnosticSource(s.sc, doc, diagnostics)
 	return diagnostics
+}
+
+func setDiagnosticSource(sc *service.Container, doc *core.Document, diagnostics []*core.Diagnostic) {
+	source := ""
+	if doc.TextDoc != nil {
+		source = doc.TextDoc.LanguageID()
+	}
+	if source == "" {
+		if languageID, err := service.Get[LanguageID](sc); err == nil {
+			source = string(languageID)
+		}
+	}
+	if source == "" {
+		return
+	}
+	for _, d := range diagnostics {
+		if d.Source == "" {
+			d.Source = source
+		}
+	}
 }

--- a/workspace/document_validator.go
+++ b/workspace/document_validator.go
@@ -35,9 +35,11 @@ func (s *DefaultDocumentValidator) Validate(ctx context.Context, doc *core.Docum
 		return nil
 	}
 
-	lexerErrors := CreateLexerDiagnostics(doc)
-	parserErrors := CreateParserDiagnostics(doc)
-	linkerErrors := CreateLinkerDiagnostics(doc)
+	source := diagnosticSource(s.sc, doc)
+
+	lexerErrors := CreateLexerDiagnostics(doc, source)
+	parserErrors := CreateParserDiagnostics(doc, source)
+	linkerErrors := CreateLinkerDiagnostics(doc, source)
 
 	capacity := len(lexerErrors) + len(parserErrors) + len(linkerErrors) + 8
 	diagnostics := make([]*core.Diagnostic, 0, capacity)
@@ -46,6 +48,9 @@ func (s *DefaultDocumentValidator) Validate(ctx context.Context, doc *core.Docum
 	diagnostics = append(diagnostics, linkerErrors...)
 
 	accept := func(d *core.Diagnostic) {
+		if d.Source == "" {
+			d.Source = source
+		}
 		diagnostics = append(diagnostics, d)
 	}
 	for node := range core.AllNodes(doc.Root) {
@@ -56,26 +61,17 @@ func (s *DefaultDocumentValidator) Validate(ctx context.Context, doc *core.Docum
 			validator.Validate(ctx, level, accept)
 		}
 	}
-	setDiagnosticSource(s.sc, doc, diagnostics)
 	return diagnostics
 }
 
-func setDiagnosticSource(sc *service.Container, doc *core.Document, diagnostics []*core.Diagnostic) {
-	source := ""
+func diagnosticSource(sc *service.Container, doc *core.Document) string {
 	if doc.TextDoc != nil {
-		source = doc.TextDoc.LanguageID()
-	}
-	if source == "" {
-		if languageID, err := service.Get[LanguageID](sc); err == nil {
-			source = string(languageID)
+		if source := doc.TextDoc.LanguageID(); source != "" {
+			return source
 		}
 	}
-	if source == "" {
-		return
+	if languageID, err := service.Get[LanguageID](sc); err == nil {
+		return string(languageID)
 	}
-	for _, d := range diagnostics {
-		if d.Source == "" {
-			d.Source = source
-		}
-	}
+	return ""
 }

--- a/workspace/validation.go
+++ b/workspace/validation.go
@@ -11,7 +11,7 @@ import (
 // CreateLexerDiagnostics converts [core.Document.LexerErrors] into
 // [core.Diagnostic] values with error severity. It returns a non-nil empty
 // slice when there are no lexer errors.
-func CreateLexerDiagnostics(doc *core.Document) []*core.Diagnostic {
+func CreateLexerDiagnostics(doc *core.Document, source string) []*core.Diagnostic {
 	if len(doc.LexerErrors) == 0 {
 		return []*core.Diagnostic{}
 	}
@@ -31,6 +31,7 @@ func CreateLexerDiagnostics(doc *core.Document) []*core.Diagnostic {
 			},
 			Severity: core.SeverityError,
 			Message:  lexErr.Msg,
+			Source:   source,
 		})
 	}
 	return diagnostics
@@ -39,7 +40,7 @@ func CreateLexerDiagnostics(doc *core.Document) []*core.Diagnostic {
 // CreateParserDiagnostics converts [core.Document.ParserErrors] into
 // [core.Diagnostic] values with error severity. When a parser error has no
 // associated token, its range is the end of the document text.
-func CreateParserDiagnostics(doc *core.Document) []*core.Diagnostic {
+func CreateParserDiagnostics(doc *core.Document, source string) []*core.Diagnostic {
 	if len(doc.ParserErrors) == 0 {
 		return []*core.Diagnostic{}
 	}
@@ -56,12 +57,14 @@ func CreateParserDiagnostics(doc *core.Document) []*core.Diagnostic {
 				Range:    core.TextRange{Start: end, End: end},
 				Severity: core.SeverityError,
 				Message:  err.Msg,
+				Source:   source,
 			})
 		} else {
 			diagnostics = append(diagnostics, &core.Diagnostic{
 				Range:    token.TextSegment.Range,
 				Severity: core.SeverityError,
 				Message:  err.Msg,
+				Source:   source,
 			})
 		}
 	}
@@ -72,7 +75,7 @@ func CreateParserDiagnostics(doc *core.Document) []*core.Diagnostic {
 // [core.Diagnostic] values. A reference contributes a diagnostic only when
 // [core.UntypedReference.Error] and [core.UntypedReference.Segment] are both
 // non-nil; severity comes from the reference error.
-func CreateLinkerDiagnostics(doc *core.Document) []*core.Diagnostic {
+func CreateLinkerDiagnostics(doc *core.Document, source string) []*core.Diagnostic {
 	diagnostics := []*core.Diagnostic{}
 	for _, ref := range doc.References {
 		err := ref.Error()
@@ -82,6 +85,7 @@ func CreateLinkerDiagnostics(doc *core.Document) []*core.Diagnostic {
 				Range:    segment.Range,
 				Severity: core.DiagnosticSeverity(err.Severity),
 				Message:  err.Msg,
+				Source:   source,
 			})
 		}
 	}


### PR DESCRIPTION
- Adds missing validations and fixes #119.
- Makes semicolons optional. ~_Note:_ for parser rules and composite rules, a semicolon is still needed if another parser rule follows after that because it starts with an ID. Maybe we can improve the lookahead for this specific case later.~
- Consistently call grammar interface fields "fields" instead of "properties" in error messages.
- _Added:_ New `entry` keyword to explicitly mark the grammar's entry rule