### PR TITLE
Add TextMate configuration generator

### DIFF
--- a/cmd/fastbelt/generate.go
+++ b/cmd/fastbelt/generate.go
@@ -162,13 +162,13 @@ func runGenerateCLI(opts generateOptions) error {
 		}
 	}
 	if opts.textMateOut != "" {
-		if err := os.MkdirAll(opts.textMateOut, 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(opts.textMateOut), 0755); err != nil {
 			return err
 		}
 		textMateGrammar := generator.GenerateTextMate(grammar, generator.TextMateGeneratorConfig{
-			Id:              service.MustGet[workspace.LanguageID](sc),
-			FileExtensions:  service.MustGet[workspace.FileExtensions](sc),
-			CaseInsensitive: false, //TODO ftm!
+			Id:              service.MustGet[workspace.LanguageID](sc),     //TODO wrong ID, should be configurable
+			FileExtensions:  service.MustGet[workspace.FileExtensions](sc), //TODO wrong extensions, should be configurable
+			CaseInsensitive: false,                                         //TODO ftm!
 		})
 		if err := writeFile("textmate", opts.textMateOut, textMateGrammar); err != nil {
 			return err

--- a/cmd/fastbelt/generate.go
+++ b/cmd/fastbelt/generate.go
@@ -26,6 +26,7 @@ type generateOptions struct {
 	packageName string
 	atn         bool
 	verbose     bool
+	textMateOut string
 }
 
 func runGenerateCLI(opts generateOptions) error {
@@ -157,6 +158,19 @@ func runGenerateCLI(opts generateOptions) error {
 	if opts.atn {
 		if err := writeFile("atn-md", filepath.Join(outputPath, "atn.md"),
 			generator.GenerateATNMarkdown(grammar, packageName, tokenTypes)); err != nil {
+			return err
+		}
+	}
+	if opts.textMateOut != "" {
+		if err := os.MkdirAll(opts.textMateOut, 0755); err != nil {
+			return err
+		}
+		textMateGrammar := generator.GenerateTextMate(grammar, generator.TextMateGeneratorConfig{
+			Id:              service.MustGet[workspace.LanguageID](sc),
+			FileExtensions:  service.MustGet[workspace.FileExtensions](sc),
+			CaseInsensitive: false, //TODO ftm!
+		})
+		if err := writeFile("textmate", opts.textMateOut, textMateGrammar); err != nil {
 			return err
 		}
 	}

--- a/cmd/fastbelt/main.go
+++ b/cmd/fastbelt/main.go
@@ -83,6 +83,7 @@ func newGenerateCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&opts.outputPath, "output", "o", "./", "Path to the output directory")
 	cmd.Flags().StringVarP(&opts.packageName, "package", "p", "", "Package name for generated code (defaults to the last segment of the output path)")
 	cmd.Flags().BoolVar(&opts.atn, "atn", false, "Enable markdown output about ATN construction")
+	cmd.Flags().StringVar(&opts.textMateOut, "textMateOut", "", "Path to output TextMate grammar JSON file (optional; omit to skip TextMate generation)")
 	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", false, "Enable verbose output about written files")
 	return cmd
 }

--- a/internal/generator/regexp_utils.go
+++ b/internal/generator/regexp_utils.go
@@ -1,0 +1,180 @@
+// Copyright 2025 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+package generator
+
+import (
+	"regexp"
+	"regexp/syntax"
+)
+
+const MaxRune = 0x10FFFF
+
+type RegexpProgram struct {
+	Instructions []VmInst
+}
+
+type VmOp int
+
+const (
+	VmOpChar VmOp = iota
+	VmOpJump
+	VmOpSplit
+	VmOpMatch
+	VmOpReset
+)
+
+type VmInst struct {
+	Op      VmOp
+	Rune    rune
+	Targets []int
+}
+
+const NL = '\n'
+
+func escapeRegExp(value string) string {
+	var re = regexp.MustCompile(`[.*+?^${}()|[\]\\]`)
+	return re.ReplaceAllStringFunc(value, func(match string) string {
+		return `\` + match
+	})
+}
+
+func visitRegexp(program *RegexpProgram, node *syntax.Regexp) {
+	switch node.Op {
+	case syntax.OpAlternate:
+		ends := []int{}
+		program.Instructions = append(program.Instructions, VmInst{
+			Op:      VmOpSplit,
+			Targets: []int{},
+		})
+		splitIndex := len(program.Instructions) - 1
+		for _, sub := range node.Sub {
+			program.Instructions[splitIndex].Targets = append(program.Instructions[splitIndex].Targets, len(program.Instructions))
+			visitRegexp(program, sub)
+			program.Instructions = append(program.Instructions, VmInst{
+				Op:      VmOpJump,
+				Targets: []int{},
+			})
+			jumpToEndIndex := len(program.Instructions) - 1
+			ends = append(ends, jumpToEndIndex)
+		}
+		for _, end := range ends {
+			program.Instructions[end].Targets = append(program.Instructions[end].Targets, len(program.Instructions))
+		}
+	case syntax.OpConcat:
+		for _, sub := range node.Sub {
+			visitRegexp(program, sub)
+		}
+	case syntax.OpLiteral:
+		for _, r := range node.Rune {
+			program.Instructions = append(program.Instructions, VmInst{
+				Op:   VmOpChar,
+				Rune: r,
+			})
+		}
+	case syntax.OpQuest:
+		splitInst := VmInst{
+			Op:      VmOpSplit,
+			Targets: []int{len(program.Instructions) + 1},
+		}
+		program.Instructions = append(program.Instructions, splitInst)
+		visitRegexp(program, node.Sub[0])
+		splitInst.Targets = append(splitInst.Targets, len(program.Instructions))
+	case syntax.OpPlus, syntax.OpStar, syntax.OpRepeat, syntax.OpAnyChar, syntax.OpAnyCharNotNL, syntax.OpCharClass:
+		program.Instructions = append(program.Instructions, VmInst{
+			Op: VmOpReset,
+		})
+	case syntax.OpCapture, syntax.OpBeginLine, syntax.OpEndLine, syntax.OpBeginText, syntax.OpEndText, syntax.OpWordBoundary, syntax.OpNoWordBoundary:
+		visitRegexp(program, node.Sub[0])
+	case syntax.OpEmptyMatch, syntax.OpNoMatch:
+	}
+}
+
+type Part struct{ start, end string }
+
+func GetTerminalParts(regexp string) []Part {
+	pattern, err := syntax.Parse(regexp, syntax.Perl)
+	if err != nil {
+		return nil
+	}
+	program := &RegexpProgram{}
+	visitRegexp(program, pattern)
+	program.Instructions = append(program.Instructions, VmInst{
+		Op: VmOpMatch,
+	})
+	return execute(program)
+}
+
+type thread struct {
+	pc          int
+	isHalted    bool
+	isStarting  bool
+	isMultiline bool
+	startRegexp string
+	endRegexp   string
+}
+
+func execute(program *RegexpProgram) []Part {
+	result := []Part{}
+	threads := []thread{{
+		pc:          0,
+		isHalted:    false,
+		isStarting:  true,
+		isMultiline: false,
+		startRegexp: "",
+		endRegexp:   "",
+	}}
+	for len(threads) > 0 {
+		th := threads[len(threads)-1]
+		threads = threads[:len(threads)-1]
+		if th.isHalted {
+			result = append(result, Part{
+				start: th.startRegexp,
+				end:   th.endRegexp,
+			})
+			continue
+		}
+		if th.pc >= len(program.Instructions) {
+			continue
+		}
+		inst := program.Instructions[th.pc]
+		switch inst.Op {
+		case VmOpChar:
+			if inst.Rune == NL {
+				th.isMultiline = true
+			}
+			char := escapeRegExp(string(inst.Rune))
+			if th.isStarting {
+				th.startRegexp += char
+			} else {
+				th.endRegexp += char
+			}
+			th.pc++
+			threads = append(threads, th)
+		case VmOpJump:
+			th.pc = inst.Targets[0]
+			threads = append(threads, th)
+		case VmOpSplit:
+			for _, target := range inst.Targets {
+				newThread := thread{
+					pc:          target,
+					isStarting:  th.isStarting,
+					isMultiline: th.isMultiline,
+					startRegexp: th.startRegexp,
+					endRegexp:   th.endRegexp,
+				}
+				threads = append(threads, newThread)
+			}
+		case VmOpMatch:
+			th.isHalted = true
+			threads = append(threads, th)
+		case VmOpReset:
+			th.isStarting = false
+			th.endRegexp = ""
+			th.pc++
+			threads = append(threads, th)
+		}
+	}
+	return result
+}

--- a/internal/generator/regexp_utils_test.go
+++ b/internal/generator/regexp_utils_test.go
@@ -1,0 +1,36 @@
+// Copyright 2025 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+package generator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommentStartEndParts(t *testing.T) {
+	require.Equal(t, GetTerminalParts(`//[^\n\r]*`), []Part{
+		{start: "//", end: ""},
+	})
+}
+
+func TestJSStyleMultilineComment(t *testing.T) {
+	require.Equal(t, GetTerminalParts(`/\*[\s\S]*?\*/`), []Part{
+		{start: "/\\*", end: "\\*/"},
+	})
+}
+
+func TestJSStyleCombinedComment(t *testing.T) {
+	require.Equal(t, GetTerminalParts(`/\*[\s\S]*?\*/|//[^\n\r]*`), []Part{
+		{start: "//", end: ""},
+		{start: "/\\*", end: "\\*/"},
+	})
+}
+
+func TestShellStyleSingleLineComment(t *testing.T) {
+	require.Equal(t, GetTerminalParts(`#[^\n\r]*`), []Part{
+		{start: "#", end: ""},
+	})
+}

--- a/internal/generator/textmate_generator.go
+++ b/internal/generator/textmate_generator.go
@@ -14,38 +14,38 @@ import (
 	"typefox.dev/fastbelt/workspace"
 )
 
-type textMateGrammar struct {
-	repository        repository
-	scopeName         string
-	patterns          []pattern
-	injections        map[string]pattern //optional
-	injectionSelector string             //optional
-	fileTypes         []string           //optional
-	name              string             //optional
-	firstLineMatch    string             //optional
+type TextMateGrammar struct {
+	Repository        Repository         "json:\"repository\""
+	ScopeName         string             "json:\"scopeName\""
+	Patterns          []Pattern          "json:\"patterns\""
+	Injections        map[string]Pattern "json:\"injections,omitempty\""
+	InjectionSelector string             "json:\"injectionSelector,omitempty\""
+	FileTypes         []string           "json:\"fileTypes,omitempty\""
+	Name              string             "json:\"name,omitempty\""
+	FirstLineMatch    string             "json:\"firstLineMatch,omitempty\""
 }
 
-type repository = map[string]pattern
+type Repository = map[string]Pattern
 
-type pattern struct {
-	id                  int        //optional
-	include             string     //optional
-	name                string     //optional
-	contentName         string     //optional
-	match               string     //optional
-	captures            captures   //optional
-	begin               string     //optional
-	beginCaptures       captures   //optional
-	end                 string     //optional
-	endCaptures         captures   //optional
-	while               string     //optional
-	whileCaptures       captures   //optional
-	patterns            []pattern  //optional
-	repository          repository //optional
-	applyEndPatternLast bool       //optional
+type Pattern struct {
+	Id                  int        "json:\"id,omitempty\""
+	Include             string     "json:\"include,omitempty\""
+	Name                string     "json:\"name,omitempty\""
+	ContentName         string     "json:\"contentName,omitempty\""
+	Match               string     "json:\"match,omitempty\""
+	Captures            Captures   "json:\"captures,omitempty\""
+	Begin               string     "json:\"begin,omitempty\""
+	BeginCaptures       Captures   "json:\"beginCaptures,omitempty\""
+	End                 string     "json:\"end,omitempty\""
+	EndCaptures         Captures   "json:\"endCaptures,omitempty\""
+	While               string     "json:\"while,omitempty\""
+	WhileCaptures       Captures   "json:\"whileCaptures,omitempty\""
+	Patterns            []Pattern  "json:\"patterns,omitempty\""
+	Repository          Repository "json:\"repository,omitempty\""
+	ApplyEndPatternLast bool       "json:\"applyEndPatternLast,omitempty\""
 }
 
-type captures = map[string]pattern
+type Captures = map[string]Pattern
 
 type TextMateGeneratorConfig struct {
 	Id              workspace.LanguageID
@@ -54,21 +54,21 @@ type TextMateGeneratorConfig struct {
 }
 
 func GenerateTextMate(grammar grammar.Grammar, config TextMateGeneratorConfig) string {
-	obj := textMateGrammar{
-		name:       string(config.Id),
-		scopeName:  fmt.Sprintf("source.%s", config.Id),
-		fileTypes:  []string(config.FileExtensions),
-		patterns:   GetPatterns(grammar, config),
-		repository: GetRepository(grammar, config),
+	obj := TextMateGrammar{
+		Name:       string(config.Id),
+		ScopeName:  fmt.Sprintf("source.%s", config.Id),
+		FileTypes:  []string(config.FileExtensions),
+		Patterns:   GetPatterns(grammar, config),
+		Repository: GetRepository(grammar, config),
 	}
 	result, _ := json.MarshalIndent(obj, "", "  ")
 	return string(result)
 }
 
-func GetPatterns(grammar grammar.Grammar, config TextMateGeneratorConfig) []pattern {
-	patterns := []pattern{}
-	patterns = append(patterns, pattern{
-		include: "#comments",
+func GetPatterns(grammar grammar.Grammar, config TextMateGeneratorConfig) []Pattern {
+	patterns := []Pattern{}
+	patterns = append(patterns, Pattern{
+		Include: "#comments",
 	})
 	patterns = append(patterns, GetControlKeywords(grammar, config))
 	patterns = append(patterns, GetStringPatterns(grammar, config)...)
@@ -76,53 +76,55 @@ func GetPatterns(grammar grammar.Grammar, config TextMateGeneratorConfig) []patt
 	return patterns
 }
 
-func GetRepository(grammar grammar.Grammar, config TextMateGeneratorConfig) repository {
-	repository := repository{}
-	commentPatterns := []pattern{}
-	var stringEscapePattern *pattern
+func GetRepository(grammar grammar.Grammar, config TextMateGeneratorConfig) Repository {
+	repository := Repository{}
+	commentPatterns := []Pattern{}
+	var stringEscapePattern *Pattern
 	for _, terminal := range grammar.Terminals() {
 		if terminal.Type() == "comment" {
-			parts := GetTerminalParts(terminal.Regexp())
+			regexPattern := terminal.Regexp()
+			regexPattern = regexPattern[1 : len(regexPattern)-1]
+			parts := GetTerminalParts(regexPattern)
 			for _, part := range parts {
 				if part.end != "" {
-					commentPatterns = append(commentPatterns, pattern{
-						name:  fmt.Sprintf(`comment.block.%s`, config.Id),
-						begin: part.start,
-						beginCaptures: captures{
-							"0": pattern{
-								name: fmt.Sprintf(`punctuation.definition.comment.%s`, config.Id),
+					commentPatterns = append(commentPatterns, Pattern{
+						Name:  fmt.Sprintf(`comment.block.%s`, config.Id),
+						Begin: part.start,
+						BeginCaptures: Captures{
+							"0": Pattern{
+								Name: fmt.Sprintf(`punctuation.definition.comment.%s`, config.Id),
 							},
 						},
-						end: part.end,
-						endCaptures: captures{
-							"0": pattern{
-								name: fmt.Sprintf(`punctuation.definition.comment.%s`, config.Id),
+						End: part.end,
+						EndCaptures: Captures{
+							"0": Pattern{
+								Name: fmt.Sprintf(`punctuation.definition.comment.%s`, config.Id),
 							},
 						},
 					})
 				} else {
-					commentPatterns = append(commentPatterns, pattern{
-						begin: part.start,
-						beginCaptures: captures{
-							"1": pattern{
-								name: fmt.Sprintf(`punctuation.whitespace.comment.leading.%s`, config.Id),
+					commentPatterns = append(commentPatterns, Pattern{
+						Begin: part.start,
+						BeginCaptures: Captures{
+							"1": Pattern{
+								Name: fmt.Sprintf(`punctuation.whitespace.comment.leading.%s`, config.Id),
 							},
 						},
-						end:  `(?=$)`,
-						name: fmt.Sprintf(`comment.line.%s`, config.Id),
+						End:  `(?=$)`,
+						Name: fmt.Sprintf(`comment.line.%s`, config.Id),
 					})
 				}
 			}
 		} else if strings.ToLower(terminal.Name()) == "string" {
-			stringEscapePattern = &pattern{
-				name:  fmt.Sprintf(`constant.character.escape.%s`, config.Id),
-				match: `\\(x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4}|u\{[0-9A-Fa-f]+\}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.|$)`,
+			stringEscapePattern = &Pattern{
+				Name:  fmt.Sprintf(`constant.character.escape.%s`, config.Id),
+				Match: `\\(x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4}|u\{[0-9A-Fa-f]+\}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.|$)`,
 			}
 		}
 
 		if len(commentPatterns) > 0 {
-			repository["comments"] = pattern{
-				patterns: commentPatterns,
+			repository["comments"] = Pattern{
+				Patterns: commentPatterns,
 			}
 		}
 		if stringEscapePattern != nil {
@@ -132,7 +134,7 @@ func GetRepository(grammar grammar.Grammar, config TextMateGeneratorConfig) repo
 	return repository
 }
 
-func GetControlKeywords(grammr grammar.Grammar, config TextMateGeneratorConfig) pattern {
+func GetControlKeywords(grammr grammar.Grammar, config TextMateGeneratorConfig) Pattern {
 	regex := regexp.MustCompile(`[A-Za-z]`)
 	controlKeywords := []grammar.Keyword{}
 	for _, keyword := range GetAllKeywords(grammr) {
@@ -141,9 +143,9 @@ func GetControlKeywords(grammr grammar.Grammar, config TextMateGeneratorConfig) 
 		}
 	}
 	groups := GroupKeywords(controlKeywords)
-	return pattern{
-		name:  fmt.Sprintf(`keyword.control.%s`, config.Id),
-		match: fmt.Sprintf(`%s%s`, ifThenElse(config.CaseInsensitive, `(?i)`, ``), strings.Join(groups, "|")),
+	return Pattern{
+		Name:  fmt.Sprintf(`keyword.control.%s`, config.Id),
+		Match: fmt.Sprintf(`%s%s`, ifThenElse(config.CaseInsensitive, `(?i)`, ``), strings.Join(groups, "|")),
 	}
 }
 
@@ -203,7 +205,7 @@ func GroupKeywords(keywords []grammar.Keyword) []string {
 	return res
 }
 
-func GetStringPatterns(grammr grammar.Grammar, config TextMateGeneratorConfig) []pattern {
+func GetStringPatterns(grammr grammar.Grammar, config TextMateGeneratorConfig) []Pattern {
 	terminals := grammr.Terminals()
 	var stringTerminal grammar.Token
 	for _, terminal := range terminals {
@@ -212,18 +214,20 @@ func GetStringPatterns(grammr grammar.Grammar, config TextMateGeneratorConfig) [
 			break
 		}
 	}
-	stringPatterns := []pattern{}
+	stringPatterns := []Pattern{}
 	if stringTerminal != nil {
-		parts := GetTerminalParts(stringTerminal.Regexp())
+		regexPattern := stringTerminal.Regexp()
+		regexPattern = regexPattern[1 : len(regexPattern)-1]
+		parts := GetTerminalParts(regexPattern)
 		for _, part := range parts {
 			if part.end != "" {
-				stringPatterns = append(stringPatterns, pattern{
-					name:  fmt.Sprintf(`string.quoted.%s.%s`, delimiterName(part.start), config.Id),
-					begin: part.start,
-					end:   part.end,
-					patterns: []pattern{
+				stringPatterns = append(stringPatterns, Pattern{
+					Name:  fmt.Sprintf(`string.quoted.%s.%s`, delimiterName(part.start), config.Id),
+					Begin: part.start,
+					End:   part.end,
+					Patterns: []Pattern{
 						{
-							include: "#string-character-escape",
+							Include: "#string-character-escape",
 						},
 					},
 				})

--- a/internal/generator/textmate_generator.go
+++ b/internal/generator/textmate_generator.go
@@ -1,0 +1,245 @@
+// Copyright 2025 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+package generator
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"typefox.dev/fastbelt/internal/grammar"
+)
+
+type textMateGrammar struct {
+	repository        repository
+	scopeName         string
+	patterns          []pattern
+	injections        map[string]pattern //optional
+	injectionSelector string             //optional
+	fileTypes         []string           //optional
+	name              string             //optional
+	firstLineMatch    string             //optional
+}
+
+type repository = map[string]pattern
+
+type pattern struct {
+	id                  int        //optional
+	include             string     //optional
+	name                string     //optional
+	contentName         string     //optional
+	match               string     //optional
+	captures            captures   //optional
+	begin               string     //optional
+	beginCaptures       captures   //optional
+	end                 string     //optional
+	endCaptures         captures   //optional
+	while               string     //optional
+	whileCaptures       captures   //optional
+	patterns            []pattern  //optional
+	repository          repository //optional
+	applyEndPatternLast bool       //optional
+}
+
+type captures = map[string]pattern
+
+type TextMateGeneratorConfig struct {
+	id              string
+	fileExtensions  []string
+	caseInsensitive bool
+}
+
+func GenerateTextMate(grammar grammar.Grammar, config TextMateGeneratorConfig) string {
+	obj := textMateGrammar{
+		name:       config.id,
+		scopeName:  `source.${config.id}`,
+		fileTypes:  config.fileExtensions,
+		patterns:   GetPatterns(grammar, config),
+		repository: GetRepository(grammar, config),
+	}
+	result, _ := json.MarshalIndent(obj, "", "  ")
+	return string(result)
+}
+
+func GetPatterns(grammar grammar.Grammar, config TextMateGeneratorConfig) []pattern {
+	patterns := []pattern{}
+	patterns = append(patterns, pattern{
+		include: "#comments",
+	})
+	patterns = append(patterns, GetControlKeywords(grammar, config))
+	patterns = append(patterns, GetStringPatterns(grammar, config)...)
+
+	return patterns
+}
+
+func GetRepository(grammar grammar.Grammar, config TextMateGeneratorConfig) repository {
+	repository := repository{}
+	commentPatterns := []pattern{}
+	var stringEscapePattern *pattern
+	for _, terminal := range grammar.Terminals() {
+		if terminal.Type() == "comment" {
+			parts := GetTerminalParts(terminal.Regexp())
+			for _, part := range parts {
+				if part.end != "" {
+					commentPatterns = append(commentPatterns, pattern{
+						name:  fmt.Sprintf(`comment.block.%s`, config.id),
+						begin: part.start,
+						beginCaptures: captures{
+							"0": pattern{
+								name: fmt.Sprintf(`punctuation.definition.comment.%s`, config.id),
+							},
+						},
+						end: part.end,
+						endCaptures: captures{
+							"0": pattern{
+								name: fmt.Sprintf(`punctuation.definition.comment.%s`, config.id),
+							},
+						},
+					})
+				} else {
+					commentPatterns = append(commentPatterns, pattern{
+						begin: part.start,
+						beginCaptures: captures{
+							"1": pattern{
+								name: fmt.Sprintf(`punctuation.whitespace.comment.leading.%s`, config.id),
+							},
+						},
+						end:  `(?=$)`,
+						name: fmt.Sprintf(`comment.line.%s`, config.id),
+					})
+				}
+			}
+		} else if strings.ToLower(terminal.Name()) == "string" {
+			stringEscapePattern = &pattern{
+				name:  fmt.Sprintf(`constant.character.escape.%s`, config.id),
+				match: `\\(x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4}|u\{[0-9A-Fa-f]+\}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.|$)`,
+			}
+		}
+
+		if len(commentPatterns) > 0 {
+			repository["comments"] = pattern{
+				patterns: commentPatterns,
+			}
+		}
+		if stringEscapePattern != nil {
+			repository["string-character-escape"] = *stringEscapePattern
+		}
+	}
+	return repository
+}
+
+func GetControlKeywords(grammr grammar.Grammar, config TextMateGeneratorConfig) pattern {
+	regex := regexp.MustCompile(`[A-Za-z]`)
+	controlKeywords := []grammar.Keyword{}
+	for _, keyword := range GetAllKeywords(grammr) {
+		if regex.MatchString(keyword.Text()) {
+			controlKeywords = append(controlKeywords, keyword)
+		}
+	}
+	groups := GroupKeywords(controlKeywords)
+	return pattern{
+		name:  fmt.Sprintf(`keyword.control.%s`, config.id),
+		match: fmt.Sprintf(`%s%s`, ifThenElse(config.caseInsensitive, `(?i)`, ``), strings.Join(groups, "|")),
+	}
+}
+
+func ifThenElse(condition bool, trueValue string, falseValue string) string {
+	if condition {
+		return trueValue
+	} else {
+		return falseValue
+	}
+}
+
+type group struct {
+	letter       []string
+	leftSpecial  []string
+	rightSpecial []string
+	special      []string
+}
+
+func GroupKeywords(keywords []grammar.Keyword) []string {
+	groups := group{
+		letter:       []string{},
+		leftSpecial:  []string{},
+		rightSpecial: []string{},
+		special:      []string{},
+	}
+
+	for _, keyword := range keywords {
+		keywordPattern := regexp.QuoteMeta(keyword.Text())
+		if regexp.MustCompile(`\w`).MatchString(string(keyword.Text()[0])) {
+			if regexp.MustCompile(`\w`).MatchString(string(keyword.Text()[len(keyword.Text())-1])) {
+				groups.letter = append(groups.letter, keywordPattern)
+			} else {
+				groups.rightSpecial = append(groups.rightSpecial, keywordPattern)
+			}
+		} else {
+			if regexp.MustCompile(`\w`).MatchString(string(keyword.Text()[len(keyword.Text())-1])) {
+				groups.leftSpecial = append(groups.leftSpecial, keywordPattern)
+			} else {
+				groups.special = append(groups.special, keywordPattern)
+			}
+		}
+	}
+
+	res := []string{}
+	if len(groups.letter) > 0 {
+		res = append(res, fmt.Sprintf(`\b(%s)\b`, strings.Join(groups.letter, "|")))
+	}
+	if len(groups.leftSpecial) > 0 {
+		res = append(res, fmt.Sprintf(`\B(%s)\b`, strings.Join(groups.leftSpecial, "|")))
+	}
+	if len(groups.rightSpecial) > 0 {
+		res = append(res, fmt.Sprintf(`\b(%s)\B`, strings.Join(groups.rightSpecial, "|")))
+	}
+	if len(groups.special) > 0 {
+		res = append(res, fmt.Sprintf(`\B(%s)\B`, strings.Join(groups.special, "|")))
+	}
+	return res
+}
+
+func GetStringPatterns(grammr grammar.Grammar, config TextMateGeneratorConfig) []pattern {
+	terminals := grammr.Terminals()
+	var stringTerminal grammar.Token
+	for _, terminal := range terminals {
+		if strings.ToLower(terminal.Name()) == "string" {
+			stringTerminal = terminal
+			break
+		}
+	}
+	stringPatterns := []pattern{}
+	if stringTerminal != nil {
+		parts := GetTerminalParts(stringTerminal.Regexp())
+		for _, part := range parts {
+			if part.end != "" {
+				stringPatterns = append(stringPatterns, pattern{
+					name:  fmt.Sprintf(`string.quoted.%s.%s`, delimiterName(part.start), config.id),
+					begin: part.start,
+					end:   part.end,
+					patterns: []pattern{
+						{
+							include: "#string-character-escape",
+						},
+					},
+				})
+			}
+		}
+	}
+	return stringPatterns
+}
+
+func delimiterName(delimiter string) string {
+	if delimiter == "'" {
+		return "single"
+	} else if delimiter == `"` {
+		return "double"
+	} else if delimiter == "`" {
+		return "backtick"
+	} else {
+		return "delimiter"
+	}
+}

--- a/internal/generator/textmate_generator.go
+++ b/internal/generator/textmate_generator.go
@@ -238,13 +238,14 @@ func GetStringPatterns(grammr grammar.Grammar, config TextMateGeneratorConfig) [
 }
 
 func delimiterName(delimiter string) string {
-	if delimiter == "'" {
+	switch delimiter {
+	case "'":
 		return "single"
-	} else if delimiter == `"` {
+	case `"`:
 		return "double"
-	} else if delimiter == "`" {
+	case "`":
 		return "backtick"
-	} else {
+	default:
 		return "delimiter"
 	}
 }

--- a/internal/generator/textmate_generator.go
+++ b/internal/generator/textmate_generator.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"typefox.dev/fastbelt/internal/grammar"
+	"typefox.dev/fastbelt/workspace"
 )
 
 type textMateGrammar struct {
@@ -47,16 +48,16 @@ type pattern struct {
 type captures = map[string]pattern
 
 type TextMateGeneratorConfig struct {
-	id              string
-	fileExtensions  []string
-	caseInsensitive bool
+	Id              workspace.LanguageID
+	FileExtensions  workspace.FileExtensions
+	CaseInsensitive bool
 }
 
 func GenerateTextMate(grammar grammar.Grammar, config TextMateGeneratorConfig) string {
 	obj := textMateGrammar{
-		name:       config.id,
-		scopeName:  `source.${config.id}`,
-		fileTypes:  config.fileExtensions,
+		name:       string(config.Id),
+		scopeName:  fmt.Sprintf("source.%s", config.Id),
+		fileTypes:  []string(config.FileExtensions),
 		patterns:   GetPatterns(grammar, config),
 		repository: GetRepository(grammar, config),
 	}
@@ -85,17 +86,17 @@ func GetRepository(grammar grammar.Grammar, config TextMateGeneratorConfig) repo
 			for _, part := range parts {
 				if part.end != "" {
 					commentPatterns = append(commentPatterns, pattern{
-						name:  fmt.Sprintf(`comment.block.%s`, config.id),
+						name:  fmt.Sprintf(`comment.block.%s`, config.Id),
 						begin: part.start,
 						beginCaptures: captures{
 							"0": pattern{
-								name: fmt.Sprintf(`punctuation.definition.comment.%s`, config.id),
+								name: fmt.Sprintf(`punctuation.definition.comment.%s`, config.Id),
 							},
 						},
 						end: part.end,
 						endCaptures: captures{
 							"0": pattern{
-								name: fmt.Sprintf(`punctuation.definition.comment.%s`, config.id),
+								name: fmt.Sprintf(`punctuation.definition.comment.%s`, config.Id),
 							},
 						},
 					})
@@ -104,17 +105,17 @@ func GetRepository(grammar grammar.Grammar, config TextMateGeneratorConfig) repo
 						begin: part.start,
 						beginCaptures: captures{
 							"1": pattern{
-								name: fmt.Sprintf(`punctuation.whitespace.comment.leading.%s`, config.id),
+								name: fmt.Sprintf(`punctuation.whitespace.comment.leading.%s`, config.Id),
 							},
 						},
 						end:  `(?=$)`,
-						name: fmt.Sprintf(`comment.line.%s`, config.id),
+						name: fmt.Sprintf(`comment.line.%s`, config.Id),
 					})
 				}
 			}
 		} else if strings.ToLower(terminal.Name()) == "string" {
 			stringEscapePattern = &pattern{
-				name:  fmt.Sprintf(`constant.character.escape.%s`, config.id),
+				name:  fmt.Sprintf(`constant.character.escape.%s`, config.Id),
 				match: `\\(x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4}|u\{[0-9A-Fa-f]+\}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.|$)`,
 			}
 		}
@@ -141,8 +142,8 @@ func GetControlKeywords(grammr grammar.Grammar, config TextMateGeneratorConfig) 
 	}
 	groups := GroupKeywords(controlKeywords)
 	return pattern{
-		name:  fmt.Sprintf(`keyword.control.%s`, config.id),
-		match: fmt.Sprintf(`%s%s`, ifThenElse(config.caseInsensitive, `(?i)`, ``), strings.Join(groups, "|")),
+		name:  fmt.Sprintf(`keyword.control.%s`, config.Id),
+		match: fmt.Sprintf(`%s%s`, ifThenElse(config.CaseInsensitive, `(?i)`, ``), strings.Join(groups, "|")),
 	}
 }
 
@@ -217,7 +218,7 @@ func GetStringPatterns(grammr grammar.Grammar, config TextMateGeneratorConfig) [
 		for _, part := range parts {
 			if part.end != "" {
 				stringPatterns = append(stringPatterns, pattern{
-					name:  fmt.Sprintf(`string.quoted.%s.%s`, delimiterName(part.start), config.id),
+					name:  fmt.Sprintf(`string.quoted.%s.%s`, delimiterName(part.start), config.Id),
 					begin: part.start,
 					end:   part.end,
 					patterns: []pattern{

--- a/internal/generator/textmate_generator_test.go
+++ b/internal/generator/textmate_generator_test.go
@@ -1,0 +1,105 @@
+// Copyright 2025 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+package generator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"typefox.dev/fastbelt/internal/grammar"
+	"typefox.dev/fastbelt/linking"
+	"typefox.dev/fastbelt/test"
+	"typefox.dev/fastbelt/textdoc"
+	"typefox.dev/fastbelt/util/service"
+	"typefox.dev/fastbelt/workspace"
+)
+
+const commonTokens = `
+token ID: /[a-zA-Z_][a-zA-Z0-9_]*/;
+hidden token WS: /[ \n\r\t]+/;
+comment token SL_COMMENT: /\/\/[^\r\n]*/;
+comment token ML_COMMENT: /\/\*[\s\S]*?\*\//;
+`
+
+func TestTextmateGenerator(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+		interface Foo { Bar *Bar }
+		interface Bar { Name string }
+		Entry returns Foo: "foo" bar=SubRule;
+		SubRule returns Bar: Name=ID;
+	` + commonTokens)
+	grammar := test.MustFindNode[grammar.Grammar](doc)
+	content := GenerateTextMate(grammar, TextMateGeneratorConfig{
+		Id:              "fastbelt",
+		FileExtensions:  []string{".fb"},
+		CaseInsensitive: false,
+	})
+	require.Equal(t, `{
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "name": "comment.line.fastbelt",
+          "begin": "//",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.whitespace.comment.leading.fastbelt"
+            }
+          },
+          "end": "(?=$)"
+        },
+        {
+          "name": "comment.block.fastbelt",
+          "begin": "/\\*",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.comment.fastbelt"
+            }
+          },
+          "end": "\\*/",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.comment.fastbelt"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "scopeName": "source.fastbelt",
+  "patterns": [
+    {
+      "include": "#comments"
+    },
+    {
+      "name": "keyword.control.fastbelt",
+      "match": "\\B(\"foo\")\\B"
+    }
+  ],
+  "fileTypes": [
+    ".fb"
+  ],
+  "name": "fastbelt"
+}`, content)
+}
+
+func CreateServices() *service.Container {
+	sc := service.NewContainer()
+	SetupServices(sc)
+	sc.Seal()
+	return sc
+}
+
+func SetupServices(sc *service.Container) {
+	service.Put[workspace.LanguageID](sc, "fastbelt")
+	service.Put[workspace.FileExtensions](sc, []string{".fb"})
+
+	textdoc.SetupDefaultServices(sc)
+	linking.SetupDefaultServices(sc)
+	workspace.SetupDefaultServices(sc)
+	grammar.SetupGeneratedServices(sc)
+}


### PR DESCRIPTION
Migrated from [here](https://github.com/eclipse-langium/langium/blob/main/packages/langium-cli/src/generator/highlighting/textmate-generator.ts)

We probably need some kind of Fastbelt configuration here, similar to the one in Langium.
I need

* the ID
* the option whether case sensitivity plays a role
* the file extensions from somewhere
* the destination path of the TextMate file
* a plan what to do with multiple languages and lexer modes

DRAFT FTM, since these questions are not answered, yet.