### PR TITLE
AstNode locating

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -27,14 +27,14 @@ type AstNode interface {
 	// Container returns the direct parent node of the node in the AST.
 	// It returns nil if this is the root node.
 	Container() AstNode
+	// ContainmentData returns a [unique.Handle] denoting the containing property within it's [AstNode.Container],
+	// defaults to a a [unique.Handle] of the empty string,
+	// and the element index within the containing property, defaults to zero for single item fields
+	ContainmentData() (unique.Handle[string], uint16)
 	// SetContainer sets the direct parent node of the node.
 	//
 	// When constructing an AST programmatically, use [AssignContainers] to link the node in the AST.
 	SetContainer(container AstNode, containerField unique.Handle[string], index uint16)
-	// NodePath returns a slash-separated path string that uniquely identifies this node
-	// within its document tree, e.g. "rules@2/alternatives@0".
-	// Returns "" for the root node (no container).
-	NodePath() (string, error)
 	// Tokens returns the tokens associated with the node.
 	Tokens() []*Token
 	// SetToken appends token to the node's token list.
@@ -67,6 +67,18 @@ type AstNode interface {
 	//
 	// Calling this method directly is not recommended. Use [References] instead for better readability.
 	ForEachReference(fn func(UntypedReference, unique.Handle[string], uint16))
+	// FieldInfos returns a descriptor for the denoted field of this AstNode.
+	FieldInfos(field unique.Handle[string]) FieldInfos
+	// NodePath returns a slash-separated path string that uniquely identifies this node
+	// within its document tree, e.g. "rules@2/alternatives@0".
+	// Returns "" for the root node (no container).
+	NodePath() (string, error)
+}
+
+// FieldInfos is a simple struct of meta data describing a field of an AstNode.
+type FieldInfos struct {
+	Multi     bool
+	Reference bool
 }
 
 // AstNodeBase provides the default [AstNode] implementation used by generated AST node types.
@@ -95,63 +107,6 @@ func (node *AstNodeBase) SetDocument(document *Document) {
 	}
 }
 
-type FieldInfos struct {
-	Multi     bool
-	Reference bool
-}
-
-// Base Implementation returning field meta data for an AstNode.
-// The generator produces specific overwrites for each generated ...Impl type.
-func (node *AstNodeBase) FieldInfos(field unique.Handle[string]) FieldInfos {
-	return FieldInfos{
-		Multi:     false,
-		Reference: false,
-	}
-}
-
-func (node *AstNodeBase) NodePath() (string, error) {
-	return GetNodePath(node)
-}
-
-type withFieldInfos interface {
-	ContainerData() (unique.Handle[string], uint16)
-	FieldInfos(field unique.Handle[string]) FieldInfos
-}
-
-func GetNodePath(node AstNode) (string, error) {
-	impl, ok := node.(withFieldInfos)
-	if !ok {
-		return "", errors.New("GetNodePath: conversion failed")
-	}
-
-	container := node.Container()
-	containerField, index := impl.ContainerData()
-
-	if container == nil {
-		return "", nil
-	} else if containerField.Value() == "" {
-		return "", errors.New("Can't determine node path, found AstNode field 'containerField' being empty.")
-	}
-
-	parentPath, err := GetNodePath(container)
-
-	if err == nil {
-		fieldPath := parentPath + "/" + containerField.Value()
-		containerWithInfos, ok := container.(withFieldInfos)
-		if ok && containerWithInfos.FieldInfos(containerField).Multi {
-			return fieldPath + "@" + strconv.Itoa(int(index)), nil
-		} else if ok {
-			x := containerWithInfos.FieldInfos(containerField)
-			println(x.Multi)
-			return fieldPath, nil
-		} else {
-			return "", errors.New("GetNodePath: conversion failed")
-		}
-	} else {
-		return "", err
-	}
-}
-
 // Container returns the direct parent node of the node in the AST.
 // It returns nil if this is the root node.
 func (node *AstNodeBase) Container() AstNode {
@@ -162,7 +117,7 @@ func (node *AstNodeBase) Container() AstNode {
 	}
 }
 
-func (node *AstNodeBase) ContainerData() (unique.Handle[string], uint16) {
+func (node *AstNodeBase) ContainmentData() (unique.Handle[string], uint16) {
 	return node.containerField, node.containerIndex
 }
 
@@ -259,6 +214,37 @@ func (node *AstNodeBase) Text() string {
 	} else {
 		fullText := node.document.TextDoc.Text(nil)
 		return fullText[node.segment.Indices.Start:node.segment.Indices.End]
+	}
+}
+
+// Base Implementation returning field meta data for an AstNode.
+// The generator produces specific overwrites for each generated ...Impl type.
+func (node *AstNodeBase) FieldInfos(field unique.Handle[string]) FieldInfos {
+	return FieldInfos{}
+}
+
+// NodePath determines node's path with it's root container in a recursive manner,
+// based on node's [AstNodeBase.ContainmentData] and [AstNode.FieldInfos]
+func (node *AstNodeBase) NodePath() (string, error) {
+	container := node.Container()
+	containerField, index := node.ContainmentData()
+
+	if container == nil {
+		return "", nil
+	} else if containerField.Value() == "" {
+		return "", errors.New("Can't determine node path, found AstNode's field 'containerField' being empty.")
+	}
+
+	parentPath, err := container.NodePath()
+	if err != nil {
+		return "", err
+	}
+
+	fieldPath := parentPath + "/" + containerField.Value()
+	if container.FieldInfos(containerField).Multi {
+		return fieldPath + "@" + strconv.Itoa(int(index)), nil
+	} else {
+		return fieldPath, nil
 	}
 }
 

--- a/ast.go
+++ b/ast.go
@@ -73,6 +73,8 @@ type AstNode interface {
 	// within its document tree, e.g. "rules@2/alternatives@0".
 	// Returns "" for the root node (no container).
 	NodePath() (string, error)
+	// GetByPath returns a (nested) child node denoted by the given path
+	GetByPath(path string) (AstNode, error)
 }
 
 // FieldInfos is a simple struct of meta data describing a field of an AstNode.
@@ -245,6 +247,16 @@ func (node *AstNodeBase) NodePath() (string, error) {
 		return fieldPath + "@" + strconv.Itoa(int(index)), nil
 	} else {
 		return fieldPath, nil
+	}
+}
+
+// Base Implementation for instances of [AstNodeBase].
+// The generator produces specific overwrites for each generated ...Impl type.
+func (node *AstNodeBase) GetByPath(path string) (AstNode, error) {
+	if path != "" {
+		return nil, errors.New("AstNodeBase.GetByPath: Cannot identify children of plain AstNodeBase instances.")
+	} else {
+		return node, nil
 	}
 }
 

--- a/ast.go
+++ b/ast.go
@@ -234,7 +234,7 @@ func (node *AstNodeBase) NodePath() (string, error) {
 	if container == nil {
 		return "", nil
 	} else if containerField.Value() == "" {
-		return "", errors.New("Can't determine node path, found AstNode's field 'containerField' being empty.")
+		return "", errors.New("cannot determine node path, found AstNode's field 'containerField' being empty")
 	}
 
 	parentPath, err := container.NodePath()
@@ -254,7 +254,7 @@ func (node *AstNodeBase) NodePath() (string, error) {
 // The generator produces specific overwrites for each generated ...Impl type.
 func (node *AstNodeBase) GetByPath(path string) (AstNode, error) {
 	if path != "" {
-		return nil, errors.New("AstNodeBase.GetByPath: Cannot identify children of plain AstNodeBase instances.")
+		return nil, errors.New("AstNodeBase.GetByPath: Cannot identify children of plain AstNodeBase instances")
 	} else {
 		return node, nil
 	}

--- a/ast.go
+++ b/ast.go
@@ -6,6 +6,7 @@ package fastbelt
 
 import (
 	"errors"
+	"fmt"
 	"iter"
 	"strconv"
 	"strings"
@@ -225,6 +226,8 @@ func (node *AstNodeBase) FieldInfos(field unique.Handle[string]) FieldInfos {
 	return FieldInfos{}
 }
 
+var fieldZero = unique.Handle[string]{}
+
 // NodePath determines node's path with it's root container in a recursive manner,
 // based on node's [AstNodeBase.ContainmentData] and [AstNode.FieldInfos]
 func (node *AstNodeBase) NodePath() (string, error) {
@@ -233,13 +236,19 @@ func (node *AstNodeBase) NodePath() (string, error) {
 
 	if container == nil {
 		return "", nil
-	} else if containerField.Value() == "" {
-		return "", errors.New("cannot determine node path, found AstNode's field 'containerField' being empty")
+	} else if containerField == fieldZero || containerField.Value() == "" {
+		return "", errors.New("cannot determine node path, 'containerField' is empty")
 	}
 
 	parentPath, err := container.NodePath()
 	if err != nil {
-		return "", err
+		if errors.Unwrap(err) == nil {
+			return "", fmt.Errorf(
+				"AstNodeBase.NodePath: error within node of type %T: %w", container, err)
+		} else {
+			return "", fmt.Errorf(
+				"AstNodeBase.NodePath: error within container of type %T:\n %w", container, err)
+		}
 	}
 
 	fieldPath := parentPath + "/" + containerField.Value()

--- a/ast.go
+++ b/ast.go
@@ -5,9 +5,12 @@
 package fastbelt
 
 import (
+	"errors"
 	"iter"
+	"strconv"
 	"strings"
 	"sync/atomic"
+	"unique"
 )
 
 // AstNode is the base interface for all AST nodes.
@@ -27,7 +30,11 @@ type AstNode interface {
 	// SetContainer sets the direct parent node of the node.
 	//
 	// When constructing an AST programmatically, use [AssignContainers] to link the node in the AST.
-	SetContainer(container AstNode)
+	SetContainer(container AstNode, containerField unique.Handle[string], index uint16)
+	// NodePath returns a slash-separated path string that uniquely identifies this node
+	// within its document tree, e.g. "rules@2/alternatives@0".
+	// Returns "" for the root node (no container).
+	NodePath() (string, error)
 	// Tokens returns the tokens associated with the node.
 	Tokens() []*Token
 	// SetToken appends token to the node's token list.
@@ -55,19 +62,21 @@ type AstNode interface {
 	// Note that this does not traverse the entire subtree. Use [AllNodes] or [AllChildren] for that.
 	//
 	// Calling this method directly is not recommended. Use [ChildNodes] instead for better readability.
-	ForEachNode(fn func(AstNode))
+	ForEachNode(fn func(AstNode, unique.Handle[string], uint16))
 	// ForEachReference calls fn for each reference field of node.
 	//
 	// Calling this method directly is not recommended. Use [References] instead for better readability.
-	ForEachReference(fn func(UntypedReference))
+	ForEachReference(fn func(UntypedReference, unique.Handle[string], uint16))
 }
 
 // AstNodeBase provides the default [AstNode] implementation used by generated AST node types.
 type AstNodeBase struct {
-	document  *Document
-	container AstNode
-	tokens    []*Token
-	segment   TextSegment
+	document       *Document
+	container      AstNode
+	containerField unique.Handle[string]
+	containerIndex uint16
+	tokens         []*Token
+	segment        TextSegment
 }
 
 // Document returns the owning document of the node.
@@ -86,6 +95,63 @@ func (node *AstNodeBase) SetDocument(document *Document) {
 	}
 }
 
+type FieldInfos struct {
+	Multi     bool
+	Reference bool
+}
+
+// Base Implementation returning field meta data for an AstNode.
+// The generator produces specific overwrites for each generated ...Impl type.
+func (node *AstNodeBase) FieldInfos(field unique.Handle[string]) FieldInfos {
+	return FieldInfos{
+		Multi:     false,
+		Reference: false,
+	}
+}
+
+func (node *AstNodeBase) NodePath() (string, error) {
+	return GetNodePath(node)
+}
+
+type withFieldInfos interface {
+	ContainerData() (unique.Handle[string], uint16)
+	FieldInfos(field unique.Handle[string]) FieldInfos
+}
+
+func GetNodePath(node AstNode) (string, error) {
+	impl, ok := node.(withFieldInfos)
+	if !ok {
+		return "", errors.New("GetNodePath: conversion failed")
+	}
+
+	container := node.Container()
+	containerField, index := impl.ContainerData()
+
+	if container == nil {
+		return "", nil
+	} else if containerField.Value() == "" {
+		return "", errors.New("Can't determine node path, found AstNode field 'containerField' being empty.")
+	}
+
+	parentPath, err := GetNodePath(container)
+
+	if err == nil {
+		fieldPath := parentPath + "/" + containerField.Value()
+		containerWithInfos, ok := container.(withFieldInfos)
+		if ok && containerWithInfos.FieldInfos(containerField).Multi {
+			return fieldPath + "@" + strconv.Itoa(int(index)), nil
+		} else if ok {
+			x := containerWithInfos.FieldInfos(containerField)
+			println(x.Multi)
+			return fieldPath, nil
+		} else {
+			return "", errors.New("GetNodePath: conversion failed")
+		}
+	} else {
+		return "", err
+	}
+}
+
 // Container returns the direct parent node of the node in the AST.
 // It returns nil if this is the root node.
 func (node *AstNodeBase) Container() AstNode {
@@ -94,6 +160,10 @@ func (node *AstNodeBase) Container() AstNode {
 	} else {
 		return nil
 	}
+}
+
+func (node *AstNodeBase) ContainerData() (unique.Handle[string], uint16) {
+	return node.containerField, node.containerIndex
 }
 
 // TODO: If concrete methods gain access to generics, refactor this into a method
@@ -116,9 +186,11 @@ func ContainerOfType[T AstNode](node AstNode) T {
 }
 
 // SetContainer sets the direct parent node of the node.
-func (node *AstNodeBase) SetContainer(container AstNode) {
+func (node *AstNodeBase) SetContainer(container AstNode, field unique.Handle[string], index uint16) {
 	if node != nil {
 		node.container = container
+		node.containerField = field
+		node.containerIndex = index
 	}
 }
 
@@ -193,14 +265,14 @@ func (node *AstNodeBase) Text() string {
 // ForEachNode calls fn for each direct child node of node.
 //
 // ForEachNode on AstNodeBase is a no-op because the base type has no child fields.
-func (node *AstNodeBase) ForEachNode(fn func(AstNode)) {
+func (node *AstNodeBase) ForEachNode(fn func(AstNode, unique.Handle[string], uint16)) {
 	// This base implementation does not have any contained nodes.
 }
 
 // ForEachReference calls fn for each reference field of node.
 //
 // ForEachReference on AstNodeBase is a no-op because the base type has no reference fields.
-func (node *AstNodeBase) ForEachReference(fn func(UntypedReference)) {
+func (node *AstNodeBase) ForEachReference(fn func(UntypedReference, unique.Handle[string], uint16)) {
 	// This base implementation does not have any references.
 }
 
@@ -219,7 +291,7 @@ func (node *AstNodeBase) ForEachReference(fn func(UntypedReference)) {
 //
 // Note that this function will traverse the entire subtree, without short-circuiting.
 func traverseContent(node AstNode, fn func(AstNode)) {
-	node.ForEachNode(func(child AstNode) {
+	node.ForEachNode(func(child AstNode, containerField unique.Handle[string], index uint16) {
 		fn(child)
 		traverseContent(child, fn)
 	})
@@ -263,7 +335,7 @@ func AllChildren(node AstNode) iter.Seq[AstNode] {
 func ChildNodes(node AstNode) iter.Seq[AstNode] {
 	return func(yield func(AstNode) bool) {
 		stopped := false
-		node.ForEachNode(func(child AstNode) {
+		node.ForEachNode(func(child AstNode, containerField unique.Handle[string], index uint16) {
 			if !stopped && !yield(child) {
 				stopped = true
 			}
@@ -278,7 +350,7 @@ func ChildNodes(node AstNode) iter.Seq[AstNode] {
 func References(node AstNode) iter.Seq[UntypedReference] {
 	return func(yield func(UntypedReference) bool) {
 		stopped := false
-		node.ForEachReference(func(ref UntypedReference) {
+		node.ForEachReference(func(ref UntypedReference, containerField unique.Handle[string], index uint16) {
 			if !stopped && !yield(ref) {
 				stopped = true
 			}
@@ -335,16 +407,16 @@ func MergeTokens(newNode AstNode, oldTokens []*Token) {
 // It also assigns document and container on composite reference units reachable via references.
 func AssignContainers(doc *Document, root AstNode) {
 	root.SetDocument(doc)
-	root.ForEachNode(func(child AstNode) {
+	root.ForEachNode(func(child AstNode, containerField unique.Handle[string], index uint16) {
 		child.SetDocument(doc)
-		child.SetContainer(root)
+		child.SetContainer(root, containerField, index)
 		AssignContainers(doc, child)
 	})
-	root.ForEachReference(func(ur UntypedReference) {
+	root.ForEachReference(func(ur UntypedReference, containerField unique.Handle[string], index uint16) {
 		unit := ur.Unit()
 		if stringNode, ok := unit.(CompositeNode); ok {
 			stringNode.SetDocument(doc)
-			stringNode.SetContainer(root)
+			stringNode.SetContainer(root, containerField, index)
 		}
 	})
 }

--- a/ast.go
+++ b/ast.go
@@ -6,9 +6,7 @@ package fastbelt
 
 import (
 	"errors"
-	"fmt"
 	"iter"
-	"strconv"
 	"strings"
 	"sync/atomic"
 	"unique"
@@ -68,8 +66,8 @@ type AstNode interface {
 	//
 	// Calling this method directly is not recommended. Use [References] instead for better readability.
 	ForEachReference(fn func(UntypedReference, unique.Handle[string], int))
-	// GetByPath returns a (nested) child node denoted by the given path
-	GetByPath(path *PathSegments) (AstNode, error)
+	// Resolve returns a (nested) child node denoted by the given relative path
+	Resolve(path FragmentPath) (AstNode, error)
 }
 
 // AstNodeBase provides the default [AstNode] implementation used by generated AST node types.
@@ -224,116 +222,8 @@ func (node *AstNodeBase) ForEachReference(fn func(UntypedReference, unique.Handl
 
 // Base Implementation for instances of [AstNodeBase].
 // The generator produces specific overwrites for each generated ...Impl type.
-func (node *AstNodeBase) GetByPath(path *PathSegments) (AstNode, error) {
-	return nil, errors.New("AstNodeBase.GetByPath: Cannot identify children of plain AstNodeBase instances")
-}
-
-func GetByPath(node AstNode, path string) (AstNode, error) {
-	if path == "" {
-		return node, nil
-	}
-	segments, err := parsePath(path)
-	if err != nil {
-		return nil, err
-	}
-	return node.GetByPath(segments)
-}
-
-var fieldZero = unique.Handle[string]{}
-
-// NodePath determines node's path within its root container in a recursive manner,
-// based on node's [AstNode.ContainmentData]. It returns a slash-separated
-// path string that uniquely identifies this node within its document tree,
-// e.g. "/rules@2/alternatives@0".
-// Returns "" for the root node (no container).
-func NodePath(node AstNode) (fmt.Stringer, error) {
-	container := node.Container()
-	containerField, index := node.ContainmentData()
-
-	b := &PathSegments{}
-	if container == nil {
-		return b, nil
-	} else if containerField == fieldZero || containerField.Value() == "" {
-		return b, errors.New("cannot determine node path, 'containerField' is empty")
-	}
-
-	parentPath, err := NodePath(container)
-	if err != nil {
-		if errors.Unwrap(err) == nil {
-			return b, fmt.Errorf(
-				"AstNodeBase.NodePath: error within node of type %T: %w", container, err)
-		} else {
-			return b, fmt.Errorf(
-				"AstNodeBase.NodePath: error within container of type %T:\n %w", container, err)
-		}
-	}
-	return parentPath.(*PathSegments).Push(containerField, index), nil
-}
-
-type PathSegments struct {
-	segments []struct {
-		name  unique.Handle[string]
-		index int
-	}
-}
-
-func (p *PathSegments) Empty() bool {
-	return len(p.segments) == 0
-}
-
-func (p *PathSegments) Push(name unique.Handle[string], index int) *PathSegments {
-	p.segments = append(p.segments, struct {
-		name  unique.Handle[string]
-		index int
-	}{name, index})
-	return p
-}
-
-func (p *PathSegments) Shift() (name unique.Handle[string], index int) {
-	len := len(p.segments)
-	if len == 0 {
-		return fieldZero, -1
-	} else {
-		head := p.segments[0]
-		p.segments = p.segments[1:]
-		return head.name, head.index
-	}
-}
-
-func (ps *PathSegments) String() string {
-	var sb strings.Builder
-	for _, s := range ps.segments {
-		sb.WriteString("/")
-		sb.WriteString(s.name.Value())
-		if s.index >= 0 {
-			sb.WriteString("@")
-			sb.WriteString(strconv.Itoa(int(s.index)))
-		}
-	}
-	return sb.String()
-}
-
-func parsePath(path string) (*PathSegments, error) {
-	result := &PathSegments{}
-	path = strings.TrimLeft(path, "/")
-	parts := strings.Split(path, "/")
-	for _, segment := range parts {
-		if segment == "" {
-			continue
-		}
-		fieldAndIndex := strings.SplitN(segment, "@", 2)
-		field := unique.Make(fieldAndIndex[0])
-		if len(fieldAndIndex) == 1 {
-			result.Push(field, -1)
-		} else {
-			index, err := strconv.Atoi(fieldAndIndex[1])
-			if err != nil {
-				return nil, fmt.Errorf("ParsePath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
-			}
-			result.Push(field, index)
-		}
-	}
-	return result, nil
+func (node *AstNodeBase) Resolve(path FragmentPath) (AstNode, error) {
+	return nil, errors.New("AstNodeBase.Resolve: Cannot identify children of plain AstNodeBase instances")
 }
 
 // Performance note about traversal function:

--- a/ast.go
+++ b/ast.go
@@ -27,8 +27,8 @@ type AstNode interface {
 	// It returns nil if this is the root node.
 	Container() AstNode
 	// ContainmentData returns a [unique.Handle] denoting the containing property within it's [AstNode.Container],
-	// defaults to a a [unique.Handle] of the empty string,
-	// and the element index within the containing property, defaults to zero for single item fields
+	// defaults to a [unique.Handle] of the empty string,
+	// and the element index within the containing property, defaults to -1 for single item fields
 	ContainmentData() (unique.Handle[string], int)
 	// SetContainer sets the direct parent node of the node.
 	//

--- a/ast.go
+++ b/ast.go
@@ -66,7 +66,7 @@ type AstNode interface {
 	//
 	// Calling this method directly is not recommended. Use [References] instead for better readability.
 	ForEachReference(fn func(UntypedReference, unique.Handle[string], int))
-	// Resolve returns a (nested) child node denoted by the given relative path
+	// Resolve returns a (nested) child node denoted by the given (relative) fragment path descriptor.
 	Resolve(path FragmentPath) (AstNode, error)
 }
 

--- a/ast.go
+++ b/ast.go
@@ -67,6 +67,8 @@ type AstNode interface {
 	// Calling this method directly is not recommended. Use [References] instead for better readability.
 	ForEachReference(fn func(UntypedReference, unique.Handle[string], int))
 	// Resolve returns a (nested) child node denoted by the given (relative) fragment path descriptor.
+	//
+	// Calling this method directly is not recommended. Use [Resolve] instead.
 	Resolve(path FragmentPath) (AstNode, error)
 }
 
@@ -221,7 +223,7 @@ func (node *AstNodeBase) ForEachReference(fn func(UntypedReference, unique.Handl
 }
 
 // Base Implementation for instances of [AstNodeBase].
-// The generator produces specific overwrites for each generated ...Impl type.
+// The generator produces specific override methods for each generated ...Impl type.
 func (node *AstNodeBase) Resolve(path FragmentPath) (AstNode, error) {
 	return nil, errors.New("AstNodeBase.Resolve: Cannot identify children of plain AstNodeBase instances")
 }

--- a/ast.go
+++ b/ast.go
@@ -31,11 +31,11 @@ type AstNode interface {
 	// ContainmentData returns a [unique.Handle] denoting the containing property within it's [AstNode.Container],
 	// defaults to a a [unique.Handle] of the empty string,
 	// and the element index within the containing property, defaults to zero for single item fields
-	ContainmentData() (unique.Handle[string], uint16)
+	ContainmentData() (unique.Handle[string], int)
 	// SetContainer sets the direct parent node of the node.
 	//
 	// When constructing an AST programmatically, use [AssignContainers] to link the node in the AST.
-	SetContainer(container AstNode, containerField unique.Handle[string], index uint16)
+	SetContainer(container AstNode, containerField unique.Handle[string], index int)
 	// Tokens returns the tokens associated with the node.
 	Tokens() []*Token
 	// SetToken appends token to the node's token list.
@@ -63,25 +63,13 @@ type AstNode interface {
 	// Note that this does not traverse the entire subtree. Use [AllNodes] or [AllChildren] for that.
 	//
 	// Calling this method directly is not recommended. Use [ChildNodes] instead for better readability.
-	ForEachNode(fn func(AstNode, unique.Handle[string], uint16))
+	ForEachNode(fn func(AstNode, unique.Handle[string], int))
 	// ForEachReference calls fn for each reference field of node.
 	//
 	// Calling this method directly is not recommended. Use [References] instead for better readability.
-	ForEachReference(fn func(UntypedReference, unique.Handle[string], uint16))
-	// FieldInfos returns a descriptor for the denoted field of this AstNode.
-	FieldInfos(field unique.Handle[string]) FieldInfos
-	// NodePath returns a slash-separated path string that uniquely identifies this node
-	// within its document tree, e.g. "rules@2/alternatives@0".
-	// Returns "" for the root node (no container).
-	NodePath() (string, error)
+	ForEachReference(fn func(UntypedReference, unique.Handle[string], int))
 	// GetByPath returns a (nested) child node denoted by the given path
-	GetByPath(path string) (AstNode, error)
-}
-
-// FieldInfos is a simple struct of meta data describing a field of an AstNode.
-type FieldInfos struct {
-	Multi     bool
-	Reference bool
+	GetByPath(path *PathSegments) (AstNode, error)
 }
 
 // AstNodeBase provides the default [AstNode] implementation used by generated AST node types.
@@ -89,7 +77,7 @@ type AstNodeBase struct {
 	document       *Document
 	container      AstNode
 	containerField unique.Handle[string]
-	containerIndex uint16
+	containerIndex int
 	tokens         []*Token
 	segment        TextSegment
 }
@@ -120,7 +108,7 @@ func (node *AstNodeBase) Container() AstNode {
 	}
 }
 
-func (node *AstNodeBase) ContainmentData() (unique.Handle[string], uint16) {
+func (node *AstNodeBase) ContainmentData() (unique.Handle[string], int) {
 	return node.containerField, node.containerIndex
 }
 
@@ -144,7 +132,7 @@ func ContainerOfType[T AstNode](node AstNode) T {
 }
 
 // SetContainer sets the direct parent node of the node.
-func (node *AstNodeBase) SetContainer(container AstNode, field unique.Handle[string], index uint16) {
+func (node *AstNodeBase) SetContainer(container AstNode, field unique.Handle[string], index int) {
 	if node != nil {
 		node.container = container
 		node.containerField = field
@@ -220,67 +208,132 @@ func (node *AstNodeBase) Text() string {
 	}
 }
 
-// Base Implementation returning field meta data for an AstNode.
-// The generator produces specific overwrites for each generated ...Impl type.
-func (node *AstNodeBase) FieldInfos(field unique.Handle[string]) FieldInfos {
-	return FieldInfos{}
-}
-
-var fieldZero = unique.Handle[string]{}
-
-// NodePath determines node's path with it's root container in a recursive manner,
-// based on node's [AstNodeBase.ContainmentData] and [AstNode.FieldInfos]
-func (node *AstNodeBase) NodePath() (string, error) {
-	container := node.Container()
-	containerField, index := node.ContainmentData()
-
-	if container == nil {
-		return "", nil
-	} else if containerField == fieldZero || containerField.Value() == "" {
-		return "", errors.New("cannot determine node path, 'containerField' is empty")
-	}
-
-	parentPath, err := container.NodePath()
-	if err != nil {
-		if errors.Unwrap(err) == nil {
-			return "", fmt.Errorf(
-				"AstNodeBase.NodePath: error within node of type %T: %w", container, err)
-		} else {
-			return "", fmt.Errorf(
-				"AstNodeBase.NodePath: error within container of type %T:\n %w", container, err)
-		}
-	}
-
-	fieldPath := parentPath + "/" + containerField.Value()
-	if container.FieldInfos(containerField).Multi {
-		return fieldPath + "@" + strconv.Itoa(int(index)), nil
-	} else {
-		return fieldPath, nil
-	}
-}
-
-// Base Implementation for instances of [AstNodeBase].
-// The generator produces specific overwrites for each generated ...Impl type.
-func (node *AstNodeBase) GetByPath(path string) (AstNode, error) {
-	if path != "" {
-		return nil, errors.New("AstNodeBase.GetByPath: Cannot identify children of plain AstNodeBase instances")
-	} else {
-		return node, nil
-	}
-}
-
 // ForEachNode calls fn for each direct child node of node.
 //
 // ForEachNode on AstNodeBase is a no-op because the base type has no child fields.
-func (node *AstNodeBase) ForEachNode(fn func(AstNode, unique.Handle[string], uint16)) {
+func (node *AstNodeBase) ForEachNode(fn func(AstNode, unique.Handle[string], int)) {
 	// This base implementation does not have any contained nodes.
 }
 
 // ForEachReference calls fn for each reference field of node.
 //
 // ForEachReference on AstNodeBase is a no-op because the base type has no reference fields.
-func (node *AstNodeBase) ForEachReference(fn func(UntypedReference, unique.Handle[string], uint16)) {
+func (node *AstNodeBase) ForEachReference(fn func(UntypedReference, unique.Handle[string], int)) {
 	// This base implementation does not have any references.
+}
+
+// Base Implementation for instances of [AstNodeBase].
+// The generator produces specific overwrites for each generated ...Impl type.
+func (node *AstNodeBase) GetByPath(path *PathSegments) (AstNode, error) {
+	return nil, errors.New("AstNodeBase.GetByPath: Cannot identify children of plain AstNodeBase instances")
+}
+
+func GetByPath(node AstNode, path string) (AstNode, error) {
+	if path == "" {
+		return node, nil
+	}
+	segments, err := parsePath(path)
+	if err != nil {
+		return nil, err
+	}
+	return node.GetByPath(segments)
+}
+
+var fieldZero = unique.Handle[string]{}
+
+// NodePath determines node's path within its root container in a recursive manner,
+// based on node's [AstNode.ContainmentData]. It returns a slash-separated
+// path string that uniquely identifies this node within its document tree,
+// e.g. "/rules@2/alternatives@0".
+// Returns "" for the root node (no container).
+func NodePath(node AstNode) (fmt.Stringer, error) {
+	container := node.Container()
+	containerField, index := node.ContainmentData()
+
+	b := &PathSegments{}
+	if container == nil {
+		return b, nil
+	} else if containerField == fieldZero || containerField.Value() == "" {
+		return b, errors.New("cannot determine node path, 'containerField' is empty")
+	}
+
+	parentPath, err := NodePath(container)
+	if err != nil {
+		if errors.Unwrap(err) == nil {
+			return b, fmt.Errorf(
+				"AstNodeBase.NodePath: error within node of type %T: %w", container, err)
+		} else {
+			return b, fmt.Errorf(
+				"AstNodeBase.NodePath: error within container of type %T:\n %w", container, err)
+		}
+	}
+	return parentPath.(*PathSegments).Push(containerField, index), nil
+}
+
+type PathSegments struct {
+	segments []struct {
+		name  unique.Handle[string]
+		index int
+	}
+}
+
+func (p *PathSegments) Empty() bool {
+	return len(p.segments) == 0
+}
+
+func (p *PathSegments) Push(name unique.Handle[string], index int) *PathSegments {
+	p.segments = append(p.segments, struct {
+		name  unique.Handle[string]
+		index int
+	}{name, index})
+	return p
+}
+
+func (p *PathSegments) Shift() (name unique.Handle[string], index int) {
+	len := len(p.segments)
+	if len == 0 {
+		return fieldZero, -1
+	} else {
+		head := p.segments[0]
+		p.segments = p.segments[1:]
+		return head.name, head.index
+	}
+}
+
+func (ps *PathSegments) String() string {
+	var sb strings.Builder
+	for _, s := range ps.segments {
+		sb.WriteString("/")
+		sb.WriteString(s.name.Value())
+		if s.index >= 0 {
+			sb.WriteString("@")
+			sb.WriteString(strconv.Itoa(int(s.index)))
+		}
+	}
+	return sb.String()
+}
+
+func parsePath(path string) (*PathSegments, error) {
+	result := &PathSegments{}
+	path = strings.TrimLeft(path, "/")
+	parts := strings.Split(path, "/")
+	for _, segment := range parts {
+		if segment == "" {
+			continue
+		}
+		fieldAndIndex := strings.SplitN(segment, "@", 2)
+		field := unique.Make(fieldAndIndex[0])
+		if len(fieldAndIndex) == 1 {
+			result.Push(field, -1)
+		} else {
+			index, err := strconv.Atoi(fieldAndIndex[1])
+			if err != nil {
+				return nil, fmt.Errorf("ParsePath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
+			}
+			result.Push(field, index)
+		}
+	}
+	return result, nil
 }
 
 // Performance note about traversal function:
@@ -298,7 +351,7 @@ func (node *AstNodeBase) ForEachReference(fn func(UntypedReference, unique.Handl
 //
 // Note that this function will traverse the entire subtree, without short-circuiting.
 func traverseContent(node AstNode, fn func(AstNode)) {
-	node.ForEachNode(func(child AstNode, containerField unique.Handle[string], index uint16) {
+	node.ForEachNode(func(child AstNode, containerField unique.Handle[string], index int) {
 		fn(child)
 		traverseContent(child, fn)
 	})
@@ -342,7 +395,7 @@ func AllChildren(node AstNode) iter.Seq[AstNode] {
 func ChildNodes(node AstNode) iter.Seq[AstNode] {
 	return func(yield func(AstNode) bool) {
 		stopped := false
-		node.ForEachNode(func(child AstNode, containerField unique.Handle[string], index uint16) {
+		node.ForEachNode(func(child AstNode, containerField unique.Handle[string], index int) {
 			if !stopped && !yield(child) {
 				stopped = true
 			}
@@ -357,7 +410,7 @@ func ChildNodes(node AstNode) iter.Seq[AstNode] {
 func References(node AstNode) iter.Seq[UntypedReference] {
 	return func(yield func(UntypedReference) bool) {
 		stopped := false
-		node.ForEachReference(func(ref UntypedReference, containerField unique.Handle[string], index uint16) {
+		node.ForEachReference(func(ref UntypedReference, containerField unique.Handle[string], index int) {
 			if !stopped && !yield(ref) {
 				stopped = true
 			}
@@ -414,12 +467,12 @@ func MergeTokens(newNode AstNode, oldTokens []*Token) {
 // It also assigns document and container on composite reference units reachable via references.
 func AssignContainers(doc *Document, root AstNode) {
 	root.SetDocument(doc)
-	root.ForEachNode(func(child AstNode, containerField unique.Handle[string], index uint16) {
+	root.ForEachNode(func(child AstNode, containerField unique.Handle[string], index int) {
 		child.SetDocument(doc)
 		child.SetContainer(root, containerField, index)
 		AssignContainers(doc, child)
 	})
-	root.ForEachReference(func(ur UntypedReference, containerField unique.Handle[string], index uint16) {
+	root.ForEachReference(func(ur UntypedReference, containerField unique.Handle[string], index int) {
 		unit := ur.Unit()
 		if stringNode, ok := unit.(CompositeNode); ok {
 			stringNode.SetDocument(doc)

--- a/examples/arithmetics/ast_locating_benchmark_test.go
+++ b/examples/arithmetics/ast_locating_benchmark_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+package arithmetics
+
+import (
+	"testing"
+
+	core "typefox.dev/fastbelt"
+	"typefox.dev/fastbelt/test"
+)
+
+// BenchmarkPathOf benchmarks [core.PathOf] at four containment depths:
+// self (0 segments), shallow (1 segment), medium (3 segments), and deep (5 segments).
+// Node pointers are resolved once before the timer starts so only PathOf itself is measured.
+func BenchmarkPathOf(b *testing.B) {
+	doc := loadPriceCalcDoc(b)
+	module := test.MustFindNode[Module](doc)
+	stmts := module.Statements()
+
+	// /statements@3/expression/left
+	def3 := stmts[3].(Definition)
+	bin3 := def3.Expression().(BinaryExpression)
+
+	// /statements@7/expression/left/left/left
+	def7 := stmts[7].(Definition)
+	outerAdd := def7.Expression().(BinaryExpression)
+	div := outerAdd.Left().(BinaryExpression)
+	innerAdd := div.Left().(BinaryExpression)
+
+	cases := []struct {
+		name string
+		node core.AstNode
+	}{
+		{"self/0-segments", module},
+		{"shallow/1-segment", stmts[3]},
+		{"medium/3-segments", bin3.Left()},
+		{"deep/5-segments", innerAdd.Left()},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			for b.Loop() {
+				_, _ = core.PathOf(tc.node)
+			}
+		})
+	}
+}
+
+// BenchmarkResolve benchmarks [core.Resolve] at four path depths:
+// self (0 segments), shallow (1 segment), medium (3 segments), and deep (5 segments).
+// The root node is obtained once before the timer starts.
+func BenchmarkResolve(b *testing.B) {
+	doc := loadPriceCalcDoc(b)
+	root := doc.Root()
+
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"self/0-segments", ""},
+		{"self/single-slash", "/"},
+		{"shallow/1-segment", "/statements@3"},
+		{"medium/3-segments", "/statements@3/expression/left"},
+		{"deep/5-segments", "/statements@7/expression/left/left/left"},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			for b.Loop() {
+				_, _ = core.Resolve(tc.path, root)
+			}
+		})
+	}
+}

--- a/examples/arithmetics/ast_locating_benchmark_test.go
+++ b/examples/arithmetics/ast_locating_benchmark_test.go
@@ -69,7 +69,7 @@ func BenchmarkResolve(b *testing.B) {
 	for _, tc := range cases {
 		b.Run(tc.name, func(b *testing.B) {
 			for b.Loop() {
-				_, _ = core.Resolve(tc.path, root)
+				_, _ = core.Resolve(root, tc.path)
 			}
 		})
 	}

--- a/examples/arithmetics/ast_locating_test.go
+++ b/examples/arithmetics/ast_locating_test.go
@@ -51,8 +51,8 @@ func TestNodePath_PriceCalc(t *testing.T) {
 		require.True(t, ok)
 		fc, ok := binExpr.Left().(FunctionCall)
 		require.True(t, ok)
-		assert.Equal(t, "materialPerUnit", fc.Callable().Text())
 		assert.Equal(t, "/statements@3/expression/left", mustNodePath(t, fc))
+		assert.Equal(t, "materialPerUnit", fc.Callable().Text())
 		assert.Equal(t, "/statements@0", mustNodePath(t, fc.Callable().Ref(doc.Ctx())))
 	})
 

--- a/examples/arithmetics/ast_locating_test.go
+++ b/examples/arithmetics/ast_locating_test.go
@@ -5,8 +5,10 @@
 package arithmetics
 
 import (
+	"fmt"
 	"os"
 	"testing"
+	"unique"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -234,6 +236,56 @@ func TestNodePath_PriceCalc(t *testing.T) {
 		assert.Equal(t, "/statements@10/expression/args@1", mustNodePath(t, fc))
 		assert.Equal(t, "vat", fc.Callable().Text())
 		assert.Equal(t, "/statements@8", mustNodePath(t, fc.Callable().Ref(doc.Ctx())))
+	})
+
+	t.Run("errorReporting/containerField-has-empty-string", func(t *testing.T) {
+		// this test creates local copies of module, its first stmt, and its contained number literal
+		//  and updates their container references accordingly
+
+		// in order to test the error logging across some levels of nesting an additional root object is created,
+		// which serves a container for the copied module,
+		// while module's 'containerField' is set to the interned value of "" --> error!
+		root := core.NewAstNode()
+
+		module := *module.(*ModuleImpl)
+		module.SetContainer(&root, unique.Make(""), 0)
+
+		def := *stmts[0].(*DefinitionImpl)
+		var field, index = def.ContainmentData()
+		def.SetContainer(&module, field, index)
+
+		expr := *def.expression.(*NumberLiteralImpl)
+		field, index = expr.ContainmentData()
+		expr.SetContainer(&def, field, index)
+
+		path, err := expr.NodePath()
+		assert.Zero(t, path)
+		fmt.Println(err)
+		assert.ErrorContains(
+			t, err,
+			"AstNodeBase.NodePath: error within node of type *arithmetics.ModuleImpl: cannot determine node path, 'containerField' is empty")
+	})
+
+	t.Run("errorReporting/containerField-has-zero-handle", func(t *testing.T) {
+		// this test creates local copies of module, its first stmt, and its contained number literal
+		//  and updates their container references accordingly
+
+		module := *module.(*ModuleImpl)
+		var fieldZero unique.Handle[string]
+
+		def := *stmts[0].(*DefinitionImpl)
+		def.SetContainer(&module, fieldZero, 0)
+
+		expr := *def.expression.(*NumberLiteralImpl)
+		field, index := expr.ContainmentData()
+		expr.SetContainer(&def, field, index)
+
+		path, err := expr.NodePath()
+		assert.Zero(t, path)
+		fmt.Println(err)
+		assert.ErrorContains(
+			t, err,
+			"AstNodeBase.NodePath: error within node of type *arithmetics.DefinitionImpl: cannot determine node path, 'containerField' is empty")
 	})
 }
 
@@ -506,5 +558,66 @@ func TestGetByPath_PriceCalc(t *testing.T) {
 		got, err = root.GetByPath("/statements@8")
 		require.NoError(t, err)
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
+	})
+
+	t.Run("errorReporting/no-such-field", func(t *testing.T) {
+		_, err := root.GetByPath("/statements@3/expressions/left")
+		assert.ErrorContains(t, err, "DefinitionImpl.GetByPath: field 'expressions' does not exist in node '/statements@3' of type 'Definition'")
+	})
+
+	t.Run("errorReporting/field-is-primitive", func(t *testing.T) {
+		_, err := root.GetByPath("/statements@0/name")
+		assert.ErrorContains(t, err, "DefinitionImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
+	})
+
+	t.Run("errorReporting/field-is-reference", func(t *testing.T) {
+		_, err := root.GetByPath("/statements@10/expression/callable")
+		assert.ErrorContains(t, err, "FunctionCallImpl.GetByPath: field 'callable' is a cross-reference instead of a container field")
+	})
+
+	t.Run("errorReporting/field-is-empty", func(t *testing.T) {
+		// create local copies of the relevant ast nodes first to avoid manipulating the shared ones
+		module := *module.(*ModuleImpl)
+		def := *stmts[0].(*DefinitionImpl)
+
+		module.statements = make([]Statement, 1)
+		module.statements[0] = &def
+
+		field, index := def.ContainmentData()
+		def.SetContainer(&module, field, index)
+
+		// set the tested field to 'nil'
+		def.expression = nil
+
+		_, err := module.GetByPath("/statements@0/expression/left")
+		assert.ErrorContains(t, err, "DefinitionImpl.GetByPath: field 'expression' is nil in node '/statements@0'")
+	})
+
+	t.Run("errorReporting/slice-index-out-of-bound-1", func(t *testing.T) {
+		_, err := root.GetByPath("/statements@15/expression")
+		assert.ErrorContains(t, err, "ModuleImpl.GetByPath: index 15 exceeds length of slice in 'statements' (length=11) in node ''")
+	})
+
+	t.Run("errorReporting/slice-index-out-of-bound-2", func(t *testing.T) {
+		_, err := root.GetByPath("/statements@10/expression/args@7/expression")
+		assert.ErrorContains(t, err, "FunctionCallImpl.GetByPath: index 7 exceeds length of slice in 'args' (length=2) in node '/statements@10/expression'")
+	})
+
+	t.Run("errorReporting/slice-item-is-nil", func(t *testing.T) {
+		expr, err := root.GetByPath("/statements@10/expression/")
+		require.NoError(t, err)
+		fc, ok := expr.(FunctionCall)
+		require.True(t, ok)
+
+		// shamelessly manipulate the shared ast and add a 'nil' item, don't want to copy everything right now; shouldn't hurt
+		fc.SetArgsItem(nil)
+		_, err = root.GetByPath("/statements@10/expression/args@2/expression")
+
+		assert.ErrorContains(t, err, "FunctionCallImpl.GetByPath: item 2 of slice in field 'args' is nil in node '/statements@10/expression'")
+	})
+
+	t.Run("errorReporting/slice-index-typo", func(t *testing.T) {
+		_, err := root.GetByPath("/statements@1a/expression")
+		assert.ErrorContains(t, err, "ModuleImpl.GetByPath: index '1a' is not a valid uint: strconv.Atoi: parsing \"1a\": invalid syntax")
 	})
 }

--- a/examples/arithmetics/ast_locating_test.go
+++ b/examples/arithmetics/ast_locating_test.go
@@ -236,3 +236,275 @@ func TestNodePath_PriceCalc(t *testing.T) {
 		assert.Equal(t, "/statements@8", mustNodePath(t, fc.Callable().Ref(doc.Ctx())))
 	})
 }
+
+// TestGetByPath_PriceCalc is the inverse of TestNodePath_PriceCalc: for each of the 13
+// FunctionCall cross-reference sites in price-calc.calc, it resolves the hardcoded path
+// string back to an AST node via GetByPath and asserts pointer identity with the node
+// obtained by direct AST navigation. Both the referencer (FunctionCall) and the
+// referenced (AbstractDefinition) are covered per subtest.
+func TestGetByPath_PriceCalc(t *testing.T) {
+	doc := loadPriceCalcDoc(t)
+	root := doc.Root()
+	module := test.MustFindNode[Module](doc)
+	stmts := module.Statements()
+	require.Len(t, stmts, 11)
+
+	// ── def costPerUnit: materialPerUnit + laborPerUnit ───────────────────────
+
+	t.Run("costPerUnit/materialPerUnit", func(t *testing.T) {
+		def, ok := stmts[3].(Definition)
+		require.True(t, ok)
+		binExpr, ok := def.Expression().(BinaryExpression)
+		require.True(t, ok)
+		fc, ok := binExpr.Left().(FunctionCall)
+		require.True(t, ok)
+
+		got, err := root.GetByPath("/statements@3/expression/left")
+		require.NoError(t, err)
+		assert.Same(t, fc, got)
+
+		got, err = root.GetByPath("/statements@0")
+		require.NoError(t, err)
+		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
+	})
+
+	t.Run("costPerUnit/laborPerUnit", func(t *testing.T) {
+		def, ok := stmts[3].(Definition)
+		require.True(t, ok)
+		binExpr, ok := def.Expression().(BinaryExpression)
+		require.True(t, ok)
+		fc, ok := binExpr.Right().(FunctionCall)
+		require.True(t, ok)
+
+		got, err := root.GetByPath("/statements@3/expression/right")
+		require.NoError(t, err)
+		assert.Same(t, fc, got)
+
+		got, err = root.GetByPath("/statements@1")
+		require.NoError(t, err)
+		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
+	})
+
+	// ── def costOfGoodsSold: expectedNoOfSales * costPerUnit ─────────────────
+
+	t.Run("costOfGoodsSold/expectedNoOfSales", func(t *testing.T) {
+		def, ok := stmts[4].(Definition)
+		require.True(t, ok)
+		binExpr, ok := def.Expression().(BinaryExpression)
+		require.True(t, ok)
+		fc, ok := binExpr.Left().(FunctionCall)
+		require.True(t, ok)
+
+		got, err := root.GetByPath("/statements@4/expression/left")
+		require.NoError(t, err)
+		assert.Same(t, fc, got)
+
+		got, err = root.GetByPath("/statements@2")
+		require.NoError(t, err)
+		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
+	})
+
+	t.Run("costOfGoodsSold/costPerUnit", func(t *testing.T) {
+		def, ok := stmts[4].(Definition)
+		require.True(t, ok)
+		binExpr, ok := def.Expression().(BinaryExpression)
+		require.True(t, ok)
+		fc, ok := binExpr.Right().(FunctionCall)
+		require.True(t, ok)
+
+		got, err := root.GetByPath("/statements@4/expression/right")
+		require.NoError(t, err)
+		assert.Same(t, fc, got)
+
+		got, err = root.GetByPath("/statements@3")
+		require.NoError(t, err)
+		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
+	})
+
+	// ── def netPrice: (costOfGoodsSold + generalExpensesAndSales) / expectedNoOfSales + desiredProfitPerUnit
+	//
+	// AST (precedence: / binds tighter than +):
+	//   Addition(+)
+	//     left: Multiplication(/)
+	//       left: Addition(+)  ← parenthesized
+	//         left:  FC "costOfGoodsSold"
+	//         right: FC "generalExpensesAndSales"
+	//       right: FC "expectedNoOfSales"
+	//     right: FC "desiredProfitPerUnit"
+
+	t.Run("netPrice/costOfGoodsSold", func(t *testing.T) {
+		def, ok := stmts[7].(Definition)
+		require.True(t, ok)
+		outerAdd, ok := def.Expression().(BinaryExpression)
+		require.True(t, ok)
+		div, ok := outerAdd.Left().(BinaryExpression)
+		require.True(t, ok)
+		innerAdd, ok := div.Left().(BinaryExpression)
+		require.True(t, ok)
+		fc, ok := innerAdd.Left().(FunctionCall)
+		require.True(t, ok)
+
+		got, err := root.GetByPath("/statements@7/expression/left/left/left")
+		require.NoError(t, err)
+		assert.Same(t, fc, got)
+
+		got, err = root.GetByPath("/statements@4")
+		require.NoError(t, err)
+		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
+	})
+
+	t.Run("netPrice/generalExpensesAndSales", func(t *testing.T) {
+		def, ok := stmts[7].(Definition)
+		require.True(t, ok)
+		outerAdd, ok := def.Expression().(BinaryExpression)
+		require.True(t, ok)
+		div, ok := outerAdd.Left().(BinaryExpression)
+		require.True(t, ok)
+		innerAdd, ok := div.Left().(BinaryExpression)
+		require.True(t, ok)
+		fc, ok := innerAdd.Right().(FunctionCall)
+		require.True(t, ok)
+
+		got, err := root.GetByPath("/statements@7/expression/left/left/right")
+		require.NoError(t, err)
+		assert.Same(t, fc, got)
+
+		got, err = root.GetByPath("/statements@5")
+		require.NoError(t, err)
+		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
+	})
+
+	t.Run("netPrice/expectedNoOfSales", func(t *testing.T) {
+		def, ok := stmts[7].(Definition)
+		require.True(t, ok)
+		outerAdd, ok := def.Expression().(BinaryExpression)
+		require.True(t, ok)
+		div, ok := outerAdd.Left().(BinaryExpression)
+		require.True(t, ok)
+		fc, ok := div.Right().(FunctionCall)
+		require.True(t, ok)
+
+		got, err := root.GetByPath("/statements@7/expression/left/right")
+		require.NoError(t, err)
+		assert.Same(t, fc, got)
+
+		got, err = root.GetByPath("/statements@2")
+		require.NoError(t, err)
+		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
+	})
+
+	t.Run("netPrice/desiredProfitPerUnit", func(t *testing.T) {
+		def, ok := stmts[7].(Definition)
+		require.True(t, ok)
+		outerAdd, ok := def.Expression().(BinaryExpression)
+		require.True(t, ok)
+		fc, ok := outerAdd.Right().(FunctionCall)
+		require.True(t, ok)
+
+		got, err := root.GetByPath("/statements@7/expression/right")
+		require.NoError(t, err)
+		assert.Same(t, fc, got)
+
+		got, err = root.GetByPath("/statements@6")
+		require.NoError(t, err)
+		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
+	})
+
+	// ── def calcGrossListPrice(net, tax): net / (1 - tax)
+	//
+	// AST:
+	//   Multiplication(/)
+	//     left:  FC "net"
+	//     right: Addition(-)  ← parenthesized
+	//       left:  NumberLiteral "1"
+	//       right: FC "tax"
+
+	t.Run("calcGrossListPrice/net", func(t *testing.T) {
+		def, ok := stmts[9].(Definition)
+		require.True(t, ok)
+		div, ok := def.Expression().(BinaryExpression)
+		require.True(t, ok)
+		fc, ok := div.Left().(FunctionCall)
+		require.True(t, ok)
+
+		got, err := root.GetByPath("/statements@9/expression/left")
+		require.NoError(t, err)
+		assert.Same(t, fc, got)
+
+		got, err = root.GetByPath("/statements@9/args@0")
+		require.NoError(t, err)
+		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
+	})
+
+	t.Run("calcGrossListPrice/tax", func(t *testing.T) {
+		def, ok := stmts[9].(Definition)
+		require.True(t, ok)
+		div, ok := def.Expression().(BinaryExpression)
+		require.True(t, ok)
+		sub, ok := div.Right().(BinaryExpression)
+		require.True(t, ok)
+		fc, ok := sub.Right().(FunctionCall)
+		require.True(t, ok)
+
+		got, err := root.GetByPath("/statements@9/expression/right/right")
+		require.NoError(t, err)
+		assert.Same(t, fc, got)
+
+		got, err = root.GetByPath("/statements@9/args@1")
+		require.NoError(t, err)
+		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
+	})
+
+	// ── calcGrossListPrice(netPrice, vat) ────────────────────────────────────
+
+	t.Run("evaluation/calcGrossListPrice", func(t *testing.T) {
+		eval, ok := stmts[10].(Evaluation)
+		require.True(t, ok)
+		fc, ok := eval.Expression().(FunctionCall)
+		require.True(t, ok)
+
+		got, err := root.GetByPath("/statements@10/expression")
+		require.NoError(t, err)
+		assert.Same(t, fc, got)
+
+		got, err = root.GetByPath("/statements@9")
+		require.NoError(t, err)
+		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
+	})
+
+	t.Run("evaluation/netPrice", func(t *testing.T) {
+		eval, ok := stmts[10].(Evaluation)
+		require.True(t, ok)
+		outerFC, ok := eval.Expression().(FunctionCall)
+		require.True(t, ok)
+		require.Len(t, outerFC.Args(), 2)
+		fc, ok := outerFC.Args()[0].(FunctionCall)
+		require.True(t, ok)
+
+		got, err := root.GetByPath("/statements@10/expression/args@0")
+		require.NoError(t, err)
+		assert.Same(t, fc, got)
+
+		got, err = root.GetByPath("/statements@7")
+		require.NoError(t, err)
+		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
+	})
+
+	t.Run("evaluation/vat", func(t *testing.T) {
+		eval, ok := stmts[10].(Evaluation)
+		require.True(t, ok)
+		outerFC, ok := eval.Expression().(FunctionCall)
+		require.True(t, ok)
+		require.Len(t, outerFC.Args(), 2)
+		fc, ok := outerFC.Args()[1].(FunctionCall)
+		require.True(t, ok)
+
+		got, err := root.GetByPath("/statements@10/expression/args@1")
+		require.NoError(t, err)
+		assert.Same(t, fc, got)
+
+		got, err = root.GetByPath("/statements@8")
+		require.NoError(t, err)
+		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
+	})
+}

--- a/examples/arithmetics/ast_locating_test.go
+++ b/examples/arithmetics/ast_locating_test.go
@@ -1,0 +1,238 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+package arithmetics
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	core "typefox.dev/fastbelt"
+	"typefox.dev/fastbelt/test"
+)
+
+func loadPriceCalcDoc(t *testing.T) *test.Doc {
+	t.Helper()
+	content, err := os.ReadFile("examples/price-calc.calc")
+	require.NoError(t, err)
+	f := test.New(t, CreateServices())
+	doc := f.Parse(string(content))
+	doc.AssertNoParseErrors()
+	doc.AssertNoLinkingErrors()
+	return doc
+}
+
+func mustNodePath(t *testing.T, node core.AstNode) string {
+	t.Helper()
+	path, err := node.NodePath()
+	require.NoError(t, err)
+	return path
+}
+
+// TestNodePath_PriceCalc verifies NodePath() for every FunctionCall (cross-reference)
+// node in price-calc.calc. Each subtest covers one reference site and checks both
+// the referencer (FunctionCall) and the referenced (AbstractDefinition) node paths.
+func TestNodePath_PriceCalc(t *testing.T) {
+	doc := loadPriceCalcDoc(t)
+
+	module := test.MustFindNode[Module](doc)
+	stmts := module.Statements()
+	require.Len(t, stmts, 11)
+
+	// ── def costPerUnit: materialPerUnit + laborPerUnit ───────────────────────
+
+	t.Run("costPerUnit/materialPerUnit", func(t *testing.T) {
+		def, ok := stmts[3].(Definition)
+		require.True(t, ok)
+		binExpr, ok := def.Expression().(BinaryExpression)
+		require.True(t, ok)
+		fc, ok := binExpr.Left().(FunctionCall)
+		require.True(t, ok)
+		assert.Equal(t, "materialPerUnit", fc.Callable().Text())
+		assert.Equal(t, "/statements@3/expression/left", mustNodePath(t, fc))
+		assert.Equal(t, "/statements@0", mustNodePath(t, fc.Callable().Ref(doc.Ctx())))
+	})
+
+	t.Run("costPerUnit/laborPerUnit", func(t *testing.T) {
+		def, ok := stmts[3].(Definition)
+		require.True(t, ok)
+		binExpr, ok := def.Expression().(BinaryExpression)
+		require.True(t, ok)
+		fc, ok := binExpr.Right().(FunctionCall)
+		require.True(t, ok)
+		assert.Equal(t, "/statements@3/expression/right", mustNodePath(t, fc))
+		assert.Equal(t, "laborPerUnit", fc.Callable().Text())
+		assert.Equal(t, "/statements@1", mustNodePath(t, fc.Callable().Ref(doc.Ctx())))
+	})
+
+	// ── def costOfGoodsSold: expectedNoOfSales * costPerUnit ─────────────────
+
+	t.Run("costOfGoodsSold/expectedNoOfSales", func(t *testing.T) {
+		def, ok := stmts[4].(Definition)
+		require.True(t, ok)
+		binExpr, ok := def.Expression().(BinaryExpression)
+		require.True(t, ok)
+		fc, ok := binExpr.Left().(FunctionCall)
+		require.True(t, ok)
+		assert.Equal(t, "/statements@4/expression/left", mustNodePath(t, fc))
+		assert.Equal(t, "expectedNoOfSales", fc.Callable().Text())
+		assert.Equal(t, "/statements@2", mustNodePath(t, fc.Callable().Ref(doc.Ctx())))
+	})
+
+	t.Run("costOfGoodsSold/costPerUnit", func(t *testing.T) {
+		def, ok := stmts[4].(Definition)
+		require.True(t, ok)
+		binExpr, ok := def.Expression().(BinaryExpression)
+		require.True(t, ok)
+		fc, ok := binExpr.Right().(FunctionCall)
+		require.True(t, ok)
+		assert.Equal(t, "/statements@4/expression/right", mustNodePath(t, fc))
+		assert.Equal(t, "costPerUnit", fc.Callable().Text())
+		assert.Equal(t, "/statements@3", mustNodePath(t, fc.Callable().Ref(doc.Ctx())))
+	})
+
+	// ── def netPrice: (costOfGoodsSold + generalExpensesAndSales) / expectedNoOfSales + desiredProfitPerUnit
+	//
+	// AST (precedence: / binds tighter than +):
+	//   Addition(+)
+	//     left: Multiplication(/)
+	//       left: Addition(+)  ← parenthesized
+	//         left:  FC "costOfGoodsSold"
+	//         right: FC "generalExpensesAndSales"
+	//       right: FC "expectedNoOfSales"
+	//     right: FC "desiredProfitPerUnit"
+
+	t.Run("netPrice/costOfGoodsSold", func(t *testing.T) {
+		def, ok := stmts[7].(Definition)
+		require.True(t, ok)
+		outerAdd, ok := def.Expression().(BinaryExpression)
+		require.True(t, ok)
+		div, ok := outerAdd.Left().(BinaryExpression)
+		require.True(t, ok)
+		innerAdd, ok := div.Left().(BinaryExpression)
+		require.True(t, ok)
+		fc, ok := innerAdd.Left().(FunctionCall)
+		require.True(t, ok)
+		assert.Equal(t, "/statements@7/expression/left/left/left", mustNodePath(t, fc))
+		assert.Equal(t, "costOfGoodsSold", fc.Callable().Text())
+		assert.Equal(t, "/statements@4", mustNodePath(t, fc.Callable().Ref(doc.Ctx())))
+	})
+
+	t.Run("netPrice/generalExpensesAndSales", func(t *testing.T) {
+		def, ok := stmts[7].(Definition)
+		require.True(t, ok)
+		outerAdd, ok := def.Expression().(BinaryExpression)
+		require.True(t, ok)
+		div, ok := outerAdd.Left().(BinaryExpression)
+		require.True(t, ok)
+		innerAdd, ok := div.Left().(BinaryExpression)
+		require.True(t, ok)
+		fc, ok := innerAdd.Right().(FunctionCall)
+		require.True(t, ok)
+		assert.Equal(t, "/statements@7/expression/left/left/right", mustNodePath(t, fc))
+		assert.Equal(t, "generalExpensesAndSales", fc.Callable().Text())
+		assert.Equal(t, "/statements@5", mustNodePath(t, fc.Callable().Ref(doc.Ctx())))
+	})
+
+	t.Run("netPrice/expectedNoOfSales", func(t *testing.T) {
+		def, ok := stmts[7].(Definition)
+		require.True(t, ok)
+		outerAdd, ok := def.Expression().(BinaryExpression)
+		require.True(t, ok)
+		div, ok := outerAdd.Left().(BinaryExpression)
+		require.True(t, ok)
+		fc, ok := div.Right().(FunctionCall)
+		require.True(t, ok)
+		assert.Equal(t, "/statements@7/expression/left/right", mustNodePath(t, fc))
+		assert.Equal(t, "expectedNoOfSales", fc.Callable().Text())
+		assert.Equal(t, "/statements@2", mustNodePath(t, fc.Callable().Ref(doc.Ctx())))
+	})
+
+	t.Run("netPrice/desiredProfitPerUnit", func(t *testing.T) {
+		def, ok := stmts[7].(Definition)
+		require.True(t, ok)
+		outerAdd, ok := def.Expression().(BinaryExpression)
+		require.True(t, ok)
+		fc, ok := outerAdd.Right().(FunctionCall)
+		require.True(t, ok)
+		assert.Equal(t, "/statements@7/expression/right", mustNodePath(t, fc))
+		assert.Equal(t, "desiredProfitPerUnit", fc.Callable().Text())
+		assert.Equal(t, "/statements@6", mustNodePath(t, fc.Callable().Ref(doc.Ctx())))
+	})
+
+	// ── def calcGrossListPrice(net, tax): net / (1 - tax)
+	//
+	// AST:
+	//   Multiplication(/)
+	//     left:  FC "net"
+	//     right: Addition(-)  ← parenthesized
+	//       left:  NumberLiteral "1"
+	//       right: FC "tax"
+
+	t.Run("calcGrossListPrice/net", func(t *testing.T) {
+		def, ok := stmts[9].(Definition)
+		require.True(t, ok)
+		div, ok := def.Expression().(BinaryExpression)
+		require.True(t, ok)
+		fc, ok := div.Left().(FunctionCall)
+		require.True(t, ok)
+		assert.Equal(t, "/statements@9/expression/left", mustNodePath(t, fc))
+		assert.Equal(t, "net", fc.Callable().Text())
+		assert.Equal(t, "/statements@9/args@0", mustNodePath(t, fc.Callable().Ref(doc.Ctx())))
+	})
+
+	t.Run("calcGrossListPrice/tax", func(t *testing.T) {
+		def, ok := stmts[9].(Definition)
+		require.True(t, ok)
+		div, ok := def.Expression().(BinaryExpression)
+		require.True(t, ok)
+		sub, ok := div.Right().(BinaryExpression)
+		require.True(t, ok)
+		fc, ok := sub.Right().(FunctionCall)
+		require.True(t, ok)
+		assert.Equal(t, "/statements@9/expression/right/right", mustNodePath(t, fc))
+		assert.Equal(t, "tax", fc.Callable().Text())
+		assert.Equal(t, "/statements@9/args@1", mustNodePath(t, fc.Callable().Ref(doc.Ctx())))
+	})
+
+	// ── calcGrossListPrice(netPrice, vat) ────────────────────────────────────
+
+	t.Run("evaluation/calcGrossListPrice", func(t *testing.T) {
+		eval, ok := stmts[10].(Evaluation)
+		require.True(t, ok)
+		fc, ok := eval.Expression().(FunctionCall)
+		require.True(t, ok)
+		assert.Equal(t, "/statements@10/expression", mustNodePath(t, fc))
+		assert.Equal(t, "calcGrossListPrice", fc.Callable().Text())
+		assert.Equal(t, "/statements@9", mustNodePath(t, fc.Callable().Ref(doc.Ctx())))
+	})
+
+	t.Run("evaluation/netPrice", func(t *testing.T) {
+		eval, ok := stmts[10].(Evaluation)
+		require.True(t, ok)
+		outerFC, ok := eval.Expression().(FunctionCall)
+		require.True(t, ok)
+		require.Len(t, outerFC.Args(), 2)
+		fc, ok := outerFC.Args()[0].(FunctionCall)
+		require.True(t, ok)
+		assert.Equal(t, "/statements@10/expression/args@0", mustNodePath(t, fc))
+		assert.Equal(t, "netPrice", fc.Callable().Text())
+		assert.Equal(t, "/statements@7", mustNodePath(t, fc.Callable().Ref(doc.Ctx())))
+	})
+
+	t.Run("evaluation/vat", func(t *testing.T) {
+		eval, ok := stmts[10].(Evaluation)
+		require.True(t, ok)
+		outerFC, ok := eval.Expression().(FunctionCall)
+		require.True(t, ok)
+		require.Len(t, outerFC.Args(), 2)
+		fc, ok := outerFC.Args()[1].(FunctionCall)
+		require.True(t, ok)
+		assert.Equal(t, "/statements@10/expression/args@1", mustNodePath(t, fc))
+		assert.Equal(t, "vat", fc.Callable().Text())
+		assert.Equal(t, "/statements@8", mustNodePath(t, fc.Callable().Ref(doc.Ctx())))
+	})
+}

--- a/examples/arithmetics/ast_locating_test.go
+++ b/examples/arithmetics/ast_locating_test.go
@@ -29,9 +29,9 @@ func loadPriceCalcDoc(t *testing.T) *test.Doc {
 
 func mustNodePath(t *testing.T, node core.AstNode) string {
 	t.Helper()
-	path, err := node.NodePath()
+	path, err := core.NodePath(node)
 	require.NoError(t, err)
-	return path
+	return path.String()
 }
 
 // TestNodePath_PriceCalc verifies NodePath() for every FunctionCall (cross-reference)
@@ -258,8 +258,8 @@ func TestNodePath_PriceCalc(t *testing.T) {
 		field, index = expr.ContainmentData()
 		expr.SetContainer(&def, field, index)
 
-		path, err := expr.NodePath()
-		assert.Zero(t, path)
+		path, err := core.NodePath(&expr)
+		assert.Zero(t, path.String())
 		fmt.Println(err)
 		assert.ErrorContains(
 			t, err,
@@ -280,8 +280,8 @@ func TestNodePath_PriceCalc(t *testing.T) {
 		field, index := expr.ContainmentData()
 		expr.SetContainer(&def, field, index)
 
-		path, err := expr.NodePath()
-		assert.Zero(t, path)
+		path, err := core.NodePath(&expr)
+		assert.Zero(t, path.String())
 		fmt.Println(err)
 		assert.ErrorContains(
 			t, err,
@@ -311,11 +311,11 @@ func TestGetByPath_PriceCalc(t *testing.T) {
 		fc, ok := binExpr.Left().(FunctionCall)
 		require.True(t, ok)
 
-		got, err := root.GetByPath("/statements@3/expression/left")
+		got, err := core.GetByPath(root, "/statements@3/expression/left")
 		require.NoError(t, err)
 		assert.Same(t, fc, got)
 
-		got, err = root.GetByPath("/statements@0")
+		got, err = core.GetByPath(root, "/statements@0")
 		require.NoError(t, err)
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
 	})
@@ -328,11 +328,11 @@ func TestGetByPath_PriceCalc(t *testing.T) {
 		fc, ok := binExpr.Right().(FunctionCall)
 		require.True(t, ok)
 
-		got, err := root.GetByPath("/statements@3/expression/right")
+		got, err := core.GetByPath(root, "/statements@3/expression/right")
 		require.NoError(t, err)
 		assert.Same(t, fc, got)
 
-		got, err = root.GetByPath("/statements@1")
+		got, err = core.GetByPath(root, "/statements@1")
 		require.NoError(t, err)
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
 	})
@@ -347,11 +347,11 @@ func TestGetByPath_PriceCalc(t *testing.T) {
 		fc, ok := binExpr.Left().(FunctionCall)
 		require.True(t, ok)
 
-		got, err := root.GetByPath("/statements@4/expression/left")
+		got, err := core.GetByPath(root, "/statements@4/expression/left")
 		require.NoError(t, err)
 		assert.Same(t, fc, got)
 
-		got, err = root.GetByPath("/statements@2")
+		got, err = core.GetByPath(root, "/statements@2")
 		require.NoError(t, err)
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
 	})
@@ -364,11 +364,11 @@ func TestGetByPath_PriceCalc(t *testing.T) {
 		fc, ok := binExpr.Right().(FunctionCall)
 		require.True(t, ok)
 
-		got, err := root.GetByPath("/statements@4/expression/right")
+		got, err := core.GetByPath(root, "/statements@4/expression/right")
 		require.NoError(t, err)
 		assert.Same(t, fc, got)
 
-		got, err = root.GetByPath("/statements@3")
+		got, err = core.GetByPath(root, "/statements@3")
 		require.NoError(t, err)
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
 	})
@@ -396,11 +396,11 @@ func TestGetByPath_PriceCalc(t *testing.T) {
 		fc, ok := innerAdd.Left().(FunctionCall)
 		require.True(t, ok)
 
-		got, err := root.GetByPath("/statements@7/expression/left/left/left")
+		got, err := core.GetByPath(root, "/statements@7/expression/left/left/left")
 		require.NoError(t, err)
 		assert.Same(t, fc, got)
 
-		got, err = root.GetByPath("/statements@4")
+		got, err = core.GetByPath(root, "/statements@4")
 		require.NoError(t, err)
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
 	})
@@ -417,11 +417,11 @@ func TestGetByPath_PriceCalc(t *testing.T) {
 		fc, ok := innerAdd.Right().(FunctionCall)
 		require.True(t, ok)
 
-		got, err := root.GetByPath("/statements@7/expression/left/left/right")
+		got, err := core.GetByPath(root, "/statements@7/expression/left/left/right")
 		require.NoError(t, err)
 		assert.Same(t, fc, got)
 
-		got, err = root.GetByPath("/statements@5")
+		got, err = core.GetByPath(root, "/statements@5")
 		require.NoError(t, err)
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
 	})
@@ -436,11 +436,11 @@ func TestGetByPath_PriceCalc(t *testing.T) {
 		fc, ok := div.Right().(FunctionCall)
 		require.True(t, ok)
 
-		got, err := root.GetByPath("/statements@7/expression/left/right")
+		got, err := core.GetByPath(root, "/statements@7/expression/left/right")
 		require.NoError(t, err)
 		assert.Same(t, fc, got)
 
-		got, err = root.GetByPath("/statements@2")
+		got, err = core.GetByPath(root, "/statements@2")
 		require.NoError(t, err)
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
 	})
@@ -453,11 +453,11 @@ func TestGetByPath_PriceCalc(t *testing.T) {
 		fc, ok := outerAdd.Right().(FunctionCall)
 		require.True(t, ok)
 
-		got, err := root.GetByPath("/statements@7/expression/right")
+		got, err := core.GetByPath(root, "/statements@7/expression/right")
 		require.NoError(t, err)
 		assert.Same(t, fc, got)
 
-		got, err = root.GetByPath("/statements@6")
+		got, err = core.GetByPath(root, "/statements@6")
 		require.NoError(t, err)
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
 	})
@@ -479,11 +479,11 @@ func TestGetByPath_PriceCalc(t *testing.T) {
 		fc, ok := div.Left().(FunctionCall)
 		require.True(t, ok)
 
-		got, err := root.GetByPath("/statements@9/expression/left")
+		got, err := core.GetByPath(root, "/statements@9/expression/left")
 		require.NoError(t, err)
 		assert.Same(t, fc, got)
 
-		got, err = root.GetByPath("/statements@9/args@0")
+		got, err = core.GetByPath(root, "/statements@9/args@0")
 		require.NoError(t, err)
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
 	})
@@ -498,11 +498,11 @@ func TestGetByPath_PriceCalc(t *testing.T) {
 		fc, ok := sub.Right().(FunctionCall)
 		require.True(t, ok)
 
-		got, err := root.GetByPath("/statements@9/expression/right/right")
+		got, err := core.GetByPath(root, "/statements@9/expression/right/right")
 		require.NoError(t, err)
 		assert.Same(t, fc, got)
 
-		got, err = root.GetByPath("/statements@9/args@1")
+		got, err = core.GetByPath(root, "/statements@9/args@1")
 		require.NoError(t, err)
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
 	})
@@ -515,11 +515,11 @@ func TestGetByPath_PriceCalc(t *testing.T) {
 		fc, ok := eval.Expression().(FunctionCall)
 		require.True(t, ok)
 
-		got, err := root.GetByPath("/statements@10/expression")
+		got, err := core.GetByPath(root, "/statements@10/expression")
 		require.NoError(t, err)
 		assert.Same(t, fc, got)
 
-		got, err = root.GetByPath("/statements@9")
+		got, err = core.GetByPath(root, "/statements@9")
 		require.NoError(t, err)
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
 	})
@@ -533,11 +533,11 @@ func TestGetByPath_PriceCalc(t *testing.T) {
 		fc, ok := outerFC.Args()[0].(FunctionCall)
 		require.True(t, ok)
 
-		got, err := root.GetByPath("/statements@10/expression/args@0")
+		got, err := core.GetByPath(root, "/statements@10/expression/args@0")
 		require.NoError(t, err)
 		assert.Same(t, fc, got)
 
-		got, err = root.GetByPath("/statements@7")
+		got, err = core.GetByPath(root, "/statements@7")
 		require.NoError(t, err)
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
 	})
@@ -551,27 +551,27 @@ func TestGetByPath_PriceCalc(t *testing.T) {
 		fc, ok := outerFC.Args()[1].(FunctionCall)
 		require.True(t, ok)
 
-		got, err := root.GetByPath("/statements@10/expression/args@1")
+		got, err := core.GetByPath(root, "/statements@10/expression/args@1")
 		require.NoError(t, err)
 		assert.Same(t, fc, got)
 
-		got, err = root.GetByPath("/statements@8")
+		got, err = core.GetByPath(root, "/statements@8")
 		require.NoError(t, err)
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
 	})
 
 	t.Run("errorReporting/no-such-field", func(t *testing.T) {
-		_, err := root.GetByPath("/statements@3/expressions/left")
+		_, err := core.GetByPath(root, "/statements@3/expressions/left")
 		assert.ErrorContains(t, err, "DefinitionImpl.GetByPath: field 'expressions' does not exist in node '/statements@3' of type 'Definition'")
 	})
 
 	t.Run("errorReporting/field-is-primitive", func(t *testing.T) {
-		_, err := root.GetByPath("/statements@0/name")
+		_, err := core.GetByPath(root, "/statements@0/name")
 		assert.ErrorContains(t, err, "DefinitionImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
 	})
 
 	t.Run("errorReporting/field-is-reference", func(t *testing.T) {
-		_, err := root.GetByPath("/statements@10/expression/callable")
+		_, err := core.GetByPath(root, "/statements@10/expression/callable")
 		assert.ErrorContains(t, err, "FunctionCallImpl.GetByPath: field 'callable' is a cross-reference instead of a container field")
 	})
 
@@ -589,35 +589,35 @@ func TestGetByPath_PriceCalc(t *testing.T) {
 		// set the tested field to 'nil'
 		def.expression = nil
 
-		_, err := module.GetByPath("/statements@0/expression/left")
+		_, err := core.GetByPath(&module, "/statements@0/expression/left")
 		assert.ErrorContains(t, err, "DefinitionImpl.GetByPath: field 'expression' is nil in node '/statements@0'")
 	})
 
 	t.Run("errorReporting/slice-index-out-of-bound-1", func(t *testing.T) {
-		_, err := root.GetByPath("/statements@15/expression")
+		_, err := core.GetByPath(root, "/statements@15/expression")
 		assert.ErrorContains(t, err, "ModuleImpl.GetByPath: index 15 exceeds length of slice in 'statements' (length=11) in node ''")
 	})
 
 	t.Run("errorReporting/slice-index-out-of-bound-2", func(t *testing.T) {
-		_, err := root.GetByPath("/statements@10/expression/args@7/expression")
+		_, err := core.GetByPath(root, "/statements@10/expression/args@7/expression")
 		assert.ErrorContains(t, err, "FunctionCallImpl.GetByPath: index 7 exceeds length of slice in 'args' (length=2) in node '/statements@10/expression'")
 	})
 
 	t.Run("errorReporting/slice-item-is-nil", func(t *testing.T) {
-		expr, err := root.GetByPath("/statements@10/expression/")
+		expr, err := core.GetByPath(root, "/statements@10/expression/")
 		require.NoError(t, err)
 		fc, ok := expr.(FunctionCall)
 		require.True(t, ok)
 
 		// shamelessly manipulate the shared ast and add a 'nil' item, don't want to copy everything right now; shouldn't hurt
 		fc.SetArgsItem(nil)
-		_, err = root.GetByPath("/statements@10/expression/args@2/expression")
+		_, err = core.GetByPath(root, "/statements@10/expression/args@2/expression")
 
 		assert.ErrorContains(t, err, "FunctionCallImpl.GetByPath: item 2 of slice in field 'args' is nil in node '/statements@10/expression'")
 	})
 
 	t.Run("errorReporting/slice-index-typo", func(t *testing.T) {
-		_, err := root.GetByPath("/statements@1a/expression")
-		assert.ErrorContains(t, err, "ModuleImpl.GetByPath: index '1a' is not a valid uint: strconv.Atoi: parsing \"1a\": invalid syntax")
+		_, err := core.GetByPath(root, "/statements@1a/expression")
+		assert.ErrorContains(t, err, "ParsePath: index '1a' is not a valid uint: strconv.Atoi: parsing \"1a\": invalid syntax")
 	})
 }

--- a/examples/arithmetics/ast_locating_test.go
+++ b/examples/arithmetics/ast_locating_test.go
@@ -16,11 +16,11 @@ import (
 	"typefox.dev/fastbelt/test"
 )
 
-func loadPriceCalcDoc(t *testing.T) *test.Doc {
-	t.Helper()
+func loadPriceCalcDoc(tb testing.TB) *test.Doc {
+	tb.Helper()
 	content, err := os.ReadFile("examples/price-calc.calc")
-	require.NoError(t, err)
-	f := test.New(t, CreateServices())
+	require.NoError(tb, err)
+	f := test.New(tb, CreateServices())
 	doc := f.Parse(string(content))
 	doc.AssertNoParseErrors()
 	doc.AssertNoLinkingErrors()
@@ -34,10 +34,10 @@ func mustConvert[T core.AstNode](t *testing.T, node core.AstNode) T {
 	return converted
 }
 
-// TestNodePath_PriceCalc verifies NodePath() for every FunctionCall (cross-reference)
+// TestPathOf verifies [core.PathOf] for every FunctionCall (cross-reference)
 // node in price-calc.calc. Each subtest covers one reference site and checks both
 // the referencer (FunctionCall) and the referenced (AbstractDefinition) node paths.
-func TestNodePath_PriceCalc(t *testing.T) {
+func TestPathOf(t *testing.T) {
 	doc := loadPriceCalcDoc(t)
 
 	module := test.MustFindNode[Module](doc)
@@ -252,12 +252,12 @@ func TestNodePath_PriceCalc(t *testing.T) {
 	})
 }
 
-// TestResolve_PriceCalc is the inverse of TestNodePath_PriceCalc: for each of the 13
+// TestResolve is the inverse of TestPathOf: for each of the 13
 // FunctionCall cross-reference sites in price-calc.calc, it resolves the hardcoded path
-// string back to an AST node via Resolve and asserts pointer identity with the node
+// string back to an AST node via [core.Resolve] and asserts pointer identity with the node
 // obtained by direct AST navigation. Both the referencer (FunctionCall) and the
 // referenced (AbstractDefinition) are covered per subtest.
-func TestResolve_PriceCalc(t *testing.T) {
+func TestResolve(t *testing.T) {
 	doc := loadPriceCalcDoc(t)
 	root := doc.Root()
 	module := test.MustFindNode[Module](doc)

--- a/examples/arithmetics/ast_locating_test.go
+++ b/examples/arithmetics/ast_locating_test.go
@@ -264,9 +264,9 @@ func TestResolve(t *testing.T) {
 	stmts := module.Statements()
 	require.Len(t, stmts, 11)
 
-	mustResolve := func(path string, node core.AstNode) core.AstNode {
+	mustResolve := func(node core.AstNode, path string) core.AstNode {
 		t.Helper()
-		child, err := core.Resolve(path, node)
+		child, err := core.Resolve(node, path)
 		require.NoError(t, err)
 		return child
 	}
@@ -277,10 +277,10 @@ func TestResolve(t *testing.T) {
 		binExpr := mustConvert[BinaryExpression](t, def.Expression())
 		fc := mustConvert[FunctionCall](t, binExpr.Left())
 
-		left := mustResolve("/statements@3/expression/left", root)
+		left := mustResolve(root, "/statements@3/expression/left")
 		assert.Same(t, fc, left)
 
-		statement := mustResolve("/statements@0", root)
+		statement := mustResolve(root, "/statements@0")
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), statement)
 	})
 
@@ -289,10 +289,10 @@ func TestResolve(t *testing.T) {
 		binExpr := mustConvert[BinaryExpression](t, def.Expression())
 		fc := mustConvert[FunctionCall](t, binExpr.Right())
 
-		right := mustResolve("/statements@3/expression/right", root)
+		right := mustResolve(root, "/statements@3/expression/right")
 		assert.Same(t, fc, right)
 
-		statement := mustResolve("/statements@1", root)
+		statement := mustResolve(root, "/statements@1")
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), statement)
 	})
 
@@ -303,10 +303,10 @@ func TestResolve(t *testing.T) {
 		binExpr := mustConvert[BinaryExpression](t, def.Expression())
 		fc := mustConvert[FunctionCall](t, binExpr.Left())
 
-		left := mustResolve("/statements@4/expression/left", root)
+		left := mustResolve(root, "/statements@4/expression/left")
 		assert.Same(t, fc, left)
 
-		statement := mustResolve("/statements@2", root)
+		statement := mustResolve(root, "/statements@2")
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), statement)
 	})
 
@@ -315,10 +315,10 @@ func TestResolve(t *testing.T) {
 		binExpr := mustConvert[BinaryExpression](t, def.Expression())
 		fc := mustConvert[FunctionCall](t, binExpr.Right())
 
-		right := mustResolve("/statements@4/expression/right", root)
+		right := mustResolve(root, "/statements@4/expression/right")
 		assert.Same(t, fc, right)
 
-		statement := mustResolve("/statements@3", root)
+		statement := mustResolve(root, "/statements@3")
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), statement)
 	})
 
@@ -340,10 +340,10 @@ func TestResolve(t *testing.T) {
 		innerAdd := mustConvert[BinaryExpression](t, div.Left())
 		fc := mustConvert[FunctionCall](t, innerAdd.Left())
 
-		left := mustResolve("/statements@7/expression/left/left/left", root)
+		left := mustResolve(root, "/statements@7/expression/left/left/left")
 		assert.Same(t, fc, left)
 
-		statement := mustResolve("/statements@4", root)
+		statement := mustResolve(root, "/statements@4")
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), statement)
 	})
 
@@ -354,10 +354,10 @@ func TestResolve(t *testing.T) {
 		innerAdd := mustConvert[BinaryExpression](t, div.Left())
 		fc := mustConvert[FunctionCall](t, innerAdd.Right())
 
-		right := mustResolve("/statements@7/expression/left/left/right", root)
+		right := mustResolve(root, "/statements@7/expression/left/left/right")
 		assert.Same(t, fc, right)
 
-		statement := mustResolve("/statements@5", root)
+		statement := mustResolve(root, "/statements@5")
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), statement)
 	})
 
@@ -367,10 +367,10 @@ func TestResolve(t *testing.T) {
 		div := mustConvert[BinaryExpression](t, outerAdd.Left())
 		fc := mustConvert[FunctionCall](t, div.Right())
 
-		right := mustResolve("/statements@7/expression/left/right", root)
+		right := mustResolve(root, "/statements@7/expression/left/right")
 		assert.Same(t, fc, right)
 
-		statement := mustResolve("/statements@2", root)
+		statement := mustResolve(root, "/statements@2")
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), statement)
 	})
 
@@ -379,10 +379,10 @@ func TestResolve(t *testing.T) {
 		outerAdd := mustConvert[BinaryExpression](t, def.Expression())
 		fc := mustConvert[FunctionCall](t, outerAdd.Right())
 
-		right := mustResolve("/statements@7/expression/right", root)
+		right := mustResolve(root, "/statements@7/expression/right")
 		assert.Same(t, fc, right)
 
-		statement := mustResolve("/statements@6", root)
+		statement := mustResolve(root, "/statements@6")
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), statement)
 	})
 
@@ -400,10 +400,10 @@ func TestResolve(t *testing.T) {
 		div := mustConvert[BinaryExpression](t, def.Expression())
 		fc := mustConvert[FunctionCall](t, div.Left())
 
-		left := mustResolve("/statements@9/expression/left", root)
+		left := mustResolve(root, "/statements@9/expression/left")
 		assert.Same(t, fc, left)
 
-		arg := mustResolve("/statements@9/args@0", root)
+		arg := mustResolve(root, "/statements@9/args@0")
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), arg)
 	})
 
@@ -413,10 +413,10 @@ func TestResolve(t *testing.T) {
 		sub := mustConvert[BinaryExpression](t, div.Right())
 		fc := mustConvert[FunctionCall](t, sub.Right())
 
-		right := mustResolve("/statements@9/expression/right/right", root)
+		right := mustResolve(root, "/statements@9/expression/right/right")
 		assert.Same(t, fc, right)
 
-		arg := mustResolve("/statements@9/args@1", root)
+		arg := mustResolve(root, "/statements@9/args@1")
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), arg)
 	})
 
@@ -426,10 +426,10 @@ func TestResolve(t *testing.T) {
 		eval := mustConvert[Evaluation](t, stmts[10])
 		fc := mustConvert[FunctionCall](t, eval.Expression())
 
-		expression := mustResolve("/statements@10/expression", root)
+		expression := mustResolve(root, "/statements@10/expression")
 		assert.Same(t, fc, expression)
 
-		statement := mustResolve("/statements@9", root)
+		statement := mustResolve(root, "/statements@9")
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), statement)
 	})
 
@@ -439,10 +439,10 @@ func TestResolve(t *testing.T) {
 		require.Len(t, outerFC.Args(), 2)
 		fc := mustConvert[FunctionCall](t, outerFC.Args()[0])
 
-		arg := mustResolve("/statements@10/expression/args@0", root)
+		arg := mustResolve(root, "/statements@10/expression/args@0")
 		assert.Same(t, fc, arg)
 
-		statement := mustResolve("/statements@7", root)
+		statement := mustResolve(root, "/statements@7")
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), statement)
 	})
 
@@ -452,25 +452,25 @@ func TestResolve(t *testing.T) {
 		require.Len(t, outerFC.Args(), 2)
 		fc := mustConvert[FunctionCall](t, outerFC.Args()[1])
 
-		arg := mustResolve("/statements@10/expression/args@1", root)
+		arg := mustResolve(root, "/statements@10/expression/args@1")
 		assert.Same(t, fc, arg)
 
-		statement := mustResolve("/statements@8", root)
+		statement := mustResolve(root, "/statements@8")
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), statement)
 	})
 
 	t.Run("errorReporting/no-such-field", func(t *testing.T) {
-		_, err := core.Resolve("/statements@3/expressions/left", root)
+		_, err := core.Resolve(root, "/statements@3/expressions/left")
 		assert.ErrorContains(t, err, "DefinitionImpl.Resolve: field 'expressions' does not exist in node '/statements@3' of type 'Definition'")
 	})
 
 	t.Run("errorReporting/field-is-primitive", func(t *testing.T) {
-		_, err := core.Resolve("/statements@0/name", root)
+		_, err := core.Resolve(root, "/statements@0/name")
 		assert.ErrorContains(t, err, "DefinitionImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
 	})
 
 	t.Run("errorReporting/field-is-reference", func(t *testing.T) {
-		_, err := core.Resolve("/statements@10/expression/callable", root)
+		_, err := core.Resolve(root, "/statements@10/expression/callable")
 		assert.ErrorContains(t, err, "FunctionCallImpl.Resolve: field 'callable' is a cross-reference instead of a container field")
 	})
 
@@ -487,34 +487,34 @@ func TestResolve(t *testing.T) {
 		// set the tested field to 'nil'
 		def.expression = nil
 
-		_, err := core.Resolve("/statements@0/expression/left", &module)
+		_, err := core.Resolve(&module, "/statements@0/expression/left")
 		assert.ErrorContains(t, err, "DefinitionImpl.Resolve: field 'expression' is nil in node '/statements@0'")
 	})
 
 	t.Run("errorReporting/slice-index-out-of-bound-1", func(t *testing.T) {
-		_, err := core.Resolve("/statements@15/expression", root)
+		_, err := core.Resolve(root, "/statements@15/expression")
 		assert.ErrorContains(t, err, "ModuleImpl.Resolve: index 15 exceeds length of slice in 'statements' (length=11) in node ''")
 	})
 
 	t.Run("errorReporting/slice-index-out-of-bound-2", func(t *testing.T) {
-		_, err := core.Resolve("/statements@10/expression/args@7/expression", root)
+		_, err := core.Resolve(root, "/statements@10/expression/args@7/expression")
 		assert.ErrorContains(t, err, "FunctionCallImpl.Resolve: index 7 exceeds length of slice in 'args' (length=2) in node '/statements@10/expression'")
 	})
 
 	t.Run("errorReporting/slice-item-is-nil", func(t *testing.T) {
-		expr, err := core.Resolve("/statements@10/expression/", root)
+		expr, err := core.Resolve(root, "/statements@10/expression/")
 		require.NoError(t, err)
 		fc := mustConvert[FunctionCall](t, expr)
 
 		// shamelessly manipulate the shared ast and add a 'nil' item, don't want to copy everything right now; shouldn't hurt
 		fc.SetArgsItem(nil)
-		_, err = core.Resolve("/statements@10/expression/args@2/expression", root)
+		_, err = core.Resolve(root, "/statements@10/expression/args@2/expression")
 
 		assert.ErrorContains(t, err, "FunctionCallImpl.Resolve: item 2 of slice in field 'args' is nil in node '/statements@10/expression'")
 	})
 
 	t.Run("errorReporting/slice-index-typo", func(t *testing.T) {
-		_, err := core.Resolve("/statements@1a/expression", root)
+		_, err := core.Resolve(root, "/statements@1a/expression")
 		assert.ErrorContains(t, err, "parsePath: index '1a' is not a valid uint: strconv.Atoi: parsing \"1a\": invalid syntax")
 	})
 }

--- a/examples/arithmetics/ast_locating_test.go
+++ b/examples/arithmetics/ast_locating_test.go
@@ -222,7 +222,7 @@ func TestNodePath_PriceCalc(t *testing.T) {
 		expr.SetContainer(&def, field, index)
 
 		path, err := core.PathOf(&expr)
-		assert.Zero(t, path.String())
+		assert.Nil(t, path)
 		fmt.Println(err)
 		assert.ErrorContains(
 			t, err,
@@ -244,7 +244,7 @@ func TestNodePath_PriceCalc(t *testing.T) {
 		expr.SetContainer(&def, field, index)
 
 		path, err := core.PathOf(&expr)
-		assert.Zero(t, path.String())
+		assert.Nil(t, path)
 		fmt.Println(err)
 		assert.ErrorContains(
 			t, err,

--- a/examples/arithmetics/ast_locating_test.go
+++ b/examples/arithmetics/ast_locating_test.go
@@ -27,9 +27,9 @@ func loadPriceCalcDoc(t *testing.T) *test.Doc {
 	return doc
 }
 
-func mustNodePath(t *testing.T, node core.AstNode) string {
+func mustFragmentGet(t *testing.T, node core.AstNode) string {
 	t.Helper()
-	path, err := core.NodePath(node)
+	path, err := core.PathOf(node)
 	require.NoError(t, err)
 	return path.String()
 }
@@ -53,9 +53,9 @@ func TestNodePath_PriceCalc(t *testing.T) {
 		require.True(t, ok)
 		fc, ok := binExpr.Left().(FunctionCall)
 		require.True(t, ok)
-		assert.Equal(t, "/statements@3/expression/left", mustNodePath(t, fc))
+		assert.Equal(t, "/statements@3/expression/left", mustFragmentGet(t, fc))
 		assert.Equal(t, "materialPerUnit", fc.Callable().Text())
-		assert.Equal(t, "/statements@0", mustNodePath(t, fc.Callable().Ref(doc.Ctx())))
+		assert.Equal(t, "/statements@0", mustFragmentGet(t, fc.Callable().Ref(doc.Ctx())))
 	})
 
 	t.Run("costPerUnit/laborPerUnit", func(t *testing.T) {
@@ -65,9 +65,9 @@ func TestNodePath_PriceCalc(t *testing.T) {
 		require.True(t, ok)
 		fc, ok := binExpr.Right().(FunctionCall)
 		require.True(t, ok)
-		assert.Equal(t, "/statements@3/expression/right", mustNodePath(t, fc))
+		assert.Equal(t, "/statements@3/expression/right", mustFragmentGet(t, fc))
 		assert.Equal(t, "laborPerUnit", fc.Callable().Text())
-		assert.Equal(t, "/statements@1", mustNodePath(t, fc.Callable().Ref(doc.Ctx())))
+		assert.Equal(t, "/statements@1", mustFragmentGet(t, fc.Callable().Ref(doc.Ctx())))
 	})
 
 	// ── def costOfGoodsSold: expectedNoOfSales * costPerUnit ─────────────────
@@ -79,9 +79,9 @@ func TestNodePath_PriceCalc(t *testing.T) {
 		require.True(t, ok)
 		fc, ok := binExpr.Left().(FunctionCall)
 		require.True(t, ok)
-		assert.Equal(t, "/statements@4/expression/left", mustNodePath(t, fc))
+		assert.Equal(t, "/statements@4/expression/left", mustFragmentGet(t, fc))
 		assert.Equal(t, "expectedNoOfSales", fc.Callable().Text())
-		assert.Equal(t, "/statements@2", mustNodePath(t, fc.Callable().Ref(doc.Ctx())))
+		assert.Equal(t, "/statements@2", mustFragmentGet(t, fc.Callable().Ref(doc.Ctx())))
 	})
 
 	t.Run("costOfGoodsSold/costPerUnit", func(t *testing.T) {
@@ -91,9 +91,9 @@ func TestNodePath_PriceCalc(t *testing.T) {
 		require.True(t, ok)
 		fc, ok := binExpr.Right().(FunctionCall)
 		require.True(t, ok)
-		assert.Equal(t, "/statements@4/expression/right", mustNodePath(t, fc))
+		assert.Equal(t, "/statements@4/expression/right", mustFragmentGet(t, fc))
 		assert.Equal(t, "costPerUnit", fc.Callable().Text())
-		assert.Equal(t, "/statements@3", mustNodePath(t, fc.Callable().Ref(doc.Ctx())))
+		assert.Equal(t, "/statements@3", mustFragmentGet(t, fc.Callable().Ref(doc.Ctx())))
 	})
 
 	// ── def netPrice: (costOfGoodsSold + generalExpensesAndSales) / expectedNoOfSales + desiredProfitPerUnit
@@ -118,9 +118,9 @@ func TestNodePath_PriceCalc(t *testing.T) {
 		require.True(t, ok)
 		fc, ok := innerAdd.Left().(FunctionCall)
 		require.True(t, ok)
-		assert.Equal(t, "/statements@7/expression/left/left/left", mustNodePath(t, fc))
+		assert.Equal(t, "/statements@7/expression/left/left/left", mustFragmentGet(t, fc))
 		assert.Equal(t, "costOfGoodsSold", fc.Callable().Text())
-		assert.Equal(t, "/statements@4", mustNodePath(t, fc.Callable().Ref(doc.Ctx())))
+		assert.Equal(t, "/statements@4", mustFragmentGet(t, fc.Callable().Ref(doc.Ctx())))
 	})
 
 	t.Run("netPrice/generalExpensesAndSales", func(t *testing.T) {
@@ -134,9 +134,9 @@ func TestNodePath_PriceCalc(t *testing.T) {
 		require.True(t, ok)
 		fc, ok := innerAdd.Right().(FunctionCall)
 		require.True(t, ok)
-		assert.Equal(t, "/statements@7/expression/left/left/right", mustNodePath(t, fc))
+		assert.Equal(t, "/statements@7/expression/left/left/right", mustFragmentGet(t, fc))
 		assert.Equal(t, "generalExpensesAndSales", fc.Callable().Text())
-		assert.Equal(t, "/statements@5", mustNodePath(t, fc.Callable().Ref(doc.Ctx())))
+		assert.Equal(t, "/statements@5", mustFragmentGet(t, fc.Callable().Ref(doc.Ctx())))
 	})
 
 	t.Run("netPrice/expectedNoOfSales", func(t *testing.T) {
@@ -148,9 +148,9 @@ func TestNodePath_PriceCalc(t *testing.T) {
 		require.True(t, ok)
 		fc, ok := div.Right().(FunctionCall)
 		require.True(t, ok)
-		assert.Equal(t, "/statements@7/expression/left/right", mustNodePath(t, fc))
+		assert.Equal(t, "/statements@7/expression/left/right", mustFragmentGet(t, fc))
 		assert.Equal(t, "expectedNoOfSales", fc.Callable().Text())
-		assert.Equal(t, "/statements@2", mustNodePath(t, fc.Callable().Ref(doc.Ctx())))
+		assert.Equal(t, "/statements@2", mustFragmentGet(t, fc.Callable().Ref(doc.Ctx())))
 	})
 
 	t.Run("netPrice/desiredProfitPerUnit", func(t *testing.T) {
@@ -160,9 +160,9 @@ func TestNodePath_PriceCalc(t *testing.T) {
 		require.True(t, ok)
 		fc, ok := outerAdd.Right().(FunctionCall)
 		require.True(t, ok)
-		assert.Equal(t, "/statements@7/expression/right", mustNodePath(t, fc))
+		assert.Equal(t, "/statements@7/expression/right", mustFragmentGet(t, fc))
 		assert.Equal(t, "desiredProfitPerUnit", fc.Callable().Text())
-		assert.Equal(t, "/statements@6", mustNodePath(t, fc.Callable().Ref(doc.Ctx())))
+		assert.Equal(t, "/statements@6", mustFragmentGet(t, fc.Callable().Ref(doc.Ctx())))
 	})
 
 	// ── def calcGrossListPrice(net, tax): net / (1 - tax)
@@ -181,9 +181,9 @@ func TestNodePath_PriceCalc(t *testing.T) {
 		require.True(t, ok)
 		fc, ok := div.Left().(FunctionCall)
 		require.True(t, ok)
-		assert.Equal(t, "/statements@9/expression/left", mustNodePath(t, fc))
+		assert.Equal(t, "/statements@9/expression/left", mustFragmentGet(t, fc))
 		assert.Equal(t, "net", fc.Callable().Text())
-		assert.Equal(t, "/statements@9/args@0", mustNodePath(t, fc.Callable().Ref(doc.Ctx())))
+		assert.Equal(t, "/statements@9/args@0", mustFragmentGet(t, fc.Callable().Ref(doc.Ctx())))
 	})
 
 	t.Run("calcGrossListPrice/tax", func(t *testing.T) {
@@ -195,9 +195,9 @@ func TestNodePath_PriceCalc(t *testing.T) {
 		require.True(t, ok)
 		fc, ok := sub.Right().(FunctionCall)
 		require.True(t, ok)
-		assert.Equal(t, "/statements@9/expression/right/right", mustNodePath(t, fc))
+		assert.Equal(t, "/statements@9/expression/right/right", mustFragmentGet(t, fc))
 		assert.Equal(t, "tax", fc.Callable().Text())
-		assert.Equal(t, "/statements@9/args@1", mustNodePath(t, fc.Callable().Ref(doc.Ctx())))
+		assert.Equal(t, "/statements@9/args@1", mustFragmentGet(t, fc.Callable().Ref(doc.Ctx())))
 	})
 
 	// ── calcGrossListPrice(netPrice, vat) ────────────────────────────────────
@@ -207,9 +207,9 @@ func TestNodePath_PriceCalc(t *testing.T) {
 		require.True(t, ok)
 		fc, ok := eval.Expression().(FunctionCall)
 		require.True(t, ok)
-		assert.Equal(t, "/statements@10/expression", mustNodePath(t, fc))
+		assert.Equal(t, "/statements@10/expression", mustFragmentGet(t, fc))
 		assert.Equal(t, "calcGrossListPrice", fc.Callable().Text())
-		assert.Equal(t, "/statements@9", mustNodePath(t, fc.Callable().Ref(doc.Ctx())))
+		assert.Equal(t, "/statements@9", mustFragmentGet(t, fc.Callable().Ref(doc.Ctx())))
 	})
 
 	t.Run("evaluation/netPrice", func(t *testing.T) {
@@ -220,9 +220,9 @@ func TestNodePath_PriceCalc(t *testing.T) {
 		require.Len(t, outerFC.Args(), 2)
 		fc, ok := outerFC.Args()[0].(FunctionCall)
 		require.True(t, ok)
-		assert.Equal(t, "/statements@10/expression/args@0", mustNodePath(t, fc))
+		assert.Equal(t, "/statements@10/expression/args@0", mustFragmentGet(t, fc))
 		assert.Equal(t, "netPrice", fc.Callable().Text())
-		assert.Equal(t, "/statements@7", mustNodePath(t, fc.Callable().Ref(doc.Ctx())))
+		assert.Equal(t, "/statements@7", mustFragmentGet(t, fc.Callable().Ref(doc.Ctx())))
 	})
 
 	t.Run("evaluation/vat", func(t *testing.T) {
@@ -233,9 +233,9 @@ func TestNodePath_PriceCalc(t *testing.T) {
 		require.Len(t, outerFC.Args(), 2)
 		fc, ok := outerFC.Args()[1].(FunctionCall)
 		require.True(t, ok)
-		assert.Equal(t, "/statements@10/expression/args@1", mustNodePath(t, fc))
+		assert.Equal(t, "/statements@10/expression/args@1", mustFragmentGet(t, fc))
 		assert.Equal(t, "vat", fc.Callable().Text())
-		assert.Equal(t, "/statements@8", mustNodePath(t, fc.Callable().Ref(doc.Ctx())))
+		assert.Equal(t, "/statements@8", mustFragmentGet(t, fc.Callable().Ref(doc.Ctx())))
 	})
 
 	t.Run("errorReporting/containerField-has-empty-string", func(t *testing.T) {
@@ -258,7 +258,7 @@ func TestNodePath_PriceCalc(t *testing.T) {
 		field, index = expr.ContainmentData()
 		expr.SetContainer(&def, field, index)
 
-		path, err := core.NodePath(&expr)
+		path, err := core.PathOf(&expr)
 		assert.Zero(t, path.String())
 		fmt.Println(err)
 		assert.ErrorContains(
@@ -280,7 +280,7 @@ func TestNodePath_PriceCalc(t *testing.T) {
 		field, index := expr.ContainmentData()
 		expr.SetContainer(&def, field, index)
 
-		path, err := core.NodePath(&expr)
+		path, err := core.PathOf(&expr)
 		assert.Zero(t, path.String())
 		fmt.Println(err)
 		assert.ErrorContains(
@@ -289,12 +289,12 @@ func TestNodePath_PriceCalc(t *testing.T) {
 	})
 }
 
-// TestGetByPath_PriceCalc is the inverse of TestNodePath_PriceCalc: for each of the 13
+// TestResolve_PriceCalc is the inverse of TestNodePath_PriceCalc: for each of the 13
 // FunctionCall cross-reference sites in price-calc.calc, it resolves the hardcoded path
-// string back to an AST node via GetByPath and asserts pointer identity with the node
+// string back to an AST node via Resolve and asserts pointer identity with the node
 // obtained by direct AST navigation. Both the referencer (FunctionCall) and the
 // referenced (AbstractDefinition) are covered per subtest.
-func TestGetByPath_PriceCalc(t *testing.T) {
+func TestResolve_PriceCalc(t *testing.T) {
 	doc := loadPriceCalcDoc(t)
 	root := doc.Root()
 	module := test.MustFindNode[Module](doc)
@@ -311,11 +311,11 @@ func TestGetByPath_PriceCalc(t *testing.T) {
 		fc, ok := binExpr.Left().(FunctionCall)
 		require.True(t, ok)
 
-		got, err := core.GetByPath(root, "/statements@3/expression/left")
+		got, err := core.Resolve("/statements@3/expression/left", root)
 		require.NoError(t, err)
 		assert.Same(t, fc, got)
 
-		got, err = core.GetByPath(root, "/statements@0")
+		got, err = core.Resolve("/statements@0", root)
 		require.NoError(t, err)
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
 	})
@@ -328,11 +328,11 @@ func TestGetByPath_PriceCalc(t *testing.T) {
 		fc, ok := binExpr.Right().(FunctionCall)
 		require.True(t, ok)
 
-		got, err := core.GetByPath(root, "/statements@3/expression/right")
+		got, err := core.Resolve("/statements@3/expression/right", root)
 		require.NoError(t, err)
 		assert.Same(t, fc, got)
 
-		got, err = core.GetByPath(root, "/statements@1")
+		got, err = core.Resolve("/statements@1", root)
 		require.NoError(t, err)
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
 	})
@@ -347,11 +347,11 @@ func TestGetByPath_PriceCalc(t *testing.T) {
 		fc, ok := binExpr.Left().(FunctionCall)
 		require.True(t, ok)
 
-		got, err := core.GetByPath(root, "/statements@4/expression/left")
+		got, err := core.Resolve("/statements@4/expression/left", root)
 		require.NoError(t, err)
 		assert.Same(t, fc, got)
 
-		got, err = core.GetByPath(root, "/statements@2")
+		got, err = core.Resolve("/statements@2", root)
 		require.NoError(t, err)
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
 	})
@@ -364,11 +364,11 @@ func TestGetByPath_PriceCalc(t *testing.T) {
 		fc, ok := binExpr.Right().(FunctionCall)
 		require.True(t, ok)
 
-		got, err := core.GetByPath(root, "/statements@4/expression/right")
+		got, err := core.Resolve("/statements@4/expression/right", root)
 		require.NoError(t, err)
 		assert.Same(t, fc, got)
 
-		got, err = core.GetByPath(root, "/statements@3")
+		got, err = core.Resolve("/statements@3", root)
 		require.NoError(t, err)
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
 	})
@@ -396,11 +396,11 @@ func TestGetByPath_PriceCalc(t *testing.T) {
 		fc, ok := innerAdd.Left().(FunctionCall)
 		require.True(t, ok)
 
-		got, err := core.GetByPath(root, "/statements@7/expression/left/left/left")
+		got, err := core.Resolve("/statements@7/expression/left/left/left", root)
 		require.NoError(t, err)
 		assert.Same(t, fc, got)
 
-		got, err = core.GetByPath(root, "/statements@4")
+		got, err = core.Resolve("/statements@4", root)
 		require.NoError(t, err)
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
 	})
@@ -417,11 +417,11 @@ func TestGetByPath_PriceCalc(t *testing.T) {
 		fc, ok := innerAdd.Right().(FunctionCall)
 		require.True(t, ok)
 
-		got, err := core.GetByPath(root, "/statements@7/expression/left/left/right")
+		got, err := core.Resolve("/statements@7/expression/left/left/right", root)
 		require.NoError(t, err)
 		assert.Same(t, fc, got)
 
-		got, err = core.GetByPath(root, "/statements@5")
+		got, err = core.Resolve("/statements@5", root)
 		require.NoError(t, err)
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
 	})
@@ -436,11 +436,11 @@ func TestGetByPath_PriceCalc(t *testing.T) {
 		fc, ok := div.Right().(FunctionCall)
 		require.True(t, ok)
 
-		got, err := core.GetByPath(root, "/statements@7/expression/left/right")
+		got, err := core.Resolve("/statements@7/expression/left/right", root)
 		require.NoError(t, err)
 		assert.Same(t, fc, got)
 
-		got, err = core.GetByPath(root, "/statements@2")
+		got, err = core.Resolve("/statements@2", root)
 		require.NoError(t, err)
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
 	})
@@ -453,11 +453,11 @@ func TestGetByPath_PriceCalc(t *testing.T) {
 		fc, ok := outerAdd.Right().(FunctionCall)
 		require.True(t, ok)
 
-		got, err := core.GetByPath(root, "/statements@7/expression/right")
+		got, err := core.Resolve("/statements@7/expression/right", root)
 		require.NoError(t, err)
 		assert.Same(t, fc, got)
 
-		got, err = core.GetByPath(root, "/statements@6")
+		got, err = core.Resolve("/statements@6", root)
 		require.NoError(t, err)
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
 	})
@@ -479,11 +479,11 @@ func TestGetByPath_PriceCalc(t *testing.T) {
 		fc, ok := div.Left().(FunctionCall)
 		require.True(t, ok)
 
-		got, err := core.GetByPath(root, "/statements@9/expression/left")
+		got, err := core.Resolve("/statements@9/expression/left", root)
 		require.NoError(t, err)
 		assert.Same(t, fc, got)
 
-		got, err = core.GetByPath(root, "/statements@9/args@0")
+		got, err = core.Resolve("/statements@9/args@0", root)
 		require.NoError(t, err)
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
 	})
@@ -498,11 +498,11 @@ func TestGetByPath_PriceCalc(t *testing.T) {
 		fc, ok := sub.Right().(FunctionCall)
 		require.True(t, ok)
 
-		got, err := core.GetByPath(root, "/statements@9/expression/right/right")
+		got, err := core.Resolve("/statements@9/expression/right/right", root)
 		require.NoError(t, err)
 		assert.Same(t, fc, got)
 
-		got, err = core.GetByPath(root, "/statements@9/args@1")
+		got, err = core.Resolve("/statements@9/args@1", root)
 		require.NoError(t, err)
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
 	})
@@ -515,11 +515,11 @@ func TestGetByPath_PriceCalc(t *testing.T) {
 		fc, ok := eval.Expression().(FunctionCall)
 		require.True(t, ok)
 
-		got, err := core.GetByPath(root, "/statements@10/expression")
+		got, err := core.Resolve("/statements@10/expression", root)
 		require.NoError(t, err)
 		assert.Same(t, fc, got)
 
-		got, err = core.GetByPath(root, "/statements@9")
+		got, err = core.Resolve("/statements@9", root)
 		require.NoError(t, err)
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
 	})
@@ -533,11 +533,11 @@ func TestGetByPath_PriceCalc(t *testing.T) {
 		fc, ok := outerFC.Args()[0].(FunctionCall)
 		require.True(t, ok)
 
-		got, err := core.GetByPath(root, "/statements@10/expression/args@0")
+		got, err := core.Resolve("/statements@10/expression/args@0", root)
 		require.NoError(t, err)
 		assert.Same(t, fc, got)
 
-		got, err = core.GetByPath(root, "/statements@7")
+		got, err = core.Resolve("/statements@7", root)
 		require.NoError(t, err)
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
 	})
@@ -551,28 +551,28 @@ func TestGetByPath_PriceCalc(t *testing.T) {
 		fc, ok := outerFC.Args()[1].(FunctionCall)
 		require.True(t, ok)
 
-		got, err := core.GetByPath(root, "/statements@10/expression/args@1")
+		got, err := core.Resolve("/statements@10/expression/args@1", root)
 		require.NoError(t, err)
 		assert.Same(t, fc, got)
 
-		got, err = core.GetByPath(root, "/statements@8")
+		got, err = core.Resolve("/statements@8", root)
 		require.NoError(t, err)
 		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
 	})
 
 	t.Run("errorReporting/no-such-field", func(t *testing.T) {
-		_, err := core.GetByPath(root, "/statements@3/expressions/left")
-		assert.ErrorContains(t, err, "DefinitionImpl.GetByPath: field 'expressions' does not exist in node '/statements@3' of type 'Definition'")
+		_, err := core.Resolve("/statements@3/expressions/left", root)
+		assert.ErrorContains(t, err, "DefinitionImpl.Resolve: field 'expressions' does not exist in node '/statements@3' of type 'Definition'")
 	})
 
 	t.Run("errorReporting/field-is-primitive", func(t *testing.T) {
-		_, err := core.GetByPath(root, "/statements@0/name")
-		assert.ErrorContains(t, err, "DefinitionImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
+		_, err := core.Resolve("/statements@0/name", root)
+		assert.ErrorContains(t, err, "DefinitionImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
 	})
 
 	t.Run("errorReporting/field-is-reference", func(t *testing.T) {
-		_, err := core.GetByPath(root, "/statements@10/expression/callable")
-		assert.ErrorContains(t, err, "FunctionCallImpl.GetByPath: field 'callable' is a cross-reference instead of a container field")
+		_, err := core.Resolve("/statements@10/expression/callable", root)
+		assert.ErrorContains(t, err, "FunctionCallImpl.Resolve: field 'callable' is a cross-reference instead of a container field")
 	})
 
 	t.Run("errorReporting/field-is-empty", func(t *testing.T) {
@@ -589,35 +589,35 @@ func TestGetByPath_PriceCalc(t *testing.T) {
 		// set the tested field to 'nil'
 		def.expression = nil
 
-		_, err := core.GetByPath(&module, "/statements@0/expression/left")
-		assert.ErrorContains(t, err, "DefinitionImpl.GetByPath: field 'expression' is nil in node '/statements@0'")
+		_, err := core.Resolve("/statements@0/expression/left", &module)
+		assert.ErrorContains(t, err, "DefinitionImpl.Resolve: field 'expression' is nil in node '/statements@0'")
 	})
 
 	t.Run("errorReporting/slice-index-out-of-bound-1", func(t *testing.T) {
-		_, err := core.GetByPath(root, "/statements@15/expression")
-		assert.ErrorContains(t, err, "ModuleImpl.GetByPath: index 15 exceeds length of slice in 'statements' (length=11) in node ''")
+		_, err := core.Resolve("/statements@15/expression", root)
+		assert.ErrorContains(t, err, "ModuleImpl.Resolve: index 15 exceeds length of slice in 'statements' (length=11) in node ''")
 	})
 
 	t.Run("errorReporting/slice-index-out-of-bound-2", func(t *testing.T) {
-		_, err := core.GetByPath(root, "/statements@10/expression/args@7/expression")
-		assert.ErrorContains(t, err, "FunctionCallImpl.GetByPath: index 7 exceeds length of slice in 'args' (length=2) in node '/statements@10/expression'")
+		_, err := core.Resolve("/statements@10/expression/args@7/expression", root)
+		assert.ErrorContains(t, err, "FunctionCallImpl.Resolve: index 7 exceeds length of slice in 'args' (length=2) in node '/statements@10/expression'")
 	})
 
 	t.Run("errorReporting/slice-item-is-nil", func(t *testing.T) {
-		expr, err := core.GetByPath(root, "/statements@10/expression/")
+		expr, err := core.Resolve("/statements@10/expression/", root)
 		require.NoError(t, err)
 		fc, ok := expr.(FunctionCall)
 		require.True(t, ok)
 
 		// shamelessly manipulate the shared ast and add a 'nil' item, don't want to copy everything right now; shouldn't hurt
 		fc.SetArgsItem(nil)
-		_, err = core.GetByPath(root, "/statements@10/expression/args@2/expression")
+		_, err = core.Resolve("/statements@10/expression/args@2/expression", root)
 
-		assert.ErrorContains(t, err, "FunctionCallImpl.GetByPath: item 2 of slice in field 'args' is nil in node '/statements@10/expression'")
+		assert.ErrorContains(t, err, "FunctionCallImpl.Resolve: item 2 of slice in field 'args' is nil in node '/statements@10/expression'")
 	})
 
 	t.Run("errorReporting/slice-index-typo", func(t *testing.T) {
-		_, err := core.GetByPath(root, "/statements@1a/expression")
+		_, err := core.Resolve("/statements@1a/expression", root)
 		assert.ErrorContains(t, err, "ParsePath: index '1a' is not a valid uint: strconv.Atoi: parsing \"1a\": invalid syntax")
 	})
 }

--- a/examples/arithmetics/ast_locating_test.go
+++ b/examples/arithmetics/ast_locating_test.go
@@ -27,11 +27,11 @@ func loadPriceCalcDoc(t *testing.T) *test.Doc {
 	return doc
 }
 
-func mustFragmentGet(t *testing.T, node core.AstNode) string {
+func mustConvert[T core.AstNode](t *testing.T, node core.AstNode) T {
 	t.Helper()
-	path, err := core.PathOf(node)
-	require.NoError(t, err)
-	return path.String()
+	converted, ok := node.(T)
+	require.True(t, ok)
+	return converted
 }
 
 // TestNodePath_PriceCalc verifies NodePath() for every FunctionCall (cross-reference)
@@ -44,56 +44,51 @@ func TestNodePath_PriceCalc(t *testing.T) {
 	stmts := module.Statements()
 	require.Len(t, stmts, 11)
 
+	mustPathOf := func(node core.AstNode) string {
+		t.Helper()
+		path, err := core.PathOf(node)
+		require.NoError(t, err)
+		return path.String()
+	}
+
 	// ── def costPerUnit: materialPerUnit + laborPerUnit ───────────────────────
 
 	t.Run("costPerUnit/materialPerUnit", func(t *testing.T) {
-		def, ok := stmts[3].(Definition)
-		require.True(t, ok)
-		binExpr, ok := def.Expression().(BinaryExpression)
-		require.True(t, ok)
-		fc, ok := binExpr.Left().(FunctionCall)
-		require.True(t, ok)
-		assert.Equal(t, "/statements@3/expression/left", mustFragmentGet(t, fc))
+		def := mustConvert[Definition](t, stmts[3])
+		binExpr := mustConvert[BinaryExpression](t, def.Expression())
+		fc := mustConvert[FunctionCall](t, binExpr.Left())
+		assert.Equal(t, "/statements@3/expression/left", mustPathOf(fc))
 		assert.Equal(t, "materialPerUnit", fc.Callable().Text())
-		assert.Equal(t, "/statements@0", mustFragmentGet(t, fc.Callable().Ref(doc.Ctx())))
+		assert.Equal(t, "/statements@0", mustPathOf(fc.Callable().Ref(doc.Ctx())))
 	})
 
 	t.Run("costPerUnit/laborPerUnit", func(t *testing.T) {
-		def, ok := stmts[3].(Definition)
-		require.True(t, ok)
-		binExpr, ok := def.Expression().(BinaryExpression)
-		require.True(t, ok)
-		fc, ok := binExpr.Right().(FunctionCall)
-		require.True(t, ok)
-		assert.Equal(t, "/statements@3/expression/right", mustFragmentGet(t, fc))
+		def := mustConvert[Definition](t, stmts[3])
+		binExpr := mustConvert[BinaryExpression](t, def.Expression())
+		fc := mustConvert[FunctionCall](t, binExpr.Right())
+		assert.Equal(t, "/statements@3/expression/right", mustPathOf(fc))
 		assert.Equal(t, "laborPerUnit", fc.Callable().Text())
-		assert.Equal(t, "/statements@1", mustFragmentGet(t, fc.Callable().Ref(doc.Ctx())))
+		assert.Equal(t, "/statements@1", mustPathOf(fc.Callable().Ref(doc.Ctx())))
 	})
 
 	// ── def costOfGoodsSold: expectedNoOfSales * costPerUnit ─────────────────
 
 	t.Run("costOfGoodsSold/expectedNoOfSales", func(t *testing.T) {
-		def, ok := stmts[4].(Definition)
-		require.True(t, ok)
-		binExpr, ok := def.Expression().(BinaryExpression)
-		require.True(t, ok)
-		fc, ok := binExpr.Left().(FunctionCall)
-		require.True(t, ok)
-		assert.Equal(t, "/statements@4/expression/left", mustFragmentGet(t, fc))
+		def := mustConvert[Definition](t, stmts[4])
+		binExpr := mustConvert[BinaryExpression](t, def.Expression())
+		fc := mustConvert[FunctionCall](t, binExpr.Left())
+		assert.Equal(t, "/statements@4/expression/left", mustPathOf(fc))
 		assert.Equal(t, "expectedNoOfSales", fc.Callable().Text())
-		assert.Equal(t, "/statements@2", mustFragmentGet(t, fc.Callable().Ref(doc.Ctx())))
+		assert.Equal(t, "/statements@2", mustPathOf(fc.Callable().Ref(doc.Ctx())))
 	})
 
 	t.Run("costOfGoodsSold/costPerUnit", func(t *testing.T) {
-		def, ok := stmts[4].(Definition)
-		require.True(t, ok)
-		binExpr, ok := def.Expression().(BinaryExpression)
-		require.True(t, ok)
-		fc, ok := binExpr.Right().(FunctionCall)
-		require.True(t, ok)
-		assert.Equal(t, "/statements@4/expression/right", mustFragmentGet(t, fc))
+		def := mustConvert[Definition](t, stmts[4])
+		binExpr := mustConvert[BinaryExpression](t, def.Expression())
+		fc := mustConvert[FunctionCall](t, binExpr.Right())
+		assert.Equal(t, "/statements@4/expression/right", mustPathOf(fc))
 		assert.Equal(t, "costPerUnit", fc.Callable().Text())
-		assert.Equal(t, "/statements@3", mustFragmentGet(t, fc.Callable().Ref(doc.Ctx())))
+		assert.Equal(t, "/statements@3", mustPathOf(fc.Callable().Ref(doc.Ctx())))
 	})
 
 	// ── def netPrice: (costOfGoodsSold + generalExpensesAndSales) / expectedNoOfSales + desiredProfitPerUnit
@@ -108,61 +103,44 @@ func TestNodePath_PriceCalc(t *testing.T) {
 	//     right: FC "desiredProfitPerUnit"
 
 	t.Run("netPrice/costOfGoodsSold", func(t *testing.T) {
-		def, ok := stmts[7].(Definition)
-		require.True(t, ok)
-		outerAdd, ok := def.Expression().(BinaryExpression)
-		require.True(t, ok)
-		div, ok := outerAdd.Left().(BinaryExpression)
-		require.True(t, ok)
-		innerAdd, ok := div.Left().(BinaryExpression)
-		require.True(t, ok)
-		fc, ok := innerAdd.Left().(FunctionCall)
-		require.True(t, ok)
-		assert.Equal(t, "/statements@7/expression/left/left/left", mustFragmentGet(t, fc))
+		def := mustConvert[Definition](t, stmts[7])
+		outerAdd := mustConvert[BinaryExpression](t, def.Expression())
+		div := mustConvert[BinaryExpression](t, outerAdd.Left())
+		innerAdd := mustConvert[BinaryExpression](t, div.Left())
+		fc := mustConvert[FunctionCall](t, innerAdd.Left())
+		assert.Equal(t, "/statements@7/expression/left/left/left", mustPathOf(fc))
 		assert.Equal(t, "costOfGoodsSold", fc.Callable().Text())
-		assert.Equal(t, "/statements@4", mustFragmentGet(t, fc.Callable().Ref(doc.Ctx())))
+		assert.Equal(t, "/statements@4", mustPathOf(fc.Callable().Ref(doc.Ctx())))
 	})
 
 	t.Run("netPrice/generalExpensesAndSales", func(t *testing.T) {
-		def, ok := stmts[7].(Definition)
-		require.True(t, ok)
-		outerAdd, ok := def.Expression().(BinaryExpression)
-		require.True(t, ok)
-		div, ok := outerAdd.Left().(BinaryExpression)
-		require.True(t, ok)
-		innerAdd, ok := div.Left().(BinaryExpression)
-		require.True(t, ok)
-		fc, ok := innerAdd.Right().(FunctionCall)
-		require.True(t, ok)
-		assert.Equal(t, "/statements@7/expression/left/left/right", mustFragmentGet(t, fc))
+		def := mustConvert[Definition](t, stmts[7])
+		outerAdd := mustConvert[BinaryExpression](t, def.Expression())
+		div := mustConvert[BinaryExpression](t, outerAdd.Left())
+		innerAdd := mustConvert[BinaryExpression](t, div.Left())
+		fc := mustConvert[FunctionCall](t, innerAdd.Right())
+		assert.Equal(t, "/statements@7/expression/left/left/right", mustPathOf(fc))
 		assert.Equal(t, "generalExpensesAndSales", fc.Callable().Text())
-		assert.Equal(t, "/statements@5", mustFragmentGet(t, fc.Callable().Ref(doc.Ctx())))
+		assert.Equal(t, "/statements@5", mustPathOf(fc.Callable().Ref(doc.Ctx())))
 	})
 
 	t.Run("netPrice/expectedNoOfSales", func(t *testing.T) {
-		def, ok := stmts[7].(Definition)
-		require.True(t, ok)
-		outerAdd, ok := def.Expression().(BinaryExpression)
-		require.True(t, ok)
-		div, ok := outerAdd.Left().(BinaryExpression)
-		require.True(t, ok)
-		fc, ok := div.Right().(FunctionCall)
-		require.True(t, ok)
-		assert.Equal(t, "/statements@7/expression/left/right", mustFragmentGet(t, fc))
+		def := mustConvert[Definition](t, stmts[7])
+		outerAdd := mustConvert[BinaryExpression](t, def.Expression())
+		div := mustConvert[BinaryExpression](t, outerAdd.Left())
+		fc := mustConvert[FunctionCall](t, div.Right())
+		assert.Equal(t, "/statements@7/expression/left/right", mustPathOf(fc))
 		assert.Equal(t, "expectedNoOfSales", fc.Callable().Text())
-		assert.Equal(t, "/statements@2", mustFragmentGet(t, fc.Callable().Ref(doc.Ctx())))
+		assert.Equal(t, "/statements@2", mustPathOf(fc.Callable().Ref(doc.Ctx())))
 	})
 
 	t.Run("netPrice/desiredProfitPerUnit", func(t *testing.T) {
-		def, ok := stmts[7].(Definition)
-		require.True(t, ok)
-		outerAdd, ok := def.Expression().(BinaryExpression)
-		require.True(t, ok)
-		fc, ok := outerAdd.Right().(FunctionCall)
-		require.True(t, ok)
-		assert.Equal(t, "/statements@7/expression/right", mustFragmentGet(t, fc))
+		def := mustConvert[Definition](t, stmts[7])
+		outerAdd := mustConvert[BinaryExpression](t, def.Expression())
+		fc := mustConvert[FunctionCall](t, outerAdd.Right())
+		assert.Equal(t, "/statements@7/expression/right", mustPathOf(fc))
 		assert.Equal(t, "desiredProfitPerUnit", fc.Callable().Text())
-		assert.Equal(t, "/statements@6", mustFragmentGet(t, fc.Callable().Ref(doc.Ctx())))
+		assert.Equal(t, "/statements@6", mustPathOf(fc.Callable().Ref(doc.Ctx())))
 	})
 
 	// ── def calcGrossListPrice(net, tax): net / (1 - tax)
@@ -175,67 +153,52 @@ func TestNodePath_PriceCalc(t *testing.T) {
 	//       right: FC "tax"
 
 	t.Run("calcGrossListPrice/net", func(t *testing.T) {
-		def, ok := stmts[9].(Definition)
-		require.True(t, ok)
-		div, ok := def.Expression().(BinaryExpression)
-		require.True(t, ok)
-		fc, ok := div.Left().(FunctionCall)
-		require.True(t, ok)
-		assert.Equal(t, "/statements@9/expression/left", mustFragmentGet(t, fc))
+		def := mustConvert[Definition](t, stmts[9])
+		div := mustConvert[BinaryExpression](t, def.Expression())
+		fc := mustConvert[FunctionCall](t, div.Left())
+		assert.Equal(t, "/statements@9/expression/left", mustPathOf(fc))
 		assert.Equal(t, "net", fc.Callable().Text())
-		assert.Equal(t, "/statements@9/args@0", mustFragmentGet(t, fc.Callable().Ref(doc.Ctx())))
+		assert.Equal(t, "/statements@9/args@0", mustPathOf(fc.Callable().Ref(doc.Ctx())))
 	})
 
 	t.Run("calcGrossListPrice/tax", func(t *testing.T) {
-		def, ok := stmts[9].(Definition)
-		require.True(t, ok)
-		div, ok := def.Expression().(BinaryExpression)
-		require.True(t, ok)
-		sub, ok := div.Right().(BinaryExpression)
-		require.True(t, ok)
-		fc, ok := sub.Right().(FunctionCall)
-		require.True(t, ok)
-		assert.Equal(t, "/statements@9/expression/right/right", mustFragmentGet(t, fc))
+		def := mustConvert[Definition](t, stmts[9])
+		div := mustConvert[BinaryExpression](t, def.Expression())
+		sub := mustConvert[BinaryExpression](t, div.Right())
+		fc := mustConvert[FunctionCall](t, sub.Right())
+		assert.Equal(t, "/statements@9/expression/right/right", mustPathOf(fc))
 		assert.Equal(t, "tax", fc.Callable().Text())
-		assert.Equal(t, "/statements@9/args@1", mustFragmentGet(t, fc.Callable().Ref(doc.Ctx())))
+		assert.Equal(t, "/statements@9/args@1", mustPathOf(fc.Callable().Ref(doc.Ctx())))
 	})
 
 	// ── calcGrossListPrice(netPrice, vat) ────────────────────────────────────
 
 	t.Run("evaluation/calcGrossListPrice", func(t *testing.T) {
-		eval, ok := stmts[10].(Evaluation)
-		require.True(t, ok)
-		fc, ok := eval.Expression().(FunctionCall)
-		require.True(t, ok)
-		assert.Equal(t, "/statements@10/expression", mustFragmentGet(t, fc))
+		eval := mustConvert[Evaluation](t, stmts[10])
+		fc := mustConvert[FunctionCall](t, eval.Expression())
+		assert.Equal(t, "/statements@10/expression", mustPathOf(fc))
 		assert.Equal(t, "calcGrossListPrice", fc.Callable().Text())
-		assert.Equal(t, "/statements@9", mustFragmentGet(t, fc.Callable().Ref(doc.Ctx())))
+		assert.Equal(t, "/statements@9", mustPathOf(fc.Callable().Ref(doc.Ctx())))
 	})
 
 	t.Run("evaluation/netPrice", func(t *testing.T) {
-		eval, ok := stmts[10].(Evaluation)
-		require.True(t, ok)
-		outerFC, ok := eval.Expression().(FunctionCall)
-		require.True(t, ok)
+		eval := mustConvert[Evaluation](t, stmts[10])
+		outerFC := mustConvert[FunctionCall](t, eval.Expression())
 		require.Len(t, outerFC.Args(), 2)
-		fc, ok := outerFC.Args()[0].(FunctionCall)
-		require.True(t, ok)
-		assert.Equal(t, "/statements@10/expression/args@0", mustFragmentGet(t, fc))
+		fc := mustConvert[FunctionCall](t, outerFC.Args()[0])
+		assert.Equal(t, "/statements@10/expression/args@0", mustPathOf(fc))
 		assert.Equal(t, "netPrice", fc.Callable().Text())
-		assert.Equal(t, "/statements@7", mustFragmentGet(t, fc.Callable().Ref(doc.Ctx())))
+		assert.Equal(t, "/statements@7", mustPathOf(fc.Callable().Ref(doc.Ctx())))
 	})
 
 	t.Run("evaluation/vat", func(t *testing.T) {
-		eval, ok := stmts[10].(Evaluation)
-		require.True(t, ok)
-		outerFC, ok := eval.Expression().(FunctionCall)
-		require.True(t, ok)
+		eval := mustConvert[Evaluation](t, stmts[10])
+		outerFC := mustConvert[FunctionCall](t, eval.Expression())
 		require.Len(t, outerFC.Args(), 2)
-		fc, ok := outerFC.Args()[1].(FunctionCall)
-		require.True(t, ok)
-		assert.Equal(t, "/statements@10/expression/args@1", mustFragmentGet(t, fc))
+		fc := mustConvert[FunctionCall](t, outerFC.Args()[1])
+		assert.Equal(t, "/statements@10/expression/args@1", mustPathOf(fc))
 		assert.Equal(t, "vat", fc.Callable().Text())
-		assert.Equal(t, "/statements@8", mustFragmentGet(t, fc.Callable().Ref(doc.Ctx())))
+		assert.Equal(t, "/statements@8", mustPathOf(fc.Callable().Ref(doc.Ctx())))
 	})
 
 	t.Run("errorReporting/containerField-has-empty-string", func(t *testing.T) {
@@ -301,76 +264,62 @@ func TestResolve_PriceCalc(t *testing.T) {
 	stmts := module.Statements()
 	require.Len(t, stmts, 11)
 
+	mustResolve := func(path string, node core.AstNode) core.AstNode {
+		t.Helper()
+		child, err := core.Resolve(path, node)
+		require.NoError(t, err)
+		return child
+	}
 	// ── def costPerUnit: materialPerUnit + laborPerUnit ───────────────────────
 
 	t.Run("costPerUnit/materialPerUnit", func(t *testing.T) {
-		def, ok := stmts[3].(Definition)
-		require.True(t, ok)
-		binExpr, ok := def.Expression().(BinaryExpression)
-		require.True(t, ok)
-		fc, ok := binExpr.Left().(FunctionCall)
-		require.True(t, ok)
+		def := mustConvert[Definition](t, stmts[3])
+		binExpr := mustConvert[BinaryExpression](t, def.Expression())
+		fc := mustConvert[FunctionCall](t, binExpr.Left())
 
-		got, err := core.Resolve("/statements@3/expression/left", root)
-		require.NoError(t, err)
-		assert.Same(t, fc, got)
+		left := mustResolve("/statements@3/expression/left", root)
+		assert.Same(t, fc, left)
 
-		got, err = core.Resolve("/statements@0", root)
-		require.NoError(t, err)
-		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
+		statement := mustResolve("/statements@0", root)
+		assert.Same(t, fc.Callable().Ref(doc.Ctx()), statement)
 	})
 
 	t.Run("costPerUnit/laborPerUnit", func(t *testing.T) {
-		def, ok := stmts[3].(Definition)
-		require.True(t, ok)
-		binExpr, ok := def.Expression().(BinaryExpression)
-		require.True(t, ok)
-		fc, ok := binExpr.Right().(FunctionCall)
-		require.True(t, ok)
+		def := mustConvert[Definition](t, stmts[3])
+		binExpr := mustConvert[BinaryExpression](t, def.Expression())
+		fc := mustConvert[FunctionCall](t, binExpr.Right())
 
-		got, err := core.Resolve("/statements@3/expression/right", root)
-		require.NoError(t, err)
-		assert.Same(t, fc, got)
+		right := mustResolve("/statements@3/expression/right", root)
+		assert.Same(t, fc, right)
 
-		got, err = core.Resolve("/statements@1", root)
-		require.NoError(t, err)
-		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
+		statement := mustResolve("/statements@1", root)
+		assert.Same(t, fc.Callable().Ref(doc.Ctx()), statement)
 	})
 
 	// ── def costOfGoodsSold: expectedNoOfSales * costPerUnit ─────────────────
 
 	t.Run("costOfGoodsSold/expectedNoOfSales", func(t *testing.T) {
-		def, ok := stmts[4].(Definition)
-		require.True(t, ok)
-		binExpr, ok := def.Expression().(BinaryExpression)
-		require.True(t, ok)
-		fc, ok := binExpr.Left().(FunctionCall)
-		require.True(t, ok)
+		def := mustConvert[Definition](t, stmts[4])
+		binExpr := mustConvert[BinaryExpression](t, def.Expression())
+		fc := mustConvert[FunctionCall](t, binExpr.Left())
 
-		got, err := core.Resolve("/statements@4/expression/left", root)
-		require.NoError(t, err)
-		assert.Same(t, fc, got)
+		left := mustResolve("/statements@4/expression/left", root)
+		assert.Same(t, fc, left)
 
-		got, err = core.Resolve("/statements@2", root)
-		require.NoError(t, err)
-		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
+		statement := mustResolve("/statements@2", root)
+		assert.Same(t, fc.Callable().Ref(doc.Ctx()), statement)
 	})
 
 	t.Run("costOfGoodsSold/costPerUnit", func(t *testing.T) {
-		def, ok := stmts[4].(Definition)
-		require.True(t, ok)
-		binExpr, ok := def.Expression().(BinaryExpression)
-		require.True(t, ok)
-		fc, ok := binExpr.Right().(FunctionCall)
-		require.True(t, ok)
+		def := mustConvert[Definition](t, stmts[4])
+		binExpr := mustConvert[BinaryExpression](t, def.Expression())
+		fc := mustConvert[FunctionCall](t, binExpr.Right())
 
-		got, err := core.Resolve("/statements@4/expression/right", root)
-		require.NoError(t, err)
-		assert.Same(t, fc, got)
+		right := mustResolve("/statements@4/expression/right", root)
+		assert.Same(t, fc, right)
 
-		got, err = core.Resolve("/statements@3", root)
-		require.NoError(t, err)
-		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
+		statement := mustResolve("/statements@3", root)
+		assert.Same(t, fc.Callable().Ref(doc.Ctx()), statement)
 	})
 
 	// ── def netPrice: (costOfGoodsSold + generalExpensesAndSales) / expectedNoOfSales + desiredProfitPerUnit
@@ -385,81 +334,56 @@ func TestResolve_PriceCalc(t *testing.T) {
 	//     right: FC "desiredProfitPerUnit"
 
 	t.Run("netPrice/costOfGoodsSold", func(t *testing.T) {
-		def, ok := stmts[7].(Definition)
-		require.True(t, ok)
-		outerAdd, ok := def.Expression().(BinaryExpression)
-		require.True(t, ok)
-		div, ok := outerAdd.Left().(BinaryExpression)
-		require.True(t, ok)
-		innerAdd, ok := div.Left().(BinaryExpression)
-		require.True(t, ok)
-		fc, ok := innerAdd.Left().(FunctionCall)
-		require.True(t, ok)
+		def := mustConvert[Definition](t, stmts[7])
+		outerAdd := mustConvert[BinaryExpression](t, def.Expression())
+		div := mustConvert[BinaryExpression](t, outerAdd.Left())
+		innerAdd := mustConvert[BinaryExpression](t, div.Left())
+		fc := mustConvert[FunctionCall](t, innerAdd.Left())
 
-		got, err := core.Resolve("/statements@7/expression/left/left/left", root)
-		require.NoError(t, err)
-		assert.Same(t, fc, got)
+		left := mustResolve("/statements@7/expression/left/left/left", root)
+		assert.Same(t, fc, left)
 
-		got, err = core.Resolve("/statements@4", root)
-		require.NoError(t, err)
-		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
+		statement := mustResolve("/statements@4", root)
+		assert.Same(t, fc.Callable().Ref(doc.Ctx()), statement)
 	})
 
 	t.Run("netPrice/generalExpensesAndSales", func(t *testing.T) {
-		def, ok := stmts[7].(Definition)
-		require.True(t, ok)
-		outerAdd, ok := def.Expression().(BinaryExpression)
-		require.True(t, ok)
-		div, ok := outerAdd.Left().(BinaryExpression)
-		require.True(t, ok)
-		innerAdd, ok := div.Left().(BinaryExpression)
-		require.True(t, ok)
-		fc, ok := innerAdd.Right().(FunctionCall)
-		require.True(t, ok)
+		def := mustConvert[Definition](t, stmts[7])
+		outerAdd := mustConvert[BinaryExpression](t, def.Expression())
+		div := mustConvert[BinaryExpression](t, outerAdd.Left())
+		innerAdd := mustConvert[BinaryExpression](t, div.Left())
+		fc := mustConvert[FunctionCall](t, innerAdd.Right())
 
-		got, err := core.Resolve("/statements@7/expression/left/left/right", root)
-		require.NoError(t, err)
-		assert.Same(t, fc, got)
+		right := mustResolve("/statements@7/expression/left/left/right", root)
+		assert.Same(t, fc, right)
 
-		got, err = core.Resolve("/statements@5", root)
-		require.NoError(t, err)
-		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
+		statement := mustResolve("/statements@5", root)
+		assert.Same(t, fc.Callable().Ref(doc.Ctx()), statement)
 	})
 
 	t.Run("netPrice/expectedNoOfSales", func(t *testing.T) {
-		def, ok := stmts[7].(Definition)
-		require.True(t, ok)
-		outerAdd, ok := def.Expression().(BinaryExpression)
-		require.True(t, ok)
-		div, ok := outerAdd.Left().(BinaryExpression)
-		require.True(t, ok)
-		fc, ok := div.Right().(FunctionCall)
-		require.True(t, ok)
+		def := mustConvert[Definition](t, stmts[7])
+		outerAdd := mustConvert[BinaryExpression](t, def.Expression())
+		div := mustConvert[BinaryExpression](t, outerAdd.Left())
+		fc := mustConvert[FunctionCall](t, div.Right())
 
-		got, err := core.Resolve("/statements@7/expression/left/right", root)
-		require.NoError(t, err)
-		assert.Same(t, fc, got)
+		right := mustResolve("/statements@7/expression/left/right", root)
+		assert.Same(t, fc, right)
 
-		got, err = core.Resolve("/statements@2", root)
-		require.NoError(t, err)
-		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
+		statement := mustResolve("/statements@2", root)
+		assert.Same(t, fc.Callable().Ref(doc.Ctx()), statement)
 	})
 
 	t.Run("netPrice/desiredProfitPerUnit", func(t *testing.T) {
-		def, ok := stmts[7].(Definition)
-		require.True(t, ok)
-		outerAdd, ok := def.Expression().(BinaryExpression)
-		require.True(t, ok)
-		fc, ok := outerAdd.Right().(FunctionCall)
-		require.True(t, ok)
+		def := mustConvert[Definition](t, stmts[7])
+		outerAdd := mustConvert[BinaryExpression](t, def.Expression())
+		fc := mustConvert[FunctionCall](t, outerAdd.Right())
 
-		got, err := core.Resolve("/statements@7/expression/right", root)
-		require.NoError(t, err)
-		assert.Same(t, fc, got)
+		right := mustResolve("/statements@7/expression/right", root)
+		assert.Same(t, fc, right)
 
-		got, err = core.Resolve("/statements@6", root)
-		require.NoError(t, err)
-		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
+		statement := mustResolve("/statements@6", root)
+		assert.Same(t, fc.Callable().Ref(doc.Ctx()), statement)
 	})
 
 	// ── def calcGrossListPrice(net, tax): net / (1 - tax)
@@ -472,92 +396,67 @@ func TestResolve_PriceCalc(t *testing.T) {
 	//       right: FC "tax"
 
 	t.Run("calcGrossListPrice/net", func(t *testing.T) {
-		def, ok := stmts[9].(Definition)
-		require.True(t, ok)
-		div, ok := def.Expression().(BinaryExpression)
-		require.True(t, ok)
-		fc, ok := div.Left().(FunctionCall)
-		require.True(t, ok)
+		def := mustConvert[Definition](t, stmts[9])
+		div := mustConvert[BinaryExpression](t, def.Expression())
+		fc := mustConvert[FunctionCall](t, div.Left())
 
-		got, err := core.Resolve("/statements@9/expression/left", root)
-		require.NoError(t, err)
-		assert.Same(t, fc, got)
+		left := mustResolve("/statements@9/expression/left", root)
+		assert.Same(t, fc, left)
 
-		got, err = core.Resolve("/statements@9/args@0", root)
-		require.NoError(t, err)
-		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
+		arg := mustResolve("/statements@9/args@0", root)
+		assert.Same(t, fc.Callable().Ref(doc.Ctx()), arg)
 	})
 
 	t.Run("calcGrossListPrice/tax", func(t *testing.T) {
-		def, ok := stmts[9].(Definition)
-		require.True(t, ok)
-		div, ok := def.Expression().(BinaryExpression)
-		require.True(t, ok)
-		sub, ok := div.Right().(BinaryExpression)
-		require.True(t, ok)
-		fc, ok := sub.Right().(FunctionCall)
-		require.True(t, ok)
+		def := mustConvert[Definition](t, stmts[9])
+		div := mustConvert[BinaryExpression](t, def.Expression())
+		sub := mustConvert[BinaryExpression](t, div.Right())
+		fc := mustConvert[FunctionCall](t, sub.Right())
 
-		got, err := core.Resolve("/statements@9/expression/right/right", root)
-		require.NoError(t, err)
-		assert.Same(t, fc, got)
+		right := mustResolve("/statements@9/expression/right/right", root)
+		assert.Same(t, fc, right)
 
-		got, err = core.Resolve("/statements@9/args@1", root)
-		require.NoError(t, err)
-		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
+		arg := mustResolve("/statements@9/args@1", root)
+		assert.Same(t, fc.Callable().Ref(doc.Ctx()), arg)
 	})
 
 	// ── calcGrossListPrice(netPrice, vat) ────────────────────────────────────
 
 	t.Run("evaluation/calcGrossListPrice", func(t *testing.T) {
-		eval, ok := stmts[10].(Evaluation)
-		require.True(t, ok)
-		fc, ok := eval.Expression().(FunctionCall)
-		require.True(t, ok)
+		eval := mustConvert[Evaluation](t, stmts[10])
+		fc := mustConvert[FunctionCall](t, eval.Expression())
 
-		got, err := core.Resolve("/statements@10/expression", root)
-		require.NoError(t, err)
-		assert.Same(t, fc, got)
+		expression := mustResolve("/statements@10/expression", root)
+		assert.Same(t, fc, expression)
 
-		got, err = core.Resolve("/statements@9", root)
-		require.NoError(t, err)
-		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
+		statement := mustResolve("/statements@9", root)
+		assert.Same(t, fc.Callable().Ref(doc.Ctx()), statement)
 	})
 
 	t.Run("evaluation/netPrice", func(t *testing.T) {
-		eval, ok := stmts[10].(Evaluation)
-		require.True(t, ok)
-		outerFC, ok := eval.Expression().(FunctionCall)
-		require.True(t, ok)
+		eval := mustConvert[Evaluation](t, stmts[10])
+		outerFC := mustConvert[FunctionCall](t, eval.Expression())
 		require.Len(t, outerFC.Args(), 2)
-		fc, ok := outerFC.Args()[0].(FunctionCall)
-		require.True(t, ok)
+		fc := mustConvert[FunctionCall](t, outerFC.Args()[0])
 
-		got, err := core.Resolve("/statements@10/expression/args@0", root)
-		require.NoError(t, err)
-		assert.Same(t, fc, got)
+		arg := mustResolve("/statements@10/expression/args@0", root)
+		assert.Same(t, fc, arg)
 
-		got, err = core.Resolve("/statements@7", root)
-		require.NoError(t, err)
-		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
+		statement := mustResolve("/statements@7", root)
+		assert.Same(t, fc.Callable().Ref(doc.Ctx()), statement)
 	})
 
 	t.Run("evaluation/vat", func(t *testing.T) {
-		eval, ok := stmts[10].(Evaluation)
-		require.True(t, ok)
-		outerFC, ok := eval.Expression().(FunctionCall)
-		require.True(t, ok)
+		eval := mustConvert[Evaluation](t, stmts[10])
+		outerFC := mustConvert[FunctionCall](t, eval.Expression())
 		require.Len(t, outerFC.Args(), 2)
-		fc, ok := outerFC.Args()[1].(FunctionCall)
-		require.True(t, ok)
+		fc := mustConvert[FunctionCall](t, outerFC.Args()[1])
 
-		got, err := core.Resolve("/statements@10/expression/args@1", root)
-		require.NoError(t, err)
-		assert.Same(t, fc, got)
+		arg := mustResolve("/statements@10/expression/args@1", root)
+		assert.Same(t, fc, arg)
 
-		got, err = core.Resolve("/statements@8", root)
-		require.NoError(t, err)
-		assert.Same(t, fc.Callable().Ref(doc.Ctx()), got)
+		statement := mustResolve("/statements@8", root)
+		assert.Same(t, fc.Callable().Ref(doc.Ctx()), statement)
 	})
 
 	t.Run("errorReporting/no-such-field", func(t *testing.T) {
@@ -580,8 +479,7 @@ func TestResolve_PriceCalc(t *testing.T) {
 		module := *module.(*ModuleImpl)
 		def := *stmts[0].(*DefinitionImpl)
 
-		module.statements = make([]Statement, 1)
-		module.statements[0] = &def
+		module.statements = []Statement{&def}
 
 		field, index := def.ContainmentData()
 		def.SetContainer(&module, field, index)
@@ -606,8 +504,7 @@ func TestResolve_PriceCalc(t *testing.T) {
 	t.Run("errorReporting/slice-item-is-nil", func(t *testing.T) {
 		expr, err := core.Resolve("/statements@10/expression/", root)
 		require.NoError(t, err)
-		fc, ok := expr.(FunctionCall)
-		require.True(t, ok)
+		fc := mustConvert[FunctionCall](t, expr)
 
 		// shamelessly manipulate the shared ast and add a 'nil' item, don't want to copy everything right now; shouldn't hurt
 		fc.SetArgsItem(nil)

--- a/examples/arithmetics/ast_locating_test.go
+++ b/examples/arithmetics/ast_locating_test.go
@@ -226,7 +226,7 @@ func TestNodePath_PriceCalc(t *testing.T) {
 		fmt.Println(err)
 		assert.ErrorContains(
 			t, err,
-			"AstNodeBase.NodePath: error within node of type *arithmetics.ModuleImpl: cannot determine node path, 'containerField' is empty")
+			"PathOf: error within node of type *arithmetics.ModuleImpl: cannot determine node path, 'containerField' is empty")
 	})
 
 	t.Run("errorReporting/containerField-has-zero-handle", func(t *testing.T) {
@@ -248,7 +248,7 @@ func TestNodePath_PriceCalc(t *testing.T) {
 		fmt.Println(err)
 		assert.ErrorContains(
 			t, err,
-			"AstNodeBase.NodePath: error within node of type *arithmetics.DefinitionImpl: cannot determine node path, 'containerField' is empty")
+			"PathOf: error within node of type *arithmetics.DefinitionImpl: cannot determine node path, 'containerField' is empty")
 	})
 }
 
@@ -515,6 +515,6 @@ func TestResolve_PriceCalc(t *testing.T) {
 
 	t.Run("errorReporting/slice-index-typo", func(t *testing.T) {
 		_, err := core.Resolve("/statements@1a/expression", root)
-		assert.ErrorContains(t, err, "ParsePath: index '1a' is not a valid uint: strconv.Atoi: parsing \"1a\": invalid syntax")
+		assert.ErrorContains(t, err, "parsePath: index '1a' is not a valid uint: strconv.Atoi: parsing \"1a\": invalid syntax")
 	})
 }

--- a/examples/arithmetics/types_gen.go
+++ b/examples/arithmetics/types_gen.go
@@ -122,7 +122,7 @@ func (i *ModuleImpl) GetByPath(path string) (core.AstNode, error) {
 		}
 		return child.GetByPath(parts[1])
 	case fieldNameName:
-		return nil, fmt.Errorf("ModuleImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("ModuleImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("ModuleImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Module'", fieldAndIndex[0], nodePath)
@@ -265,7 +265,7 @@ func (i *AbstractDefinitionImpl) GetByPath(path string) (core.AstNode, error) {
 	field := unique.Make(fieldAndIndex[0])
 	switch field {
 	case fieldNameName:
-		return nil, fmt.Errorf("AbstractDefinitionImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("AbstractDefinitionImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("AbstractDefinitionImpl.GetByPath: field '%s' does not exist in node '%s' of type 'AbstractDefinition'", fieldAndIndex[0], nodePath)
@@ -403,7 +403,7 @@ func (i *DefinitionImpl) GetByPath(path string) (core.AstNode, error) {
 		}
 		return child.GetByPath(parts[1])
 	case fieldNameName:
-		return nil, fmt.Errorf("DefinitionImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("DefinitionImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("DefinitionImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Definition'", fieldAndIndex[0], nodePath)
@@ -475,7 +475,7 @@ func (i *DeclaredParameterImpl) GetByPath(path string) (core.AstNode, error) {
 	field := unique.Make(fieldAndIndex[0])
 	switch field {
 	case fieldNameName:
-		return nil, fmt.Errorf("DeclaredParameterImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("DeclaredParameterImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("DeclaredParameterImpl.GetByPath: field '%s' does not exist in node '%s' of type 'DeclaredParameter'", fieldAndIndex[0], nodePath)
@@ -781,7 +781,7 @@ func (i *BinaryExpressionImpl) GetByPath(path string) (core.AstNode, error) {
 		}
 		return child.GetByPath(parts[1])
 	case fieldNameOperator:
-		return nil, fmt.Errorf("BinaryExpressionImpl.GetByPath: field 'operator' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("BinaryExpressionImpl.GetByPath: field 'operator' holds a primitive value instead of an ast node")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("BinaryExpressionImpl.GetByPath: field '%s' does not exist in node '%s' of type 'BinaryExpression'", fieldAndIndex[0], nodePath)
@@ -901,6 +901,8 @@ func (i *FunctionCallImpl) GetByPath(path string) (core.AstNode, error) {
 			return child, nil
 		}
 		return child.GetByPath(parts[1])
+	case fieldNameCallable:
+		return nil, fmt.Errorf("FunctionCallImpl.GetByPath: field 'callable' is a cross-reference instead of a container field")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("FunctionCallImpl.GetByPath: field '%s' does not exist in node '%s' of type 'FunctionCall'", fieldAndIndex[0], nodePath)
@@ -992,7 +994,7 @@ func (i *NumberLiteralImpl) GetByPath(path string) (core.AstNode, error) {
 	field := unique.Make(fieldAndIndex[0])
 	switch field {
 	case fieldNameValue:
-		return nil, fmt.Errorf("NumberLiteralImpl.GetByPath: field 'value' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("NumberLiteralImpl.GetByPath: field 'value' holds a primitive value instead of an ast node")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("NumberLiteralImpl.GetByPath: field '%s' does not exist in node '%s' of type 'NumberLiteral'", fieldAndIndex[0], nodePath)

--- a/examples/arithmetics/types_gen.go
+++ b/examples/arithmetics/types_gen.go
@@ -3,8 +3,12 @@
 package arithmetics
 
 import (
-	core "typefox.dev/fastbelt"
+	"fmt"
+	"strconv"
+	"strings"
 	"unique"
+
+	core "typefox.dev/fastbelt"
 )
 
 type Module interface {
@@ -95,6 +99,36 @@ func (i *ModuleImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
 	}
 }
 
+func (i *ModuleImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameStatements:
+		index, err := strconv.Atoi(fieldAndIndex[1])
+		if err != nil {
+			return nil, err
+		} else if index >= len(i.Statements()) {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("ModuleImpl.GetByPath: index %d exceeds slice length of 'statements' (%d) at '%s'", index, len(i.Statements()), nodePath)
+		}
+		child := i.Statements()[index]
+		if len(parts) == 1 {
+			return child, nil
+		}
+		return child.GetByPath(parts[1])
+	case fieldNameName:
+		return nil, fmt.Errorf("ModuleImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("ModuleImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Module'", fieldAndIndex[0], nodePath)
+	}
+}
+
 type Statement interface {
 	core.AstNode
 
@@ -138,6 +172,17 @@ func (i *StatementImpl) ForEachReference(fn func(core.UntypedReference, unique.H
 
 func (i *StatementImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
 	return core.FieldInfos{}
+}
+
+func (i *StatementImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	nodePath, _ := i.AstNodeBase.NodePath()
+	return nil, fmt.Errorf("StatementImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Statement'", fieldAndIndex[0], nodePath)
 }
 
 type AbstractDefinition interface {
@@ -207,6 +252,23 @@ func (i *AbstractDefinitionImpl) FieldInfos(field unique.Handle[string]) core.Fi
 		return core.FieldInfos{Multi: false, Reference: false}
 	default:
 		return core.FieldInfos{}
+	}
+}
+
+func (i *AbstractDefinitionImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameName:
+		return nil, fmt.Errorf("AbstractDefinitionImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("AbstractDefinitionImpl.GetByPath: field '%s' does not exist in node '%s' of type 'AbstractDefinition'", fieldAndIndex[0], nodePath)
 	}
 }
 
@@ -308,6 +370,46 @@ func (i *DefinitionImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos
 	}
 }
 
+func (i *DefinitionImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameArgs:
+		index, err := strconv.Atoi(fieldAndIndex[1])
+		if err != nil {
+			return nil, err
+		} else if index >= len(i.Args()) {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("DefinitionImpl.GetByPath: index %d exceeds slice length of 'args' (%d) at '%s'", index, len(i.Args()), nodePath)
+		}
+		child := i.Args()[index]
+		if len(parts) == 1 {
+			return child, nil
+		}
+		return child.GetByPath(parts[1])
+	case fieldNameExpression:
+		if i.Expression() == nil {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("DefinitionImpl.GetByPath: field 'expression' is nil at '%s'", nodePath)
+		}
+		child := i.Expression()
+		if len(parts) == 1 {
+			return child, nil
+		}
+		return child.GetByPath(parts[1])
+	case fieldNameName:
+		return nil, fmt.Errorf("DefinitionImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("DefinitionImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Definition'", fieldAndIndex[0], nodePath)
+	}
+}
+
 type DeclaredParameter interface {
 	core.AstNode
 	AbstractDefinition
@@ -360,6 +462,23 @@ func (i *DeclaredParameterImpl) FieldInfos(field unique.Handle[string]) core.Fie
 		return core.FieldInfos{Multi: false, Reference: false}
 	default:
 		return core.FieldInfos{}
+	}
+}
+
+func (i *DeclaredParameterImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameName:
+		return nil, fmt.Errorf("DeclaredParameterImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("DeclaredParameterImpl.GetByPath: field '%s' does not exist in node '%s' of type 'DeclaredParameter'", fieldAndIndex[0], nodePath)
 	}
 }
 
@@ -436,6 +555,31 @@ func (i *EvaluationImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos
 	}
 }
 
+func (i *EvaluationImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameExpression:
+		if i.Expression() == nil {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("EvaluationImpl.GetByPath: field 'expression' is nil at '%s'", nodePath)
+		}
+		child := i.Expression()
+		if len(parts) == 1 {
+			return child, nil
+		}
+		return child.GetByPath(parts[1])
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("EvaluationImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Evaluation'", fieldAndIndex[0], nodePath)
+	}
+}
+
 type Expression interface {
 	core.AstNode
 
@@ -479,6 +623,17 @@ func (i *ExpressionImpl) ForEachReference(fn func(core.UntypedReference, unique.
 
 func (i *ExpressionImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
 	return core.FieldInfos{}
+}
+
+func (i *ExpressionImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	nodePath, _ := i.AstNodeBase.NodePath()
+	return nil, fmt.Errorf("ExpressionImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Expression'", fieldAndIndex[0], nodePath)
 }
 
 type BinaryExpression interface {
@@ -596,6 +751,43 @@ func (i *BinaryExpressionImpl) FieldInfos(field unique.Handle[string]) core.Fiel
 	}
 }
 
+func (i *BinaryExpressionImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameLeft:
+		if i.Left() == nil {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("BinaryExpressionImpl.GetByPath: field 'left' is nil at '%s'", nodePath)
+		}
+		child := i.Left()
+		if len(parts) == 1 {
+			return child, nil
+		}
+		return child.GetByPath(parts[1])
+	case fieldNameRight:
+		if i.Right() == nil {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("BinaryExpressionImpl.GetByPath: field 'right' is nil at '%s'", nodePath)
+		}
+		child := i.Right()
+		if len(parts) == 1 {
+			return child, nil
+		}
+		return child.GetByPath(parts[1])
+	case fieldNameOperator:
+		return nil, fmt.Errorf("BinaryExpressionImpl.GetByPath: field 'operator' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("BinaryExpressionImpl.GetByPath: field '%s' does not exist in node '%s' of type 'BinaryExpression'", fieldAndIndex[0], nodePath)
+	}
+}
+
 type FunctionCall interface {
 	core.AstNode
 	Expression
@@ -687,6 +879,34 @@ func (i *FunctionCallImpl) FieldInfos(field unique.Handle[string]) core.FieldInf
 	}
 }
 
+func (i *FunctionCallImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameArgs:
+		index, err := strconv.Atoi(fieldAndIndex[1])
+		if err != nil {
+			return nil, err
+		} else if index >= len(i.Args()) {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("FunctionCallImpl.GetByPath: index %d exceeds slice length of 'args' (%d) at '%s'", index, len(i.Args()), nodePath)
+		}
+		child := i.Args()[index]
+		if len(parts) == 1 {
+			return child, nil
+		}
+		return child.GetByPath(parts[1])
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("FunctionCallImpl.GetByPath: field '%s' does not exist in node '%s' of type 'FunctionCall'", fieldAndIndex[0], nodePath)
+	}
+}
+
 type NumberLiteral interface {
 	core.AstNode
 	Expression
@@ -759,6 +979,23 @@ func (i *NumberLiteralImpl) FieldInfos(field unique.Handle[string]) core.FieldIn
 		return core.FieldInfos{Multi: false, Reference: false}
 	default:
 		return core.FieldInfos{}
+	}
+}
+
+func (i *NumberLiteralImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameValue:
+		return nil, fmt.Errorf("NumberLiteralImpl.GetByPath: field 'value' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("NumberLiteralImpl.GetByPath: field '%s' does not exist in node '%s' of type 'NumberLiteral'", fieldAndIndex[0], nodePath)
 	}
 }
 

--- a/examples/arithmetics/types_gen.go
+++ b/examples/arithmetics/types_gen.go
@@ -111,12 +111,17 @@ func (i *ModuleImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameStatements:
 		index, err := strconv.Atoi(fieldAndIndex[1])
 		if err != nil {
-			return nil, err
-		} else if index >= len(i.Statements()) {
+			return nil, fmt.Errorf("ModuleImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
+		}
+		if index >= len(i.Statements()) {
 			nodePath, _ := i.AstNodeBase.NodePath()
-			return nil, fmt.Errorf("ModuleImpl.GetByPath: index %d exceeds slice length of 'statements' (%d) at '%s'", index, len(i.Statements()), nodePath)
+			return nil, fmt.Errorf("ModuleImpl.GetByPath: index %d exceeds length of slice in 'statements' (length=%d) in node '%s'", index, len(i.Statements()), nodePath)
 		}
 		child := i.Statements()[index]
+		if child == nil {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("ModuleImpl.GetByPath: item %d of slice in field 'statements' is nil in node '%s'", index, nodePath)
+		}
 		if len(parts) == 1 {
 			return child, nil
 		}
@@ -382,12 +387,17 @@ func (i *DefinitionImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameArgs:
 		index, err := strconv.Atoi(fieldAndIndex[1])
 		if err != nil {
-			return nil, err
-		} else if index >= len(i.Args()) {
+			return nil, fmt.Errorf("DefinitionImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
+		}
+		if index >= len(i.Args()) {
 			nodePath, _ := i.AstNodeBase.NodePath()
-			return nil, fmt.Errorf("DefinitionImpl.GetByPath: index %d exceeds slice length of 'args' (%d) at '%s'", index, len(i.Args()), nodePath)
+			return nil, fmt.Errorf("DefinitionImpl.GetByPath: index %d exceeds length of slice in 'args' (length=%d) in node '%s'", index, len(i.Args()), nodePath)
 		}
 		child := i.Args()[index]
+		if child == nil {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("DefinitionImpl.GetByPath: item %d of slice in field 'args' is nil in node '%s'", index, nodePath)
+		}
 		if len(parts) == 1 {
 			return child, nil
 		}
@@ -395,7 +405,7 @@ func (i *DefinitionImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameExpression:
 		if i.Expression() == nil {
 			nodePath, _ := i.AstNodeBase.NodePath()
-			return nil, fmt.Errorf("DefinitionImpl.GetByPath: field 'expression' is nil at '%s'", nodePath)
+			return nil, fmt.Errorf("DefinitionImpl.GetByPath: field 'expression' is nil in node '%s'", nodePath)
 		}
 		child := i.Expression()
 		if len(parts) == 1 {
@@ -567,7 +577,7 @@ func (i *EvaluationImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameExpression:
 		if i.Expression() == nil {
 			nodePath, _ := i.AstNodeBase.NodePath()
-			return nil, fmt.Errorf("EvaluationImpl.GetByPath: field 'expression' is nil at '%s'", nodePath)
+			return nil, fmt.Errorf("EvaluationImpl.GetByPath: field 'expression' is nil in node '%s'", nodePath)
 		}
 		child := i.Expression()
 		if len(parts) == 1 {
@@ -763,7 +773,7 @@ func (i *BinaryExpressionImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameLeft:
 		if i.Left() == nil {
 			nodePath, _ := i.AstNodeBase.NodePath()
-			return nil, fmt.Errorf("BinaryExpressionImpl.GetByPath: field 'left' is nil at '%s'", nodePath)
+			return nil, fmt.Errorf("BinaryExpressionImpl.GetByPath: field 'left' is nil in node '%s'", nodePath)
 		}
 		child := i.Left()
 		if len(parts) == 1 {
@@ -773,7 +783,7 @@ func (i *BinaryExpressionImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameRight:
 		if i.Right() == nil {
 			nodePath, _ := i.AstNodeBase.NodePath()
-			return nil, fmt.Errorf("BinaryExpressionImpl.GetByPath: field 'right' is nil at '%s'", nodePath)
+			return nil, fmt.Errorf("BinaryExpressionImpl.GetByPath: field 'right' is nil in node '%s'", nodePath)
 		}
 		child := i.Right()
 		if len(parts) == 1 {
@@ -891,12 +901,17 @@ func (i *FunctionCallImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameArgs:
 		index, err := strconv.Atoi(fieldAndIndex[1])
 		if err != nil {
-			return nil, err
-		} else if index >= len(i.Args()) {
+			return nil, fmt.Errorf("FunctionCallImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
+		}
+		if index >= len(i.Args()) {
 			nodePath, _ := i.AstNodeBase.NodePath()
-			return nil, fmt.Errorf("FunctionCallImpl.GetByPath: index %d exceeds slice length of 'args' (%d) at '%s'", index, len(i.Args()), nodePath)
+			return nil, fmt.Errorf("FunctionCallImpl.GetByPath: index %d exceeds length of slice in 'args' (length=%d) in node '%s'", index, len(i.Args()), nodePath)
 		}
 		child := i.Args()[index]
+		if child == nil {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("FunctionCallImpl.GetByPath: item %d of slice in field 'args' is nil in node '%s'", index, nodePath)
+		}
 		if len(parts) == 1 {
 			return child, nil
 		}

--- a/examples/arithmetics/types_gen.go
+++ b/examples/arithmetics/types_gen.go
@@ -4,6 +4,7 @@ package arithmetics
 
 import (
 	core "typefox.dev/fastbelt"
+	"unique"
 )
 
 type Module interface {
@@ -37,13 +38,13 @@ func NewModuleData() ModuleData {
 
 func (i *ModuleData) IsModule() {}
 
-func (i *ModuleData) ForEachNode(fn func(core.AstNode)) {
-	for _, item := range i.statements {
-		fn(item)
+func (i *ModuleData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+	for j, item := range i.statements {
+		fn(item, unique.Make("statements"), uint16(j))
 	}
 }
 
-func (i *ModuleData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *ModuleData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 func (i *ModuleData) Name() string {
@@ -75,12 +76,16 @@ type ModuleImpl struct {
 	ModuleData
 }
 
-func (i *ModuleImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *ModuleImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.ModuleData.ForEachNode(fn)
 }
 
-func (i *ModuleImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *ModuleImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.ModuleData.ForEachReference(fn)
+}
+
+func (i *ModuleImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return ArithmeticsFieldInfos["Module"][field.Value()]
 }
 
 type Statement interface {
@@ -105,10 +110,10 @@ func NewStatementData() StatementData {
 
 func (i *StatementData) IsStatement() {}
 
-func (i *StatementData) ForEachNode(fn func(core.AstNode)) {
+func (i *StatementData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 }
 
-func (i *StatementData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *StatementData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 type StatementImpl struct {
@@ -116,12 +121,16 @@ type StatementImpl struct {
 	StatementData
 }
 
-func (i *StatementImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *StatementImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.StatementData.ForEachNode(fn)
 }
 
-func (i *StatementImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *StatementImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.StatementData.ForEachReference(fn)
+}
+
+func (i *StatementImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return ArithmeticsFieldInfos["Statement"][field.Value()]
 }
 
 type AbstractDefinition interface {
@@ -150,10 +159,10 @@ func NewAbstractDefinitionData() AbstractDefinitionData {
 
 func (i *AbstractDefinitionData) IsAbstractDefinition() {}
 
-func (i *AbstractDefinitionData) ForEachNode(fn func(core.AstNode)) {
+func (i *AbstractDefinitionData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 }
 
-func (i *AbstractDefinitionData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *AbstractDefinitionData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 func (i *AbstractDefinitionData) Name() string {
@@ -177,12 +186,16 @@ type AbstractDefinitionImpl struct {
 	AbstractDefinitionData
 }
 
-func (i *AbstractDefinitionImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *AbstractDefinitionImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.AbstractDefinitionData.ForEachNode(fn)
 }
 
-func (i *AbstractDefinitionImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *AbstractDefinitionImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.AbstractDefinitionData.ForEachReference(fn)
+}
+
+func (i *AbstractDefinitionImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return ArithmeticsFieldInfos["AbstractDefinition"][field.Value()]
 }
 
 type Definition interface {
@@ -219,16 +232,16 @@ func NewDefinitionData() DefinitionData {
 
 func (i *DefinitionData) IsDefinition() {}
 
-func (i *DefinitionData) ForEachNode(fn func(core.AstNode)) {
-	for _, item := range i.args {
-		fn(item)
+func (i *DefinitionData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+	for j, item := range i.args {
+		fn(item, unique.Make("args"), uint16(j))
 	}
 	if i.expression != nil {
-		fn(i.expression)
+		fn(i.expression, unique.Make("expression"), 0)
 	}
 }
 
-func (i *DefinitionData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *DefinitionData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 func (i *DefinitionData) Args() []DeclaredParameter {
@@ -258,16 +271,20 @@ type DefinitionImpl struct {
 	DefinitionData
 }
 
-func (i *DefinitionImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *DefinitionImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.AbstractDefinitionData.ForEachNode(fn)
 	i.StatementData.ForEachNode(fn)
 	i.DefinitionData.ForEachNode(fn)
 }
 
-func (i *DefinitionImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *DefinitionImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.AbstractDefinitionData.ForEachReference(fn)
 	i.StatementData.ForEachReference(fn)
 	i.DefinitionData.ForEachReference(fn)
+}
+
+func (i *DefinitionImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return ArithmeticsFieldInfos["Definition"][field.Value()]
 }
 
 type DeclaredParameter interface {
@@ -294,10 +311,10 @@ func NewDeclaredParameterData() DeclaredParameterData {
 
 func (i *DeclaredParameterData) IsDeclaredParameter() {}
 
-func (i *DeclaredParameterData) ForEachNode(fn func(core.AstNode)) {
+func (i *DeclaredParameterData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 }
 
-func (i *DeclaredParameterData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *DeclaredParameterData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 type DeclaredParameterImpl struct {
@@ -306,14 +323,18 @@ type DeclaredParameterImpl struct {
 	DeclaredParameterData
 }
 
-func (i *DeclaredParameterImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *DeclaredParameterImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.AbstractDefinitionData.ForEachNode(fn)
 	i.DeclaredParameterData.ForEachNode(fn)
 }
 
-func (i *DeclaredParameterImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *DeclaredParameterImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.AbstractDefinitionData.ForEachReference(fn)
 	i.DeclaredParameterData.ForEachReference(fn)
+}
+
+func (i *DeclaredParameterImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return ArithmeticsFieldInfos["DeclaredParameter"][field.Value()]
 }
 
 type Evaluation interface {
@@ -343,13 +364,13 @@ func NewEvaluationData() EvaluationData {
 
 func (i *EvaluationData) IsEvaluation() {}
 
-func (i *EvaluationData) ForEachNode(fn func(core.AstNode)) {
+func (i *EvaluationData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	if i.expression != nil {
-		fn(i.expression)
+		fn(i.expression, unique.Make("expression"), 0)
 	}
 }
 
-func (i *EvaluationData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *EvaluationData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 func (i *EvaluationData) Expression() Expression {
@@ -370,14 +391,18 @@ type EvaluationImpl struct {
 	EvaluationData
 }
 
-func (i *EvaluationImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *EvaluationImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.StatementData.ForEachNode(fn)
 	i.EvaluationData.ForEachNode(fn)
 }
 
-func (i *EvaluationImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *EvaluationImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.StatementData.ForEachReference(fn)
 	i.EvaluationData.ForEachReference(fn)
+}
+
+func (i *EvaluationImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return ArithmeticsFieldInfos["Evaluation"][field.Value()]
 }
 
 type Expression interface {
@@ -402,10 +427,10 @@ func NewExpressionData() ExpressionData {
 
 func (i *ExpressionData) IsExpression() {}
 
-func (i *ExpressionData) ForEachNode(fn func(core.AstNode)) {
+func (i *ExpressionData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 }
 
-func (i *ExpressionData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *ExpressionData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 type ExpressionImpl struct {
@@ -413,12 +438,16 @@ type ExpressionImpl struct {
 	ExpressionData
 }
 
-func (i *ExpressionImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *ExpressionImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.ExpressionData.ForEachNode(fn)
 }
 
-func (i *ExpressionImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *ExpressionImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.ExpressionData.ForEachReference(fn)
+}
+
+func (i *ExpressionImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return ArithmeticsFieldInfos["Expression"][field.Value()]
 }
 
 type BinaryExpression interface {
@@ -455,16 +484,16 @@ func NewBinaryExpressionData() BinaryExpressionData {
 
 func (i *BinaryExpressionData) IsBinaryExpression() {}
 
-func (i *BinaryExpressionData) ForEachNode(fn func(core.AstNode)) {
+func (i *BinaryExpressionData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	if i.left != nil {
-		fn(i.left)
+		fn(i.left, unique.Make("left"), 0)
 	}
 	if i.right != nil {
-		fn(i.right)
+		fn(i.right, unique.Make("right"), 0)
 	}
 }
 
-func (i *BinaryExpressionData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *BinaryExpressionData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 func (i *BinaryExpressionData) Left() Expression {
@@ -513,14 +542,18 @@ type BinaryExpressionImpl struct {
 	BinaryExpressionData
 }
 
-func (i *BinaryExpressionImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *BinaryExpressionImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.ExpressionData.ForEachNode(fn)
 	i.BinaryExpressionData.ForEachNode(fn)
 }
 
-func (i *BinaryExpressionImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *BinaryExpressionImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.ExpressionData.ForEachReference(fn)
 	i.BinaryExpressionData.ForEachReference(fn)
+}
+
+func (i *BinaryExpressionImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return ArithmeticsFieldInfos["BinaryExpression"][field.Value()]
 }
 
 type FunctionCall interface {
@@ -555,15 +588,15 @@ func NewFunctionCallData() FunctionCallData {
 
 func (i *FunctionCallData) IsFunctionCall() {}
 
-func (i *FunctionCallData) ForEachNode(fn func(core.AstNode)) {
-	for _, item := range i.args {
-		fn(item)
+func (i *FunctionCallData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+	for j, item := range i.args {
+		fn(item, unique.Make("args"), uint16(j))
 	}
 }
 
-func (i *FunctionCallData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *FunctionCallData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i.callable != nil {
-		fn(i.callable)
+		fn(i.callable, unique.Make("callable"), 0)
 	}
 }
 
@@ -593,14 +626,18 @@ type FunctionCallImpl struct {
 	FunctionCallData
 }
 
-func (i *FunctionCallImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *FunctionCallImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.ExpressionData.ForEachNode(fn)
 	i.FunctionCallData.ForEachNode(fn)
 }
 
-func (i *FunctionCallImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *FunctionCallImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.ExpressionData.ForEachReference(fn)
 	i.FunctionCallData.ForEachReference(fn)
+}
+
+func (i *FunctionCallImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return ArithmeticsFieldInfos["FunctionCall"][field.Value()]
 }
 
 type NumberLiteral interface {
@@ -631,10 +668,10 @@ func NewNumberLiteralData() NumberLiteralData {
 
 func (i *NumberLiteralData) IsNumberLiteral() {}
 
-func (i *NumberLiteralData) ForEachNode(fn func(core.AstNode)) {
+func (i *NumberLiteralData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 }
 
-func (i *NumberLiteralData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *NumberLiteralData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 func (i *NumberLiteralData) Value() string {
@@ -659,14 +696,18 @@ type NumberLiteralImpl struct {
 	NumberLiteralData
 }
 
-func (i *NumberLiteralImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *NumberLiteralImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.ExpressionData.ForEachNode(fn)
 	i.NumberLiteralData.ForEachNode(fn)
 }
 
-func (i *NumberLiteralImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *NumberLiteralImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.ExpressionData.ForEachReference(fn)
 	i.NumberLiteralData.ForEachReference(fn)
+}
+
+func (i *NumberLiteralImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return ArithmeticsFieldInfos["NumberLiteral"][field.Value()]
 }
 
 var ArithmeticsSyntheticFactories = map[string]func() core.AstNode{
@@ -680,4 +721,81 @@ var ArithmeticsSyntheticFactories = map[string]func() core.AstNode{
 	"Module":             func() core.AstNode { return NewModule() },
 	"NumberLiteral":      func() core.AstNode { return NewNumberLiteral() },
 	"Statement":          func() core.AstNode { return NewStatement() },
+}
+
+var ArithmeticsFieldInfos = map[string]map[string]core.FieldInfos{
+	"AbstractDefinition": map[string]core.FieldInfos{
+		"name": {
+			Multi:     false,
+			Reference: false,
+		},
+	},
+	"BinaryExpression": map[string]core.FieldInfos{
+		"left": {
+			Multi:     false,
+			Reference: false,
+		},
+		"operator": {
+			Multi:     false,
+			Reference: false,
+		},
+		"right": {
+			Multi:     false,
+			Reference: false,
+		},
+	},
+	"DeclaredParameter": map[string]core.FieldInfos{
+		"name": {
+			Multi:     false,
+			Reference: false,
+		},
+	},
+	"Definition": map[string]core.FieldInfos{
+		"args": {
+			Multi:     true,
+			Reference: false,
+		},
+		"expression": {
+			Multi:     false,
+			Reference: false,
+		},
+		"name": {
+			Multi:     false,
+			Reference: false,
+		},
+	},
+	"Evaluation": map[string]core.FieldInfos{
+		"expression": {
+			Multi:     false,
+			Reference: false,
+		},
+	},
+	"Expression": map[string]core.FieldInfos{},
+	"FunctionCall": map[string]core.FieldInfos{
+		"args": {
+			Multi:     true,
+			Reference: false,
+		},
+		"callable": {
+			Multi:     false,
+			Reference: true,
+		},
+	},
+	"Module": map[string]core.FieldInfos{
+		"name": {
+			Multi:     false,
+			Reference: false,
+		},
+		"statements": {
+			Multi:     true,
+			Reference: false,
+		},
+	},
+	"NumberLiteral": map[string]core.FieldInfos{
+		"value": {
+			Multi:     false,
+			Reference: false,
+		},
+	},
+	"Statement": map[string]core.FieldInfos{},
 }

--- a/examples/arithmetics/types_gen.go
+++ b/examples/arithmetics/types_gen.go
@@ -40,7 +40,7 @@ func (i *ModuleData) IsModule() {}
 
 func (i *ModuleData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	for j, item := range i.statements {
-		fn(item, unique.Make("statements"), uint16(j))
+		fn(item, fieldNameStatements, uint16(j))
 	}
 }
 
@@ -85,7 +85,14 @@ func (i *ModuleImpl) ForEachReference(fn func(core.UntypedReference, unique.Hand
 }
 
 func (i *ModuleImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return ArithmeticsFieldInfos["Module"][field.Value()]
+	switch field {
+	case fieldNameName:
+		return core.FieldInfos{Multi: false, Reference: false}
+	case fieldNameStatements:
+		return core.FieldInfos{Multi: true, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type Statement interface {
@@ -130,7 +137,7 @@ func (i *StatementImpl) ForEachReference(fn func(core.UntypedReference, unique.H
 }
 
 func (i *StatementImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return ArithmeticsFieldInfos["Statement"][field.Value()]
+	return core.FieldInfos{}
 }
 
 type AbstractDefinition interface {
@@ -195,7 +202,12 @@ func (i *AbstractDefinitionImpl) ForEachReference(fn func(core.UntypedReference,
 }
 
 func (i *AbstractDefinitionImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return ArithmeticsFieldInfos["AbstractDefinition"][field.Value()]
+	switch field {
+	case fieldNameName:
+		return core.FieldInfos{Multi: false, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type Definition interface {
@@ -234,10 +246,10 @@ func (i *DefinitionData) IsDefinition() {}
 
 func (i *DefinitionData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	for j, item := range i.args {
-		fn(item, unique.Make("args"), uint16(j))
+		fn(item, fieldNameArgs, uint16(j))
 	}
 	if i.expression != nil {
-		fn(i.expression, unique.Make("expression"), 0)
+		fn(i.expression, fieldNameExpression, 0)
 	}
 }
 
@@ -284,7 +296,16 @@ func (i *DefinitionImpl) ForEachReference(fn func(core.UntypedReference, unique.
 }
 
 func (i *DefinitionImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return ArithmeticsFieldInfos["Definition"][field.Value()]
+	switch field {
+	case fieldNameArgs:
+		return core.FieldInfos{Multi: true, Reference: false}
+	case fieldNameExpression:
+		return core.FieldInfos{Multi: false, Reference: false}
+	case fieldNameName:
+		return core.FieldInfos{Multi: false, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type DeclaredParameter interface {
@@ -334,7 +355,12 @@ func (i *DeclaredParameterImpl) ForEachReference(fn func(core.UntypedReference, 
 }
 
 func (i *DeclaredParameterImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return ArithmeticsFieldInfos["DeclaredParameter"][field.Value()]
+	switch field {
+	case fieldNameName:
+		return core.FieldInfos{Multi: false, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type Evaluation interface {
@@ -366,7 +392,7 @@ func (i *EvaluationData) IsEvaluation() {}
 
 func (i *EvaluationData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	if i.expression != nil {
-		fn(i.expression, unique.Make("expression"), 0)
+		fn(i.expression, fieldNameExpression, 0)
 	}
 }
 
@@ -402,7 +428,12 @@ func (i *EvaluationImpl) ForEachReference(fn func(core.UntypedReference, unique.
 }
 
 func (i *EvaluationImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return ArithmeticsFieldInfos["Evaluation"][field.Value()]
+	switch field {
+	case fieldNameExpression:
+		return core.FieldInfos{Multi: false, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type Expression interface {
@@ -447,7 +478,7 @@ func (i *ExpressionImpl) ForEachReference(fn func(core.UntypedReference, unique.
 }
 
 func (i *ExpressionImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return ArithmeticsFieldInfos["Expression"][field.Value()]
+	return core.FieldInfos{}
 }
 
 type BinaryExpression interface {
@@ -486,10 +517,10 @@ func (i *BinaryExpressionData) IsBinaryExpression() {}
 
 func (i *BinaryExpressionData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	if i.left != nil {
-		fn(i.left, unique.Make("left"), 0)
+		fn(i.left, fieldNameLeft, 0)
 	}
 	if i.right != nil {
-		fn(i.right, unique.Make("right"), 0)
+		fn(i.right, fieldNameRight, 0)
 	}
 }
 
@@ -553,7 +584,16 @@ func (i *BinaryExpressionImpl) ForEachReference(fn func(core.UntypedReference, u
 }
 
 func (i *BinaryExpressionImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return ArithmeticsFieldInfos["BinaryExpression"][field.Value()]
+	switch field {
+	case fieldNameLeft:
+		return core.FieldInfos{Multi: false, Reference: false}
+	case fieldNameOperator:
+		return core.FieldInfos{Multi: false, Reference: false}
+	case fieldNameRight:
+		return core.FieldInfos{Multi: false, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type FunctionCall interface {
@@ -590,13 +630,13 @@ func (i *FunctionCallData) IsFunctionCall() {}
 
 func (i *FunctionCallData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	for j, item := range i.args {
-		fn(item, unique.Make("args"), uint16(j))
+		fn(item, fieldNameArgs, uint16(j))
 	}
 }
 
 func (i *FunctionCallData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i.callable != nil {
-		fn(i.callable, unique.Make("callable"), 0)
+		fn(i.callable, fieldNameCallable, 0)
 	}
 }
 
@@ -637,7 +677,14 @@ func (i *FunctionCallImpl) ForEachReference(fn func(core.UntypedReference, uniqu
 }
 
 func (i *FunctionCallImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return ArithmeticsFieldInfos["FunctionCall"][field.Value()]
+	switch field {
+	case fieldNameArgs:
+		return core.FieldInfos{Multi: true, Reference: false}
+	case fieldNameCallable:
+		return core.FieldInfos{Multi: false, Reference: true}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type NumberLiteral interface {
@@ -707,8 +754,25 @@ func (i *NumberLiteralImpl) ForEachReference(fn func(core.UntypedReference, uniq
 }
 
 func (i *NumberLiteralImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return ArithmeticsFieldInfos["NumberLiteral"][field.Value()]
+	switch field {
+	case fieldNameValue:
+		return core.FieldInfos{Multi: false, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
+
+var (
+	fieldNameArgs       = unique.Make("args")
+	fieldNameCallable   = unique.Make("callable")
+	fieldNameExpression = unique.Make("expression")
+	fieldNameLeft       = unique.Make("left")
+	fieldNameName       = unique.Make("name")
+	fieldNameOperator   = unique.Make("operator")
+	fieldNameRight      = unique.Make("right")
+	fieldNameStatements = unique.Make("statements")
+	fieldNameValue      = unique.Make("value")
+)
 
 var ArithmeticsSyntheticFactories = map[string]func() core.AstNode{
 	"AbstractDefinition": func() core.AstNode { return NewAbstractDefinition() },
@@ -721,81 +785,4 @@ var ArithmeticsSyntheticFactories = map[string]func() core.AstNode{
 	"Module":             func() core.AstNode { return NewModule() },
 	"NumberLiteral":      func() core.AstNode { return NewNumberLiteral() },
 	"Statement":          func() core.AstNode { return NewStatement() },
-}
-
-var ArithmeticsFieldInfos = map[string]map[string]core.FieldInfos{
-	"AbstractDefinition": map[string]core.FieldInfos{
-		"name": {
-			Multi:     false,
-			Reference: false,
-		},
-	},
-	"BinaryExpression": map[string]core.FieldInfos{
-		"left": {
-			Multi:     false,
-			Reference: false,
-		},
-		"operator": {
-			Multi:     false,
-			Reference: false,
-		},
-		"right": {
-			Multi:     false,
-			Reference: false,
-		},
-	},
-	"DeclaredParameter": map[string]core.FieldInfos{
-		"name": {
-			Multi:     false,
-			Reference: false,
-		},
-	},
-	"Definition": map[string]core.FieldInfos{
-		"args": {
-			Multi:     true,
-			Reference: false,
-		},
-		"expression": {
-			Multi:     false,
-			Reference: false,
-		},
-		"name": {
-			Multi:     false,
-			Reference: false,
-		},
-	},
-	"Evaluation": map[string]core.FieldInfos{
-		"expression": {
-			Multi:     false,
-			Reference: false,
-		},
-	},
-	"Expression": map[string]core.FieldInfos{},
-	"FunctionCall": map[string]core.FieldInfos{
-		"args": {
-			Multi:     true,
-			Reference: false,
-		},
-		"callable": {
-			Multi:     false,
-			Reference: true,
-		},
-	},
-	"Module": map[string]core.FieldInfos{
-		"name": {
-			Multi:     false,
-			Reference: false,
-		},
-		"statements": {
-			Multi:     true,
-			Reference: false,
-		},
-	},
-	"NumberLiteral": map[string]core.FieldInfos{
-		"value": {
-			Multi:     false,
-			Reference: false,
-		},
-	},
-	"Statement": map[string]core.FieldInfos{},
 }

--- a/examples/arithmetics/types_gen.go
+++ b/examples/arithmetics/types_gen.go
@@ -86,28 +86,28 @@ func (i *ModuleImpl) ForEachReference(fn func(core.UntypedReference, unique.Hand
 	i.ModuleData.ForEachReference(fn)
 }
 
-func (i *ModuleImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *ModuleImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, index := path.Shift()
 	switch field {
 	case fieldNameStatements:
 		if index >= len(i.Statements()) {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("ModuleImpl.GetByPath: index %d exceeds length of slice in 'statements' (length=%d) in node '%s'", index, len(i.Statements()), nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("ModuleImpl.Resolve: index %d exceeds length of slice in 'statements' (length=%d) in node '%s'", index, len(i.Statements()), nodePath)
 		}
 		child := i.Statements()[index]
 		if child == nil {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("ModuleImpl.GetByPath: item %d of slice in field 'statements' is nil in node '%s'", index, nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("ModuleImpl.Resolve: item %d of slice in field 'statements' is nil in node '%s'", index, nodePath)
 		}
 		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(path)
+		return child.Resolve(path)
 	case fieldNameName:
-		return nil, fmt.Errorf("ModuleImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("ModuleImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("ModuleImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Module'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("ModuleImpl.Resolve: field '%s' does not exist in node '%s' of type 'Module'", field.Value(), nodePath)
 	}
 }
 
@@ -152,10 +152,10 @@ func (i *StatementImpl) ForEachReference(fn func(core.UntypedReference, unique.H
 	i.StatementData.ForEachReference(fn)
 }
 
-func (i *StatementImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *StatementImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
-	nodePath, _ := core.NodePath(i)
-	return nil, fmt.Errorf("StatementImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Statement'", field.Value(), nodePath)
+	nodePath, _ := core.PathOf(i)
+	return nil, fmt.Errorf("StatementImpl.Resolve: field '%s' does not exist in node '%s' of type 'Statement'", field.Value(), nodePath)
 }
 
 type AbstractDefinition interface {
@@ -219,14 +219,14 @@ func (i *AbstractDefinitionImpl) ForEachReference(fn func(core.UntypedReference,
 	i.AbstractDefinitionData.ForEachReference(fn)
 }
 
-func (i *AbstractDefinitionImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *AbstractDefinitionImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameName:
-		return nil, fmt.Errorf("AbstractDefinitionImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("AbstractDefinitionImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("AbstractDefinitionImpl.GetByPath: field '%s' does not exist in node '%s' of type 'AbstractDefinition'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("AbstractDefinitionImpl.Resolve: field '%s' does not exist in node '%s' of type 'AbstractDefinition'", field.Value(), nodePath)
 	}
 }
 
@@ -315,38 +315,38 @@ func (i *DefinitionImpl) ForEachReference(fn func(core.UntypedReference, unique.
 	i.DefinitionData.ForEachReference(fn)
 }
 
-func (i *DefinitionImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *DefinitionImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, index := path.Shift()
 	switch field {
 	case fieldNameArgs:
 		if index >= len(i.Args()) {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("DefinitionImpl.GetByPath: index %d exceeds length of slice in 'args' (length=%d) in node '%s'", index, len(i.Args()), nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("DefinitionImpl.Resolve: index %d exceeds length of slice in 'args' (length=%d) in node '%s'", index, len(i.Args()), nodePath)
 		}
 		child := i.Args()[index]
 		if child == nil {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("DefinitionImpl.GetByPath: item %d of slice in field 'args' is nil in node '%s'", index, nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("DefinitionImpl.Resolve: item %d of slice in field 'args' is nil in node '%s'", index, nodePath)
 		}
 		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(path)
+		return child.Resolve(path)
 	case fieldNameExpression:
 		if i.Expression() == nil {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("DefinitionImpl.GetByPath: field 'expression' is nil in node '%s'", nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("DefinitionImpl.Resolve: field 'expression' is nil in node '%s'", nodePath)
 		}
 		child := i.Expression()
 		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(path)
+		return child.Resolve(path)
 	case fieldNameName:
-		return nil, fmt.Errorf("DefinitionImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("DefinitionImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("DefinitionImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Definition'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("DefinitionImpl.Resolve: field '%s' does not exist in node '%s' of type 'Definition'", field.Value(), nodePath)
 	}
 }
 
@@ -396,14 +396,14 @@ func (i *DeclaredParameterImpl) ForEachReference(fn func(core.UntypedReference, 
 	i.DeclaredParameterData.ForEachReference(fn)
 }
 
-func (i *DeclaredParameterImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *DeclaredParameterImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameName:
-		return nil, fmt.Errorf("DeclaredParameterImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("DeclaredParameterImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("DeclaredParameterImpl.GetByPath: field '%s' does not exist in node '%s' of type 'DeclaredParameter'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("DeclaredParameterImpl.Resolve: field '%s' does not exist in node '%s' of type 'DeclaredParameter'", field.Value(), nodePath)
 	}
 }
 
@@ -471,22 +471,22 @@ func (i *EvaluationImpl) ForEachReference(fn func(core.UntypedReference, unique.
 	i.EvaluationData.ForEachReference(fn)
 }
 
-func (i *EvaluationImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *EvaluationImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameExpression:
 		if i.Expression() == nil {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("EvaluationImpl.GetByPath: field 'expression' is nil in node '%s'", nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("EvaluationImpl.Resolve: field 'expression' is nil in node '%s'", nodePath)
 		}
 		child := i.Expression()
 		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(path)
+		return child.Resolve(path)
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("EvaluationImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Evaluation'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("EvaluationImpl.Resolve: field '%s' does not exist in node '%s' of type 'Evaluation'", field.Value(), nodePath)
 	}
 }
 
@@ -531,10 +531,10 @@ func (i *ExpressionImpl) ForEachReference(fn func(core.UntypedReference, unique.
 	i.ExpressionData.ForEachReference(fn)
 }
 
-func (i *ExpressionImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *ExpressionImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
-	nodePath, _ := core.NodePath(i)
-	return nil, fmt.Errorf("ExpressionImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Expression'", field.Value(), nodePath)
+	nodePath, _ := core.PathOf(i)
+	return nil, fmt.Errorf("ExpressionImpl.Resolve: field '%s' does not exist in node '%s' of type 'Expression'", field.Value(), nodePath)
 }
 
 type BinaryExpression interface {
@@ -639,34 +639,34 @@ func (i *BinaryExpressionImpl) ForEachReference(fn func(core.UntypedReference, u
 	i.BinaryExpressionData.ForEachReference(fn)
 }
 
-func (i *BinaryExpressionImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *BinaryExpressionImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameLeft:
 		if i.Left() == nil {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("BinaryExpressionImpl.GetByPath: field 'left' is nil in node '%s'", nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("BinaryExpressionImpl.Resolve: field 'left' is nil in node '%s'", nodePath)
 		}
 		child := i.Left()
 		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(path)
+		return child.Resolve(path)
 	case fieldNameRight:
 		if i.Right() == nil {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("BinaryExpressionImpl.GetByPath: field 'right' is nil in node '%s'", nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("BinaryExpressionImpl.Resolve: field 'right' is nil in node '%s'", nodePath)
 		}
 		child := i.Right()
 		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(path)
+		return child.Resolve(path)
 	case fieldNameOperator:
-		return nil, fmt.Errorf("BinaryExpressionImpl.GetByPath: field 'operator' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("BinaryExpressionImpl.Resolve: field 'operator' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("BinaryExpressionImpl.GetByPath: field '%s' does not exist in node '%s' of type 'BinaryExpression'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("BinaryExpressionImpl.Resolve: field '%s' does not exist in node '%s' of type 'BinaryExpression'", field.Value(), nodePath)
 	}
 }
 
@@ -750,28 +750,28 @@ func (i *FunctionCallImpl) ForEachReference(fn func(core.UntypedReference, uniqu
 	i.FunctionCallData.ForEachReference(fn)
 }
 
-func (i *FunctionCallImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *FunctionCallImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, index := path.Shift()
 	switch field {
 	case fieldNameArgs:
 		if index >= len(i.Args()) {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("FunctionCallImpl.GetByPath: index %d exceeds length of slice in 'args' (length=%d) in node '%s'", index, len(i.Args()), nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("FunctionCallImpl.Resolve: index %d exceeds length of slice in 'args' (length=%d) in node '%s'", index, len(i.Args()), nodePath)
 		}
 		child := i.Args()[index]
 		if child == nil {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("FunctionCallImpl.GetByPath: item %d of slice in field 'args' is nil in node '%s'", index, nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("FunctionCallImpl.Resolve: item %d of slice in field 'args' is nil in node '%s'", index, nodePath)
 		}
 		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(path)
+		return child.Resolve(path)
 	case fieldNameCallable:
-		return nil, fmt.Errorf("FunctionCallImpl.GetByPath: field 'callable' is a cross-reference instead of a container field")
+		return nil, fmt.Errorf("FunctionCallImpl.Resolve: field 'callable' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("FunctionCallImpl.GetByPath: field '%s' does not exist in node '%s' of type 'FunctionCall'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("FunctionCallImpl.Resolve: field '%s' does not exist in node '%s' of type 'FunctionCall'", field.Value(), nodePath)
 	}
 }
 
@@ -841,14 +841,14 @@ func (i *NumberLiteralImpl) ForEachReference(fn func(core.UntypedReference, uniq
 	i.NumberLiteralData.ForEachReference(fn)
 }
 
-func (i *NumberLiteralImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *NumberLiteralImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameValue:
-		return nil, fmt.Errorf("NumberLiteralImpl.GetByPath: field 'value' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("NumberLiteralImpl.Resolve: field 'value' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("NumberLiteralImpl.GetByPath: field '%s' does not exist in node '%s' of type 'NumberLiteral'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("NumberLiteralImpl.Resolve: field '%s' does not exist in node '%s' of type 'NumberLiteral'", field.Value(), nodePath)
 	}
 }
 

--- a/examples/arithmetics/types_gen.go
+++ b/examples/arithmetics/types_gen.go
@@ -87,7 +87,10 @@ func (i *ModuleImpl) ForEachReference(fn func(core.UntypedReference, unique.Hand
 }
 
 func (i *ModuleImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, index := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, index := path.Head()
 	switch field {
 	case fieldNameStatements:
 		if index >= len(i.Statements()) {
@@ -99,10 +102,7 @@ func (i *ModuleImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 			nodePath, _ := core.PathOf(i)
 			return nil, fmt.Errorf("ModuleImpl.Resolve: item %d of slice in field 'statements' is nil in node '%s'", index, nodePath)
 		}
-		if path.Empty() {
-			return child, nil
-		}
-		return child.Resolve(path)
+		return child.Resolve(path.Tail())
 	case fieldNameName:
 		return nil, fmt.Errorf("ModuleImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
 	default:
@@ -153,7 +153,10 @@ func (i *StatementImpl) ForEachReference(fn func(core.UntypedReference, unique.H
 }
 
 func (i *StatementImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	nodePath, _ := core.PathOf(i)
 	return nil, fmt.Errorf("StatementImpl.Resolve: field '%s' does not exist in node '%s' of type 'Statement'", field.Value(), nodePath)
 }
@@ -220,7 +223,10 @@ func (i *AbstractDefinitionImpl) ForEachReference(fn func(core.UntypedReference,
 }
 
 func (i *AbstractDefinitionImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameName:
 		return nil, fmt.Errorf("AbstractDefinitionImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
@@ -316,7 +322,10 @@ func (i *DefinitionImpl) ForEachReference(fn func(core.UntypedReference, unique.
 }
 
 func (i *DefinitionImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, index := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, index := path.Head()
 	switch field {
 	case fieldNameArgs:
 		if index >= len(i.Args()) {
@@ -328,20 +337,14 @@ func (i *DefinitionImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 			nodePath, _ := core.PathOf(i)
 			return nil, fmt.Errorf("DefinitionImpl.Resolve: item %d of slice in field 'args' is nil in node '%s'", index, nodePath)
 		}
-		if path.Empty() {
-			return child, nil
-		}
-		return child.Resolve(path)
+		return child.Resolve(path.Tail())
 	case fieldNameExpression:
 		if i.Expression() == nil {
 			nodePath, _ := core.PathOf(i)
 			return nil, fmt.Errorf("DefinitionImpl.Resolve: field 'expression' is nil in node '%s'", nodePath)
 		}
 		child := i.Expression()
-		if path.Empty() {
-			return child, nil
-		}
-		return child.Resolve(path)
+		return child.Resolve(path.Tail())
 	case fieldNameName:
 		return nil, fmt.Errorf("DefinitionImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
 	default:
@@ -397,7 +400,10 @@ func (i *DeclaredParameterImpl) ForEachReference(fn func(core.UntypedReference, 
 }
 
 func (i *DeclaredParameterImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameName:
 		return nil, fmt.Errorf("DeclaredParameterImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
@@ -472,7 +478,10 @@ func (i *EvaluationImpl) ForEachReference(fn func(core.UntypedReference, unique.
 }
 
 func (i *EvaluationImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameExpression:
 		if i.Expression() == nil {
@@ -480,10 +489,7 @@ func (i *EvaluationImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 			return nil, fmt.Errorf("EvaluationImpl.Resolve: field 'expression' is nil in node '%s'", nodePath)
 		}
 		child := i.Expression()
-		if path.Empty() {
-			return child, nil
-		}
-		return child.Resolve(path)
+		return child.Resolve(path.Tail())
 	default:
 		nodePath, _ := core.PathOf(i)
 		return nil, fmt.Errorf("EvaluationImpl.Resolve: field '%s' does not exist in node '%s' of type 'Evaluation'", field.Value(), nodePath)
@@ -532,7 +538,10 @@ func (i *ExpressionImpl) ForEachReference(fn func(core.UntypedReference, unique.
 }
 
 func (i *ExpressionImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	nodePath, _ := core.PathOf(i)
 	return nil, fmt.Errorf("ExpressionImpl.Resolve: field '%s' does not exist in node '%s' of type 'Expression'", field.Value(), nodePath)
 }
@@ -640,7 +649,10 @@ func (i *BinaryExpressionImpl) ForEachReference(fn func(core.UntypedReference, u
 }
 
 func (i *BinaryExpressionImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameLeft:
 		if i.Left() == nil {
@@ -648,20 +660,14 @@ func (i *BinaryExpressionImpl) Resolve(path core.FragmentPath) (core.AstNode, er
 			return nil, fmt.Errorf("BinaryExpressionImpl.Resolve: field 'left' is nil in node '%s'", nodePath)
 		}
 		child := i.Left()
-		if path.Empty() {
-			return child, nil
-		}
-		return child.Resolve(path)
+		return child.Resolve(path.Tail())
 	case fieldNameRight:
 		if i.Right() == nil {
 			nodePath, _ := core.PathOf(i)
 			return nil, fmt.Errorf("BinaryExpressionImpl.Resolve: field 'right' is nil in node '%s'", nodePath)
 		}
 		child := i.Right()
-		if path.Empty() {
-			return child, nil
-		}
-		return child.Resolve(path)
+		return child.Resolve(path.Tail())
 	case fieldNameOperator:
 		return nil, fmt.Errorf("BinaryExpressionImpl.Resolve: field 'operator' holds a primitive value instead of an ast node")
 	default:
@@ -751,7 +757,10 @@ func (i *FunctionCallImpl) ForEachReference(fn func(core.UntypedReference, uniqu
 }
 
 func (i *FunctionCallImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, index := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, index := path.Head()
 	switch field {
 	case fieldNameArgs:
 		if index >= len(i.Args()) {
@@ -763,10 +772,7 @@ func (i *FunctionCallImpl) Resolve(path core.FragmentPath) (core.AstNode, error)
 			nodePath, _ := core.PathOf(i)
 			return nil, fmt.Errorf("FunctionCallImpl.Resolve: item %d of slice in field 'args' is nil in node '%s'", index, nodePath)
 		}
-		if path.Empty() {
-			return child, nil
-		}
-		return child.Resolve(path)
+		return child.Resolve(path.Tail())
 	case fieldNameCallable:
 		return nil, fmt.Errorf("FunctionCallImpl.Resolve: field 'callable' is a cross-reference instead of a container field")
 	default:
@@ -842,7 +848,10 @@ func (i *NumberLiteralImpl) ForEachReference(fn func(core.UntypedReference, uniq
 }
 
 func (i *NumberLiteralImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameValue:
 		return nil, fmt.Errorf("NumberLiteralImpl.Resolve: field 'value' holds a primitive value instead of an ast node")

--- a/examples/arithmetics/types_gen.go
+++ b/examples/arithmetics/types_gen.go
@@ -4,8 +4,6 @@ package arithmetics
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
 	"unique"
 
 	core "typefox.dev/fastbelt"
@@ -42,13 +40,13 @@ func NewModuleData() ModuleData {
 
 func (i *ModuleData) IsModule() {}
 
-func (i *ModuleData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *ModuleData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	for j, item := range i.statements {
-		fn(item, fieldNameStatements, uint16(j))
+		fn(item, fieldNameStatements, j)
 	}
 }
 
-func (i *ModuleData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *ModuleData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 func (i *ModuleData) Name() string {
@@ -80,57 +78,36 @@ type ModuleImpl struct {
 	ModuleData
 }
 
-func (i *ModuleImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *ModuleImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.ModuleData.ForEachNode(fn)
 }
 
-func (i *ModuleImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *ModuleImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.ModuleData.ForEachReference(fn)
 }
 
-func (i *ModuleImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameName:
-		return core.FieldInfos{Multi: false, Reference: false}
-	case fieldNameStatements:
-		return core.FieldInfos{Multi: true, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *ModuleImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *ModuleImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, index := path.Shift()
 	switch field {
 	case fieldNameStatements:
-		index, err := strconv.Atoi(fieldAndIndex[1])
-		if err != nil {
-			return nil, fmt.Errorf("ModuleImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
-		}
 		if index >= len(i.Statements()) {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("ModuleImpl.GetByPath: index %d exceeds length of slice in 'statements' (length=%d) in node '%s'", index, len(i.Statements()), nodePath)
 		}
 		child := i.Statements()[index]
 		if child == nil {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("ModuleImpl.GetByPath: item %d of slice in field 'statements' is nil in node '%s'", index, nodePath)
 		}
-		if len(parts) == 1 {
+		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(parts[1])
+		return child.GetByPath(path)
 	case fieldNameName:
 		return nil, fmt.Errorf("ModuleImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("ModuleImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Module'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("ModuleImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Module'", field.Value(), nodePath)
 	}
 }
 
@@ -156,10 +133,10 @@ func NewStatementData() StatementData {
 
 func (i *StatementData) IsStatement() {}
 
-func (i *StatementData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *StatementData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 }
 
-func (i *StatementData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *StatementData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 type StatementImpl struct {
@@ -167,27 +144,18 @@ type StatementImpl struct {
 	StatementData
 }
 
-func (i *StatementImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *StatementImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.StatementData.ForEachNode(fn)
 }
 
-func (i *StatementImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *StatementImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.StatementData.ForEachReference(fn)
 }
 
-func (i *StatementImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return core.FieldInfos{}
-}
-
-func (i *StatementImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	nodePath, _ := i.AstNodeBase.NodePath()
-	return nil, fmt.Errorf("StatementImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Statement'", fieldAndIndex[0], nodePath)
+func (i *StatementImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
+	nodePath, _ := core.NodePath(i)
+	return nil, fmt.Errorf("StatementImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Statement'", field.Value(), nodePath)
 }
 
 type AbstractDefinition interface {
@@ -216,10 +184,10 @@ func NewAbstractDefinitionData() AbstractDefinitionData {
 
 func (i *AbstractDefinitionData) IsAbstractDefinition() {}
 
-func (i *AbstractDefinitionData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *AbstractDefinitionData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 }
 
-func (i *AbstractDefinitionData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *AbstractDefinitionData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 func (i *AbstractDefinitionData) Name() string {
@@ -243,37 +211,22 @@ type AbstractDefinitionImpl struct {
 	AbstractDefinitionData
 }
 
-func (i *AbstractDefinitionImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *AbstractDefinitionImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.AbstractDefinitionData.ForEachNode(fn)
 }
 
-func (i *AbstractDefinitionImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *AbstractDefinitionImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.AbstractDefinitionData.ForEachReference(fn)
 }
 
-func (i *AbstractDefinitionImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameName:
-		return core.FieldInfos{Multi: false, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *AbstractDefinitionImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *AbstractDefinitionImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameName:
 		return nil, fmt.Errorf("AbstractDefinitionImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("AbstractDefinitionImpl.GetByPath: field '%s' does not exist in node '%s' of type 'AbstractDefinition'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("AbstractDefinitionImpl.GetByPath: field '%s' does not exist in node '%s' of type 'AbstractDefinition'", field.Value(), nodePath)
 	}
 }
 
@@ -311,16 +264,16 @@ func NewDefinitionData() DefinitionData {
 
 func (i *DefinitionData) IsDefinition() {}
 
-func (i *DefinitionData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *DefinitionData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	for j, item := range i.args {
-		fn(item, fieldNameArgs, uint16(j))
+		fn(item, fieldNameArgs, j)
 	}
 	if i.expression != nil {
-		fn(i.expression, fieldNameExpression, 0)
+		fn(i.expression, fieldNameExpression, -1)
 	}
 }
 
-func (i *DefinitionData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *DefinitionData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 func (i *DefinitionData) Args() []DeclaredParameter {
@@ -350,73 +303,50 @@ type DefinitionImpl struct {
 	DefinitionData
 }
 
-func (i *DefinitionImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *DefinitionImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.AbstractDefinitionData.ForEachNode(fn)
 	i.StatementData.ForEachNode(fn)
 	i.DefinitionData.ForEachNode(fn)
 }
 
-func (i *DefinitionImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *DefinitionImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.AbstractDefinitionData.ForEachReference(fn)
 	i.StatementData.ForEachReference(fn)
 	i.DefinitionData.ForEachReference(fn)
 }
 
-func (i *DefinitionImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+func (i *DefinitionImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, index := path.Shift()
 	switch field {
 	case fieldNameArgs:
-		return core.FieldInfos{Multi: true, Reference: false}
-	case fieldNameExpression:
-		return core.FieldInfos{Multi: false, Reference: false}
-	case fieldNameName:
-		return core.FieldInfos{Multi: false, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *DefinitionImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
-	switch field {
-	case fieldNameArgs:
-		index, err := strconv.Atoi(fieldAndIndex[1])
-		if err != nil {
-			return nil, fmt.Errorf("DefinitionImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
-		}
 		if index >= len(i.Args()) {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("DefinitionImpl.GetByPath: index %d exceeds length of slice in 'args' (length=%d) in node '%s'", index, len(i.Args()), nodePath)
 		}
 		child := i.Args()[index]
 		if child == nil {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("DefinitionImpl.GetByPath: item %d of slice in field 'args' is nil in node '%s'", index, nodePath)
 		}
-		if len(parts) == 1 {
+		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(parts[1])
+		return child.GetByPath(path)
 	case fieldNameExpression:
 		if i.Expression() == nil {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("DefinitionImpl.GetByPath: field 'expression' is nil in node '%s'", nodePath)
 		}
 		child := i.Expression()
-		if len(parts) == 1 {
+		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(parts[1])
+		return child.GetByPath(path)
 	case fieldNameName:
 		return nil, fmt.Errorf("DefinitionImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("DefinitionImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Definition'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("DefinitionImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Definition'", field.Value(), nodePath)
 	}
 }
 
@@ -444,10 +374,10 @@ func NewDeclaredParameterData() DeclaredParameterData {
 
 func (i *DeclaredParameterData) IsDeclaredParameter() {}
 
-func (i *DeclaredParameterData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *DeclaredParameterData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 }
 
-func (i *DeclaredParameterData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *DeclaredParameterData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 type DeclaredParameterImpl struct {
@@ -456,39 +386,24 @@ type DeclaredParameterImpl struct {
 	DeclaredParameterData
 }
 
-func (i *DeclaredParameterImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *DeclaredParameterImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.AbstractDefinitionData.ForEachNode(fn)
 	i.DeclaredParameterData.ForEachNode(fn)
 }
 
-func (i *DeclaredParameterImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *DeclaredParameterImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.AbstractDefinitionData.ForEachReference(fn)
 	i.DeclaredParameterData.ForEachReference(fn)
 }
 
-func (i *DeclaredParameterImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameName:
-		return core.FieldInfos{Multi: false, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *DeclaredParameterImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *DeclaredParameterImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameName:
 		return nil, fmt.Errorf("DeclaredParameterImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("DeclaredParameterImpl.GetByPath: field '%s' does not exist in node '%s' of type 'DeclaredParameter'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("DeclaredParameterImpl.GetByPath: field '%s' does not exist in node '%s' of type 'DeclaredParameter'", field.Value(), nodePath)
 	}
 }
 
@@ -519,13 +434,13 @@ func NewEvaluationData() EvaluationData {
 
 func (i *EvaluationData) IsEvaluation() {}
 
-func (i *EvaluationData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *EvaluationData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	if i.expression != nil {
-		fn(i.expression, fieldNameExpression, 0)
+		fn(i.expression, fieldNameExpression, -1)
 	}
 }
 
-func (i *EvaluationData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *EvaluationData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 func (i *EvaluationData) Expression() Expression {
@@ -546,47 +461,32 @@ type EvaluationImpl struct {
 	EvaluationData
 }
 
-func (i *EvaluationImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *EvaluationImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.StatementData.ForEachNode(fn)
 	i.EvaluationData.ForEachNode(fn)
 }
 
-func (i *EvaluationImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *EvaluationImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.StatementData.ForEachReference(fn)
 	i.EvaluationData.ForEachReference(fn)
 }
 
-func (i *EvaluationImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameExpression:
-		return core.FieldInfos{Multi: false, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *EvaluationImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *EvaluationImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameExpression:
 		if i.Expression() == nil {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("EvaluationImpl.GetByPath: field 'expression' is nil in node '%s'", nodePath)
 		}
 		child := i.Expression()
-		if len(parts) == 1 {
+		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(parts[1])
+		return child.GetByPath(path)
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("EvaluationImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Evaluation'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("EvaluationImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Evaluation'", field.Value(), nodePath)
 	}
 }
 
@@ -612,10 +512,10 @@ func NewExpressionData() ExpressionData {
 
 func (i *ExpressionData) IsExpression() {}
 
-func (i *ExpressionData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *ExpressionData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 }
 
-func (i *ExpressionData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *ExpressionData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 type ExpressionImpl struct {
@@ -623,27 +523,18 @@ type ExpressionImpl struct {
 	ExpressionData
 }
 
-func (i *ExpressionImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *ExpressionImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.ExpressionData.ForEachNode(fn)
 }
 
-func (i *ExpressionImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *ExpressionImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.ExpressionData.ForEachReference(fn)
 }
 
-func (i *ExpressionImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return core.FieldInfos{}
-}
-
-func (i *ExpressionImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	nodePath, _ := i.AstNodeBase.NodePath()
-	return nil, fmt.Errorf("ExpressionImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Expression'", fieldAndIndex[0], nodePath)
+func (i *ExpressionImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
+	nodePath, _ := core.NodePath(i)
+	return nil, fmt.Errorf("ExpressionImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Expression'", field.Value(), nodePath)
 }
 
 type BinaryExpression interface {
@@ -680,16 +571,16 @@ func NewBinaryExpressionData() BinaryExpressionData {
 
 func (i *BinaryExpressionData) IsBinaryExpression() {}
 
-func (i *BinaryExpressionData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *BinaryExpressionData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	if i.left != nil {
-		fn(i.left, fieldNameLeft, 0)
+		fn(i.left, fieldNameLeft, -1)
 	}
 	if i.right != nil {
-		fn(i.right, fieldNameRight, 0)
+		fn(i.right, fieldNameRight, -1)
 	}
 }
 
-func (i *BinaryExpressionData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *BinaryExpressionData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 func (i *BinaryExpressionData) Left() Expression {
@@ -738,63 +629,44 @@ type BinaryExpressionImpl struct {
 	BinaryExpressionData
 }
 
-func (i *BinaryExpressionImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *BinaryExpressionImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.ExpressionData.ForEachNode(fn)
 	i.BinaryExpressionData.ForEachNode(fn)
 }
 
-func (i *BinaryExpressionImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *BinaryExpressionImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.ExpressionData.ForEachReference(fn)
 	i.BinaryExpressionData.ForEachReference(fn)
 }
 
-func (i *BinaryExpressionImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameLeft:
-		return core.FieldInfos{Multi: false, Reference: false}
-	case fieldNameOperator:
-		return core.FieldInfos{Multi: false, Reference: false}
-	case fieldNameRight:
-		return core.FieldInfos{Multi: false, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *BinaryExpressionImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *BinaryExpressionImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameLeft:
 		if i.Left() == nil {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("BinaryExpressionImpl.GetByPath: field 'left' is nil in node '%s'", nodePath)
 		}
 		child := i.Left()
-		if len(parts) == 1 {
+		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(parts[1])
+		return child.GetByPath(path)
 	case fieldNameRight:
 		if i.Right() == nil {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("BinaryExpressionImpl.GetByPath: field 'right' is nil in node '%s'", nodePath)
 		}
 		child := i.Right()
-		if len(parts) == 1 {
+		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(parts[1])
+		return child.GetByPath(path)
 	case fieldNameOperator:
 		return nil, fmt.Errorf("BinaryExpressionImpl.GetByPath: field 'operator' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("BinaryExpressionImpl.GetByPath: field '%s' does not exist in node '%s' of type 'BinaryExpression'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("BinaryExpressionImpl.GetByPath: field '%s' does not exist in node '%s' of type 'BinaryExpression'", field.Value(), nodePath)
 	}
 }
 
@@ -830,15 +702,15 @@ func NewFunctionCallData() FunctionCallData {
 
 func (i *FunctionCallData) IsFunctionCall() {}
 
-func (i *FunctionCallData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *FunctionCallData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	for j, item := range i.args {
-		fn(item, fieldNameArgs, uint16(j))
+		fn(item, fieldNameArgs, j)
 	}
 }
 
-func (i *FunctionCallData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *FunctionCallData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	if i.callable != nil {
-		fn(i.callable, fieldNameCallable, 0)
+		fn(i.callable, fieldNameCallable, -1)
 	}
 }
 
@@ -868,59 +740,38 @@ type FunctionCallImpl struct {
 	FunctionCallData
 }
 
-func (i *FunctionCallImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *FunctionCallImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.ExpressionData.ForEachNode(fn)
 	i.FunctionCallData.ForEachNode(fn)
 }
 
-func (i *FunctionCallImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *FunctionCallImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.ExpressionData.ForEachReference(fn)
 	i.FunctionCallData.ForEachReference(fn)
 }
 
-func (i *FunctionCallImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+func (i *FunctionCallImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, index := path.Shift()
 	switch field {
 	case fieldNameArgs:
-		return core.FieldInfos{Multi: true, Reference: false}
-	case fieldNameCallable:
-		return core.FieldInfos{Multi: false, Reference: true}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *FunctionCallImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
-	switch field {
-	case fieldNameArgs:
-		index, err := strconv.Atoi(fieldAndIndex[1])
-		if err != nil {
-			return nil, fmt.Errorf("FunctionCallImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
-		}
 		if index >= len(i.Args()) {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("FunctionCallImpl.GetByPath: index %d exceeds length of slice in 'args' (length=%d) in node '%s'", index, len(i.Args()), nodePath)
 		}
 		child := i.Args()[index]
 		if child == nil {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("FunctionCallImpl.GetByPath: item %d of slice in field 'args' is nil in node '%s'", index, nodePath)
 		}
-		if len(parts) == 1 {
+		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(parts[1])
+		return child.GetByPath(path)
 	case fieldNameCallable:
 		return nil, fmt.Errorf("FunctionCallImpl.GetByPath: field 'callable' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("FunctionCallImpl.GetByPath: field '%s' does not exist in node '%s' of type 'FunctionCall'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("FunctionCallImpl.GetByPath: field '%s' does not exist in node '%s' of type 'FunctionCall'", field.Value(), nodePath)
 	}
 }
 
@@ -952,10 +803,10 @@ func NewNumberLiteralData() NumberLiteralData {
 
 func (i *NumberLiteralData) IsNumberLiteral() {}
 
-func (i *NumberLiteralData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *NumberLiteralData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 }
 
-func (i *NumberLiteralData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *NumberLiteralData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 func (i *NumberLiteralData) Value() string {
@@ -980,39 +831,24 @@ type NumberLiteralImpl struct {
 	NumberLiteralData
 }
 
-func (i *NumberLiteralImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *NumberLiteralImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.ExpressionData.ForEachNode(fn)
 	i.NumberLiteralData.ForEachNode(fn)
 }
 
-func (i *NumberLiteralImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *NumberLiteralImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.ExpressionData.ForEachReference(fn)
 	i.NumberLiteralData.ForEachReference(fn)
 }
 
-func (i *NumberLiteralImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameValue:
-		return core.FieldInfos{Multi: false, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *NumberLiteralImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *NumberLiteralImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameValue:
 		return nil, fmt.Errorf("NumberLiteralImpl.GetByPath: field 'value' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("NumberLiteralImpl.GetByPath: field '%s' does not exist in node '%s' of type 'NumberLiteral'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("NumberLiteralImpl.GetByPath: field '%s' does not exist in node '%s' of type 'NumberLiteral'", field.Value(), nodePath)
 	}
 }
 

--- a/examples/statemachine/types_gen.go
+++ b/examples/statemachine/types_gen.go
@@ -202,7 +202,9 @@ func (i *StatemachineImpl) GetByPath(path string) (core.AstNode, error) {
 		}
 		return child.GetByPath(parts[1])
 	case fieldNameName:
-		return nil, fmt.Errorf("StatemachineImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("StatemachineImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
+	case fieldNameInit:
+		return nil, fmt.Errorf("StatemachineImpl.GetByPath: field 'init' is a cross-reference instead of a container field")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("StatemachineImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Statemachine'", fieldAndIndex[0], nodePath)
@@ -289,7 +291,7 @@ func (i *EventImpl) GetByPath(path string) (core.AstNode, error) {
 	field := unique.Make(fieldAndIndex[0])
 	switch field {
 	case fieldNameName:
-		return nil, fmt.Errorf("EventImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("EventImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("EventImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Event'", fieldAndIndex[0], nodePath)
@@ -376,7 +378,7 @@ func (i *CommandImpl) GetByPath(path string) (core.AstNode, error) {
 	field := unique.Make(fieldAndIndex[0])
 	switch field {
 	case fieldNameName:
-		return nil, fmt.Errorf("CommandImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("CommandImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("CommandImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Command'", fieldAndIndex[0], nodePath)
@@ -511,7 +513,9 @@ func (i *StateImpl) GetByPath(path string) (core.AstNode, error) {
 		}
 		return child.GetByPath(parts[1])
 	case fieldNameName:
-		return nil, fmt.Errorf("StateImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("StateImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
+	case fieldNameActions:
+		return nil, fmt.Errorf("StateImpl.GetByPath: field 'actions' is a cross-reference instead of a container field")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("StateImpl.GetByPath: field '%s' does not exist in node '%s' of type 'State'", fieldAndIndex[0], nodePath)
@@ -613,8 +617,16 @@ func (i *TransitionImpl) GetByPath(path string) (core.AstNode, error) {
 	}
 	parts := strings.SplitN(path, "/", 2)
 	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	nodePath, _ := i.AstNodeBase.NodePath()
-	return nil, fmt.Errorf("TransitionImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Transition'", fieldAndIndex[0], nodePath)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameEvent:
+		return nil, fmt.Errorf("TransitionImpl.GetByPath: field 'event' is a cross-reference instead of a container field")
+	case fieldNameState:
+		return nil, fmt.Errorf("TransitionImpl.GetByPath: field 'state' is a cross-reference instead of a container field")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("TransitionImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Transition'", fieldAndIndex[0], nodePath)
+	}
 }
 
 var (

--- a/examples/statemachine/types_gen.go
+++ b/examples/statemachine/types_gen.go
@@ -3,8 +3,12 @@
 package statemachine
 
 import (
-	core "typefox.dev/fastbelt"
+	"fmt"
+	"strconv"
+	"strings"
 	"unique"
+
+	core "typefox.dev/fastbelt"
 )
 
 type Statemachine interface {
@@ -149,6 +153,62 @@ func (i *StatemachineImpl) FieldInfos(field unique.Handle[string]) core.FieldInf
 	}
 }
 
+func (i *StatemachineImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameCommands:
+		index, err := strconv.Atoi(fieldAndIndex[1])
+		if err != nil {
+			return nil, err
+		} else if index >= len(i.Commands()) {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("StatemachineImpl.GetByPath: index %d exceeds slice length of 'commands' (%d) at '%s'", index, len(i.Commands()), nodePath)
+		}
+		child := i.Commands()[index]
+		if len(parts) == 1 {
+			return child, nil
+		}
+		return child.GetByPath(parts[1])
+	case fieldNameEvents:
+		index, err := strconv.Atoi(fieldAndIndex[1])
+		if err != nil {
+			return nil, err
+		} else if index >= len(i.Events()) {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("StatemachineImpl.GetByPath: index %d exceeds slice length of 'events' (%d) at '%s'", index, len(i.Events()), nodePath)
+		}
+		child := i.Events()[index]
+		if len(parts) == 1 {
+			return child, nil
+		}
+		return child.GetByPath(parts[1])
+	case fieldNameStates:
+		index, err := strconv.Atoi(fieldAndIndex[1])
+		if err != nil {
+			return nil, err
+		} else if index >= len(i.States()) {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("StatemachineImpl.GetByPath: index %d exceeds slice length of 'states' (%d) at '%s'", index, len(i.States()), nodePath)
+		}
+		child := i.States()[index]
+		if len(parts) == 1 {
+			return child, nil
+		}
+		return child.GetByPath(parts[1])
+	case fieldNameName:
+		return nil, fmt.Errorf("StatemachineImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("StatemachineImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Statemachine'", fieldAndIndex[0], nodePath)
+	}
+}
+
 type Event interface {
 	core.AstNode
 
@@ -219,6 +279,23 @@ func (i *EventImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
 	}
 }
 
+func (i *EventImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameName:
+		return nil, fmt.Errorf("EventImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("EventImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Event'", fieldAndIndex[0], nodePath)
+	}
+}
+
 type Command interface {
 	core.AstNode
 
@@ -286,6 +363,23 @@ func (i *CommandImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
 		return core.FieldInfos{Multi: false, Reference: false}
 	default:
 		return core.FieldInfos{}
+	}
+}
+
+func (i *CommandImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameName:
+		return nil, fmt.Errorf("CommandImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("CommandImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Command'", fieldAndIndex[0], nodePath)
 	}
 }
 
@@ -394,6 +488,36 @@ func (i *StateImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
 	}
 }
 
+func (i *StateImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameTransitions:
+		index, err := strconv.Atoi(fieldAndIndex[1])
+		if err != nil {
+			return nil, err
+		} else if index >= len(i.Transitions()) {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("StateImpl.GetByPath: index %d exceeds slice length of 'transitions' (%d) at '%s'", index, len(i.Transitions()), nodePath)
+		}
+		child := i.Transitions()[index]
+		if len(parts) == 1 {
+			return child, nil
+		}
+		return child.GetByPath(parts[1])
+	case fieldNameName:
+		return nil, fmt.Errorf("StateImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("StateImpl.GetByPath: field '%s' does not exist in node '%s' of type 'State'", fieldAndIndex[0], nodePath)
+	}
+}
+
 type Transition interface {
 	core.AstNode
 
@@ -480,6 +604,17 @@ func (i *TransitionImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos
 	default:
 		return core.FieldInfos{}
 	}
+}
+
+func (i *TransitionImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	nodePath, _ := i.AstNodeBase.NodePath()
+	return nil, fmt.Errorf("TransitionImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Transition'", fieldAndIndex[0], nodePath)
 }
 
 var (

--- a/examples/statemachine/types_gen.go
+++ b/examples/statemachine/types_gen.go
@@ -4,6 +4,7 @@ package statemachine
 
 import (
 	core "typefox.dev/fastbelt"
+	"unique"
 )
 
 type Statemachine interface {
@@ -48,21 +49,21 @@ func NewStatemachineData() StatemachineData {
 
 func (i *StatemachineData) IsStatemachine() {}
 
-func (i *StatemachineData) ForEachNode(fn func(core.AstNode)) {
-	for _, item := range i.events {
-		fn(item)
+func (i *StatemachineData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+	for j, item := range i.events {
+		fn(item, unique.Make("events"), uint16(j))
 	}
-	for _, item := range i.commands {
-		fn(item)
+	for j, item := range i.commands {
+		fn(item, unique.Make("commands"), uint16(j))
 	}
-	for _, item := range i.states {
-		fn(item)
+	for j, item := range i.states {
+		fn(item, unique.Make("states"), uint16(j))
 	}
 }
 
-func (i *StatemachineData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *StatemachineData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i.init != nil {
-		fn(i.init)
+		fn(i.init, unique.Make("init"), 0)
 	}
 }
 
@@ -123,12 +124,16 @@ type StatemachineImpl struct {
 	StatemachineData
 }
 
-func (i *StatemachineImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *StatemachineImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.StatemachineData.ForEachNode(fn)
 }
 
-func (i *StatemachineImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *StatemachineImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.StatemachineData.ForEachReference(fn)
+}
+
+func (i *StatemachineImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return StatemachineModelFieldInfos["Statemachine"][field.Value()]
 }
 
 type Event interface {
@@ -157,10 +162,10 @@ func NewEventData() EventData {
 
 func (i *EventData) IsEvent() {}
 
-func (i *EventData) ForEachNode(fn func(core.AstNode)) {
+func (i *EventData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 }
 
-func (i *EventData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *EventData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 func (i *EventData) Name() string {
@@ -184,12 +189,16 @@ type EventImpl struct {
 	EventData
 }
 
-func (i *EventImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *EventImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.EventData.ForEachNode(fn)
 }
 
-func (i *EventImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *EventImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.EventData.ForEachReference(fn)
+}
+
+func (i *EventImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return StatemachineModelFieldInfos["Event"][field.Value()]
 }
 
 type Command interface {
@@ -218,10 +227,10 @@ func NewCommandData() CommandData {
 
 func (i *CommandData) IsCommand() {}
 
-func (i *CommandData) ForEachNode(fn func(core.AstNode)) {
+func (i *CommandData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 }
 
-func (i *CommandData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *CommandData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 func (i *CommandData) Name() string {
@@ -245,12 +254,16 @@ type CommandImpl struct {
 	CommandData
 }
 
-func (i *CommandImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *CommandImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.CommandData.ForEachNode(fn)
 }
 
-func (i *CommandImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *CommandImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.CommandData.ForEachReference(fn)
+}
+
+func (i *CommandImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return StatemachineModelFieldInfos["Command"][field.Value()]
 }
 
 type State interface {
@@ -288,15 +301,15 @@ func NewStateData() StateData {
 
 func (i *StateData) IsState() {}
 
-func (i *StateData) ForEachNode(fn func(core.AstNode)) {
-	for _, item := range i.transitions {
-		fn(item)
+func (i *StateData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+	for j, item := range i.transitions {
+		fn(item, unique.Make("transitions"), uint16(j))
 	}
 }
 
-func (i *StateData) ForEachReference(fn func(core.UntypedReference)) {
-	for _, item := range i.actions {
-		fn(item)
+func (i *StateData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+	for j, item := range i.actions {
+		fn(item, unique.Make("actions"), uint16(j))
 	}
 }
 
@@ -337,12 +350,16 @@ type StateImpl struct {
 	StateData
 }
 
-func (i *StateImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *StateImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.StateData.ForEachNode(fn)
 }
 
-func (i *StateImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *StateImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.StateData.ForEachReference(fn)
+}
+
+func (i *StateImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return StatemachineModelFieldInfos["State"][field.Value()]
 }
 
 type Transition interface {
@@ -373,15 +390,15 @@ func NewTransitionData() TransitionData {
 
 func (i *TransitionData) IsTransition() {}
 
-func (i *TransitionData) ForEachNode(fn func(core.AstNode)) {
+func (i *TransitionData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 }
 
-func (i *TransitionData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *TransitionData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i.event != nil {
-		fn(i.event)
+		fn(i.event, unique.Make("event"), 0)
 	}
 	if i.state != nil {
-		fn(i.state)
+		fn(i.state, unique.Make("state"), 0)
 	}
 }
 
@@ -414,12 +431,16 @@ type TransitionImpl struct {
 	TransitionData
 }
 
-func (i *TransitionImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *TransitionImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.TransitionData.ForEachNode(fn)
 }
 
-func (i *TransitionImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *TransitionImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.TransitionData.ForEachReference(fn)
+}
+
+func (i *TransitionImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return StatemachineModelFieldInfos["Transition"][field.Value()]
 }
 
 var StatemachineModelSyntheticFactories = map[string]func() core.AstNode{
@@ -428,4 +449,65 @@ var StatemachineModelSyntheticFactories = map[string]func() core.AstNode{
 	"State":        func() core.AstNode { return NewState() },
 	"Statemachine": func() core.AstNode { return NewStatemachine() },
 	"Transition":   func() core.AstNode { return NewTransition() },
+}
+
+var StatemachineModelFieldInfos = map[string]map[string]core.FieldInfos{
+	"Command": map[string]core.FieldInfos{
+		"name": {
+			Multi:     false,
+			Reference: false,
+		},
+	},
+	"Event": map[string]core.FieldInfos{
+		"name": {
+			Multi:     false,
+			Reference: false,
+		},
+	},
+	"State": map[string]core.FieldInfos{
+		"actions": {
+			Multi:     true,
+			Reference: true,
+		},
+		"name": {
+			Multi:     false,
+			Reference: false,
+		},
+		"transitions": {
+			Multi:     true,
+			Reference: false,
+		},
+	},
+	"Statemachine": map[string]core.FieldInfos{
+		"commands": {
+			Multi:     true,
+			Reference: false,
+		},
+		"events": {
+			Multi:     true,
+			Reference: false,
+		},
+		"init": {
+			Multi:     false,
+			Reference: true,
+		},
+		"name": {
+			Multi:     false,
+			Reference: false,
+		},
+		"states": {
+			Multi:     true,
+			Reference: false,
+		},
+	},
+	"Transition": map[string]core.FieldInfos{
+		"event": {
+			Multi:     false,
+			Reference: true,
+		},
+		"state": {
+			Multi:     false,
+			Reference: true,
+		},
+	},
 }

--- a/examples/statemachine/types_gen.go
+++ b/examples/statemachine/types_gen.go
@@ -165,12 +165,17 @@ func (i *StatemachineImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameCommands:
 		index, err := strconv.Atoi(fieldAndIndex[1])
 		if err != nil {
-			return nil, err
-		} else if index >= len(i.Commands()) {
+			return nil, fmt.Errorf("StatemachineImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
+		}
+		if index >= len(i.Commands()) {
 			nodePath, _ := i.AstNodeBase.NodePath()
-			return nil, fmt.Errorf("StatemachineImpl.GetByPath: index %d exceeds slice length of 'commands' (%d) at '%s'", index, len(i.Commands()), nodePath)
+			return nil, fmt.Errorf("StatemachineImpl.GetByPath: index %d exceeds length of slice in 'commands' (length=%d) in node '%s'", index, len(i.Commands()), nodePath)
 		}
 		child := i.Commands()[index]
+		if child == nil {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("StatemachineImpl.GetByPath: item %d of slice in field 'commands' is nil in node '%s'", index, nodePath)
+		}
 		if len(parts) == 1 {
 			return child, nil
 		}
@@ -178,12 +183,17 @@ func (i *StatemachineImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameEvents:
 		index, err := strconv.Atoi(fieldAndIndex[1])
 		if err != nil {
-			return nil, err
-		} else if index >= len(i.Events()) {
+			return nil, fmt.Errorf("StatemachineImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
+		}
+		if index >= len(i.Events()) {
 			nodePath, _ := i.AstNodeBase.NodePath()
-			return nil, fmt.Errorf("StatemachineImpl.GetByPath: index %d exceeds slice length of 'events' (%d) at '%s'", index, len(i.Events()), nodePath)
+			return nil, fmt.Errorf("StatemachineImpl.GetByPath: index %d exceeds length of slice in 'events' (length=%d) in node '%s'", index, len(i.Events()), nodePath)
 		}
 		child := i.Events()[index]
+		if child == nil {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("StatemachineImpl.GetByPath: item %d of slice in field 'events' is nil in node '%s'", index, nodePath)
+		}
 		if len(parts) == 1 {
 			return child, nil
 		}
@@ -191,12 +201,17 @@ func (i *StatemachineImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameStates:
 		index, err := strconv.Atoi(fieldAndIndex[1])
 		if err != nil {
-			return nil, err
-		} else if index >= len(i.States()) {
+			return nil, fmt.Errorf("StatemachineImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
+		}
+		if index >= len(i.States()) {
 			nodePath, _ := i.AstNodeBase.NodePath()
-			return nil, fmt.Errorf("StatemachineImpl.GetByPath: index %d exceeds slice length of 'states' (%d) at '%s'", index, len(i.States()), nodePath)
+			return nil, fmt.Errorf("StatemachineImpl.GetByPath: index %d exceeds length of slice in 'states' (length=%d) in node '%s'", index, len(i.States()), nodePath)
 		}
 		child := i.States()[index]
+		if child == nil {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("StatemachineImpl.GetByPath: item %d of slice in field 'states' is nil in node '%s'", index, nodePath)
+		}
 		if len(parts) == 1 {
 			return child, nil
 		}
@@ -502,12 +517,17 @@ func (i *StateImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameTransitions:
 		index, err := strconv.Atoi(fieldAndIndex[1])
 		if err != nil {
-			return nil, err
-		} else if index >= len(i.Transitions()) {
+			return nil, fmt.Errorf("StateImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
+		}
+		if index >= len(i.Transitions()) {
 			nodePath, _ := i.AstNodeBase.NodePath()
-			return nil, fmt.Errorf("StateImpl.GetByPath: index %d exceeds slice length of 'transitions' (%d) at '%s'", index, len(i.Transitions()), nodePath)
+			return nil, fmt.Errorf("StateImpl.GetByPath: index %d exceeds length of slice in 'transitions' (length=%d) in node '%s'", index, len(i.Transitions()), nodePath)
 		}
 		child := i.Transitions()[index]
+		if child == nil {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("StateImpl.GetByPath: item %d of slice in field 'transitions' is nil in node '%s'", index, nodePath)
+		}
 		if len(parts) == 1 {
 			return child, nil
 		}

--- a/examples/statemachine/types_gen.go
+++ b/examples/statemachine/types_gen.go
@@ -51,19 +51,19 @@ func (i *StatemachineData) IsStatemachine() {}
 
 func (i *StatemachineData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	for j, item := range i.events {
-		fn(item, unique.Make("events"), uint16(j))
+		fn(item, fieldNameEvents, uint16(j))
 	}
 	for j, item := range i.commands {
-		fn(item, unique.Make("commands"), uint16(j))
+		fn(item, fieldNameCommands, uint16(j))
 	}
 	for j, item := range i.states {
-		fn(item, unique.Make("states"), uint16(j))
+		fn(item, fieldNameStates, uint16(j))
 	}
 }
 
 func (i *StatemachineData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i.init != nil {
-		fn(i.init, unique.Make("init"), 0)
+		fn(i.init, fieldNameInit, 0)
 	}
 }
 
@@ -133,7 +133,20 @@ func (i *StatemachineImpl) ForEachReference(fn func(core.UntypedReference, uniqu
 }
 
 func (i *StatemachineImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return StatemachineModelFieldInfos["Statemachine"][field.Value()]
+	switch field {
+	case fieldNameCommands:
+		return core.FieldInfos{Multi: true, Reference: false}
+	case fieldNameEvents:
+		return core.FieldInfos{Multi: true, Reference: false}
+	case fieldNameInit:
+		return core.FieldInfos{Multi: false, Reference: true}
+	case fieldNameName:
+		return core.FieldInfos{Multi: false, Reference: false}
+	case fieldNameStates:
+		return core.FieldInfos{Multi: true, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type Event interface {
@@ -198,7 +211,12 @@ func (i *EventImpl) ForEachReference(fn func(core.UntypedReference, unique.Handl
 }
 
 func (i *EventImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return StatemachineModelFieldInfos["Event"][field.Value()]
+	switch field {
+	case fieldNameName:
+		return core.FieldInfos{Multi: false, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type Command interface {
@@ -263,7 +281,12 @@ func (i *CommandImpl) ForEachReference(fn func(core.UntypedReference, unique.Han
 }
 
 func (i *CommandImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return StatemachineModelFieldInfos["Command"][field.Value()]
+	switch field {
+	case fieldNameName:
+		return core.FieldInfos{Multi: false, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type State interface {
@@ -303,13 +326,13 @@ func (i *StateData) IsState() {}
 
 func (i *StateData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	for j, item := range i.transitions {
-		fn(item, unique.Make("transitions"), uint16(j))
+		fn(item, fieldNameTransitions, uint16(j))
 	}
 }
 
 func (i *StateData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	for j, item := range i.actions {
-		fn(item, unique.Make("actions"), uint16(j))
+		fn(item, fieldNameActions, uint16(j))
 	}
 }
 
@@ -359,7 +382,16 @@ func (i *StateImpl) ForEachReference(fn func(core.UntypedReference, unique.Handl
 }
 
 func (i *StateImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return StatemachineModelFieldInfos["State"][field.Value()]
+	switch field {
+	case fieldNameActions:
+		return core.FieldInfos{Multi: true, Reference: true}
+	case fieldNameName:
+		return core.FieldInfos{Multi: false, Reference: false}
+	case fieldNameTransitions:
+		return core.FieldInfos{Multi: true, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type Transition interface {
@@ -395,10 +427,10 @@ func (i *TransitionData) ForEachNode(fn func(core.AstNode, unique.Handle[string]
 
 func (i *TransitionData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i.event != nil {
-		fn(i.event, unique.Make("event"), 0)
+		fn(i.event, fieldNameEvent, 0)
 	}
 	if i.state != nil {
-		fn(i.state, unique.Make("state"), 0)
+		fn(i.state, fieldNameState, 0)
 	}
 }
 
@@ -440,8 +472,27 @@ func (i *TransitionImpl) ForEachReference(fn func(core.UntypedReference, unique.
 }
 
 func (i *TransitionImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return StatemachineModelFieldInfos["Transition"][field.Value()]
+	switch field {
+	case fieldNameEvent:
+		return core.FieldInfos{Multi: false, Reference: true}
+	case fieldNameState:
+		return core.FieldInfos{Multi: false, Reference: true}
+	default:
+		return core.FieldInfos{}
+	}
 }
+
+var (
+	fieldNameActions     = unique.Make("actions")
+	fieldNameCommands    = unique.Make("commands")
+	fieldNameEvent       = unique.Make("event")
+	fieldNameEvents      = unique.Make("events")
+	fieldNameInit        = unique.Make("init")
+	fieldNameName        = unique.Make("name")
+	fieldNameState       = unique.Make("state")
+	fieldNameStates      = unique.Make("states")
+	fieldNameTransitions = unique.Make("transitions")
+)
 
 var StatemachineModelSyntheticFactories = map[string]func() core.AstNode{
 	"Command":      func() core.AstNode { return NewCommand() },
@@ -449,65 +500,4 @@ var StatemachineModelSyntheticFactories = map[string]func() core.AstNode{
 	"State":        func() core.AstNode { return NewState() },
 	"Statemachine": func() core.AstNode { return NewStatemachine() },
 	"Transition":   func() core.AstNode { return NewTransition() },
-}
-
-var StatemachineModelFieldInfos = map[string]map[string]core.FieldInfos{
-	"Command": map[string]core.FieldInfos{
-		"name": {
-			Multi:     false,
-			Reference: false,
-		},
-	},
-	"Event": map[string]core.FieldInfos{
-		"name": {
-			Multi:     false,
-			Reference: false,
-		},
-	},
-	"State": map[string]core.FieldInfos{
-		"actions": {
-			Multi:     true,
-			Reference: true,
-		},
-		"name": {
-			Multi:     false,
-			Reference: false,
-		},
-		"transitions": {
-			Multi:     true,
-			Reference: false,
-		},
-	},
-	"Statemachine": map[string]core.FieldInfos{
-		"commands": {
-			Multi:     true,
-			Reference: false,
-		},
-		"events": {
-			Multi:     true,
-			Reference: false,
-		},
-		"init": {
-			Multi:     false,
-			Reference: true,
-		},
-		"name": {
-			Multi:     false,
-			Reference: false,
-		},
-		"states": {
-			Multi:     true,
-			Reference: false,
-		},
-	},
-	"Transition": map[string]core.FieldInfos{
-		"event": {
-			Multi:     false,
-			Reference: true,
-		},
-		"state": {
-			Multi:     false,
-			Reference: true,
-		},
-	},
 }

--- a/examples/statemachine/types_gen.go
+++ b/examples/statemachine/types_gen.go
@@ -135,7 +135,10 @@ func (i *StatemachineImpl) ForEachReference(fn func(core.UntypedReference, uniqu
 }
 
 func (i *StatemachineImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, index := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, index := path.Head()
 	switch field {
 	case fieldNameCommands:
 		if index >= len(i.Commands()) {
@@ -147,10 +150,7 @@ func (i *StatemachineImpl) Resolve(path core.FragmentPath) (core.AstNode, error)
 			nodePath, _ := core.PathOf(i)
 			return nil, fmt.Errorf("StatemachineImpl.Resolve: item %d of slice in field 'commands' is nil in node '%s'", index, nodePath)
 		}
-		if path.Empty() {
-			return child, nil
-		}
-		return child.Resolve(path)
+		return child.Resolve(path.Tail())
 	case fieldNameEvents:
 		if index >= len(i.Events()) {
 			nodePath, _ := core.PathOf(i)
@@ -161,10 +161,7 @@ func (i *StatemachineImpl) Resolve(path core.FragmentPath) (core.AstNode, error)
 			nodePath, _ := core.PathOf(i)
 			return nil, fmt.Errorf("StatemachineImpl.Resolve: item %d of slice in field 'events' is nil in node '%s'", index, nodePath)
 		}
-		if path.Empty() {
-			return child, nil
-		}
-		return child.Resolve(path)
+		return child.Resolve(path.Tail())
 	case fieldNameStates:
 		if index >= len(i.States()) {
 			nodePath, _ := core.PathOf(i)
@@ -175,10 +172,7 @@ func (i *StatemachineImpl) Resolve(path core.FragmentPath) (core.AstNode, error)
 			nodePath, _ := core.PathOf(i)
 			return nil, fmt.Errorf("StatemachineImpl.Resolve: item %d of slice in field 'states' is nil in node '%s'", index, nodePath)
 		}
-		if path.Empty() {
-			return child, nil
-		}
-		return child.Resolve(path)
+		return child.Resolve(path.Tail())
 	case fieldNameName:
 		return nil, fmt.Errorf("StatemachineImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
 	case fieldNameInit:
@@ -251,7 +245,10 @@ func (i *EventImpl) ForEachReference(fn func(core.UntypedReference, unique.Handl
 }
 
 func (i *EventImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameName:
 		return nil, fmt.Errorf("EventImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
@@ -323,7 +320,10 @@ func (i *CommandImpl) ForEachReference(fn func(core.UntypedReference, unique.Han
 }
 
 func (i *CommandImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameName:
 		return nil, fmt.Errorf("CommandImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
@@ -426,7 +426,10 @@ func (i *StateImpl) ForEachReference(fn func(core.UntypedReference, unique.Handl
 }
 
 func (i *StateImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, index := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, index := path.Head()
 	switch field {
 	case fieldNameTransitions:
 		if index >= len(i.Transitions()) {
@@ -438,10 +441,7 @@ func (i *StateImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 			nodePath, _ := core.PathOf(i)
 			return nil, fmt.Errorf("StateImpl.Resolve: item %d of slice in field 'transitions' is nil in node '%s'", index, nodePath)
 		}
-		if path.Empty() {
-			return child, nil
-		}
-		return child.Resolve(path)
+		return child.Resolve(path.Tail())
 	case fieldNameName:
 		return nil, fmt.Errorf("StateImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
 	case fieldNameActions:
@@ -530,7 +530,10 @@ func (i *TransitionImpl) ForEachReference(fn func(core.UntypedReference, unique.
 }
 
 func (i *TransitionImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameEvent:
 		return nil, fmt.Errorf("TransitionImpl.Resolve: field 'event' is a cross-reference instead of a container field")

--- a/examples/statemachine/types_gen.go
+++ b/examples/statemachine/types_gen.go
@@ -134,58 +134,58 @@ func (i *StatemachineImpl) ForEachReference(fn func(core.UntypedReference, uniqu
 	i.StatemachineData.ForEachReference(fn)
 }
 
-func (i *StatemachineImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *StatemachineImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, index := path.Shift()
 	switch field {
 	case fieldNameCommands:
 		if index >= len(i.Commands()) {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("StatemachineImpl.GetByPath: index %d exceeds length of slice in 'commands' (length=%d) in node '%s'", index, len(i.Commands()), nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("StatemachineImpl.Resolve: index %d exceeds length of slice in 'commands' (length=%d) in node '%s'", index, len(i.Commands()), nodePath)
 		}
 		child := i.Commands()[index]
 		if child == nil {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("StatemachineImpl.GetByPath: item %d of slice in field 'commands' is nil in node '%s'", index, nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("StatemachineImpl.Resolve: item %d of slice in field 'commands' is nil in node '%s'", index, nodePath)
 		}
 		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(path)
+		return child.Resolve(path)
 	case fieldNameEvents:
 		if index >= len(i.Events()) {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("StatemachineImpl.GetByPath: index %d exceeds length of slice in 'events' (length=%d) in node '%s'", index, len(i.Events()), nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("StatemachineImpl.Resolve: index %d exceeds length of slice in 'events' (length=%d) in node '%s'", index, len(i.Events()), nodePath)
 		}
 		child := i.Events()[index]
 		if child == nil {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("StatemachineImpl.GetByPath: item %d of slice in field 'events' is nil in node '%s'", index, nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("StatemachineImpl.Resolve: item %d of slice in field 'events' is nil in node '%s'", index, nodePath)
 		}
 		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(path)
+		return child.Resolve(path)
 	case fieldNameStates:
 		if index >= len(i.States()) {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("StatemachineImpl.GetByPath: index %d exceeds length of slice in 'states' (length=%d) in node '%s'", index, len(i.States()), nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("StatemachineImpl.Resolve: index %d exceeds length of slice in 'states' (length=%d) in node '%s'", index, len(i.States()), nodePath)
 		}
 		child := i.States()[index]
 		if child == nil {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("StatemachineImpl.GetByPath: item %d of slice in field 'states' is nil in node '%s'", index, nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("StatemachineImpl.Resolve: item %d of slice in field 'states' is nil in node '%s'", index, nodePath)
 		}
 		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(path)
+		return child.Resolve(path)
 	case fieldNameName:
-		return nil, fmt.Errorf("StatemachineImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("StatemachineImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
 	case fieldNameInit:
-		return nil, fmt.Errorf("StatemachineImpl.GetByPath: field 'init' is a cross-reference instead of a container field")
+		return nil, fmt.Errorf("StatemachineImpl.Resolve: field 'init' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("StatemachineImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Statemachine'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("StatemachineImpl.Resolve: field '%s' does not exist in node '%s' of type 'Statemachine'", field.Value(), nodePath)
 	}
 }
 
@@ -250,14 +250,14 @@ func (i *EventImpl) ForEachReference(fn func(core.UntypedReference, unique.Handl
 	i.EventData.ForEachReference(fn)
 }
 
-func (i *EventImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *EventImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameName:
-		return nil, fmt.Errorf("EventImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("EventImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("EventImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Event'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("EventImpl.Resolve: field '%s' does not exist in node '%s' of type 'Event'", field.Value(), nodePath)
 	}
 }
 
@@ -322,14 +322,14 @@ func (i *CommandImpl) ForEachReference(fn func(core.UntypedReference, unique.Han
 	i.CommandData.ForEachReference(fn)
 }
 
-func (i *CommandImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *CommandImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameName:
-		return nil, fmt.Errorf("CommandImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("CommandImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("CommandImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Command'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("CommandImpl.Resolve: field '%s' does not exist in node '%s' of type 'Command'", field.Value(), nodePath)
 	}
 }
 
@@ -425,30 +425,30 @@ func (i *StateImpl) ForEachReference(fn func(core.UntypedReference, unique.Handl
 	i.StateData.ForEachReference(fn)
 }
 
-func (i *StateImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *StateImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, index := path.Shift()
 	switch field {
 	case fieldNameTransitions:
 		if index >= len(i.Transitions()) {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("StateImpl.GetByPath: index %d exceeds length of slice in 'transitions' (length=%d) in node '%s'", index, len(i.Transitions()), nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("StateImpl.Resolve: index %d exceeds length of slice in 'transitions' (length=%d) in node '%s'", index, len(i.Transitions()), nodePath)
 		}
 		child := i.Transitions()[index]
 		if child == nil {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("StateImpl.GetByPath: item %d of slice in field 'transitions' is nil in node '%s'", index, nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("StateImpl.Resolve: item %d of slice in field 'transitions' is nil in node '%s'", index, nodePath)
 		}
 		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(path)
+		return child.Resolve(path)
 	case fieldNameName:
-		return nil, fmt.Errorf("StateImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("StateImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
 	case fieldNameActions:
-		return nil, fmt.Errorf("StateImpl.GetByPath: field 'actions' is a cross-reference instead of a container field")
+		return nil, fmt.Errorf("StateImpl.Resolve: field 'actions' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("StateImpl.GetByPath: field '%s' does not exist in node '%s' of type 'State'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("StateImpl.Resolve: field '%s' does not exist in node '%s' of type 'State'", field.Value(), nodePath)
 	}
 }
 
@@ -529,16 +529,16 @@ func (i *TransitionImpl) ForEachReference(fn func(core.UntypedReference, unique.
 	i.TransitionData.ForEachReference(fn)
 }
 
-func (i *TransitionImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *TransitionImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameEvent:
-		return nil, fmt.Errorf("TransitionImpl.GetByPath: field 'event' is a cross-reference instead of a container field")
+		return nil, fmt.Errorf("TransitionImpl.Resolve: field 'event' is a cross-reference instead of a container field")
 	case fieldNameState:
-		return nil, fmt.Errorf("TransitionImpl.GetByPath: field 'state' is a cross-reference instead of a container field")
+		return nil, fmt.Errorf("TransitionImpl.Resolve: field 'state' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("TransitionImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Transition'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("TransitionImpl.Resolve: field '%s' does not exist in node '%s' of type 'Transition'", field.Value(), nodePath)
 	}
 }
 

--- a/examples/statemachine/types_gen.go
+++ b/examples/statemachine/types_gen.go
@@ -4,8 +4,6 @@ package statemachine
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
 	"unique"
 
 	core "typefox.dev/fastbelt"
@@ -53,21 +51,21 @@ func NewStatemachineData() StatemachineData {
 
 func (i *StatemachineData) IsStatemachine() {}
 
-func (i *StatemachineData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *StatemachineData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	for j, item := range i.events {
-		fn(item, fieldNameEvents, uint16(j))
+		fn(item, fieldNameEvents, j)
 	}
 	for j, item := range i.commands {
-		fn(item, fieldNameCommands, uint16(j))
+		fn(item, fieldNameCommands, j)
 	}
 	for j, item := range i.states {
-		fn(item, fieldNameStates, uint16(j))
+		fn(item, fieldNameStates, j)
 	}
 }
 
-func (i *StatemachineData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *StatemachineData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	if i.init != nil {
-		fn(i.init, fieldNameInit, 0)
+		fn(i.init, fieldNameInit, -1)
 	}
 }
 
@@ -128,101 +126,66 @@ type StatemachineImpl struct {
 	StatemachineData
 }
 
-func (i *StatemachineImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *StatemachineImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.StatemachineData.ForEachNode(fn)
 }
 
-func (i *StatemachineImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *StatemachineImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.StatemachineData.ForEachReference(fn)
 }
 
-func (i *StatemachineImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+func (i *StatemachineImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, index := path.Shift()
 	switch field {
 	case fieldNameCommands:
-		return core.FieldInfos{Multi: true, Reference: false}
-	case fieldNameEvents:
-		return core.FieldInfos{Multi: true, Reference: false}
-	case fieldNameInit:
-		return core.FieldInfos{Multi: false, Reference: true}
-	case fieldNameName:
-		return core.FieldInfos{Multi: false, Reference: false}
-	case fieldNameStates:
-		return core.FieldInfos{Multi: true, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *StatemachineImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
-	switch field {
-	case fieldNameCommands:
-		index, err := strconv.Atoi(fieldAndIndex[1])
-		if err != nil {
-			return nil, fmt.Errorf("StatemachineImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
-		}
 		if index >= len(i.Commands()) {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("StatemachineImpl.GetByPath: index %d exceeds length of slice in 'commands' (length=%d) in node '%s'", index, len(i.Commands()), nodePath)
 		}
 		child := i.Commands()[index]
 		if child == nil {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("StatemachineImpl.GetByPath: item %d of slice in field 'commands' is nil in node '%s'", index, nodePath)
 		}
-		if len(parts) == 1 {
+		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(parts[1])
+		return child.GetByPath(path)
 	case fieldNameEvents:
-		index, err := strconv.Atoi(fieldAndIndex[1])
-		if err != nil {
-			return nil, fmt.Errorf("StatemachineImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
-		}
 		if index >= len(i.Events()) {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("StatemachineImpl.GetByPath: index %d exceeds length of slice in 'events' (length=%d) in node '%s'", index, len(i.Events()), nodePath)
 		}
 		child := i.Events()[index]
 		if child == nil {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("StatemachineImpl.GetByPath: item %d of slice in field 'events' is nil in node '%s'", index, nodePath)
 		}
-		if len(parts) == 1 {
+		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(parts[1])
+		return child.GetByPath(path)
 	case fieldNameStates:
-		index, err := strconv.Atoi(fieldAndIndex[1])
-		if err != nil {
-			return nil, fmt.Errorf("StatemachineImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
-		}
 		if index >= len(i.States()) {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("StatemachineImpl.GetByPath: index %d exceeds length of slice in 'states' (length=%d) in node '%s'", index, len(i.States()), nodePath)
 		}
 		child := i.States()[index]
 		if child == nil {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("StatemachineImpl.GetByPath: item %d of slice in field 'states' is nil in node '%s'", index, nodePath)
 		}
-		if len(parts) == 1 {
+		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(parts[1])
+		return child.GetByPath(path)
 	case fieldNameName:
 		return nil, fmt.Errorf("StatemachineImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
 	case fieldNameInit:
 		return nil, fmt.Errorf("StatemachineImpl.GetByPath: field 'init' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("StatemachineImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Statemachine'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("StatemachineImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Statemachine'", field.Value(), nodePath)
 	}
 }
 
@@ -252,10 +215,10 @@ func NewEventData() EventData {
 
 func (i *EventData) IsEvent() {}
 
-func (i *EventData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *EventData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 }
 
-func (i *EventData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *EventData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 func (i *EventData) Name() string {
@@ -279,37 +242,22 @@ type EventImpl struct {
 	EventData
 }
 
-func (i *EventImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *EventImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.EventData.ForEachNode(fn)
 }
 
-func (i *EventImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *EventImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.EventData.ForEachReference(fn)
 }
 
-func (i *EventImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameName:
-		return core.FieldInfos{Multi: false, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *EventImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *EventImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameName:
 		return nil, fmt.Errorf("EventImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("EventImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Event'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("EventImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Event'", field.Value(), nodePath)
 	}
 }
 
@@ -339,10 +287,10 @@ func NewCommandData() CommandData {
 
 func (i *CommandData) IsCommand() {}
 
-func (i *CommandData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *CommandData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 }
 
-func (i *CommandData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *CommandData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 func (i *CommandData) Name() string {
@@ -366,37 +314,22 @@ type CommandImpl struct {
 	CommandData
 }
 
-func (i *CommandImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *CommandImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.CommandData.ForEachNode(fn)
 }
 
-func (i *CommandImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *CommandImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.CommandData.ForEachReference(fn)
 }
 
-func (i *CommandImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameName:
-		return core.FieldInfos{Multi: false, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *CommandImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *CommandImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameName:
 		return nil, fmt.Errorf("CommandImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("CommandImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Command'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("CommandImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Command'", field.Value(), nodePath)
 	}
 }
 
@@ -435,15 +368,15 @@ func NewStateData() StateData {
 
 func (i *StateData) IsState() {}
 
-func (i *StateData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *StateData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	for j, item := range i.transitions {
-		fn(item, fieldNameTransitions, uint16(j))
+		fn(item, fieldNameTransitions, j)
 	}
 }
 
-func (i *StateData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *StateData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	for j, item := range i.actions {
-		fn(item, fieldNameActions, uint16(j))
+		fn(item, fieldNameActions, j)
 	}
 }
 
@@ -484,61 +417,38 @@ type StateImpl struct {
 	StateData
 }
 
-func (i *StateImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *StateImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.StateData.ForEachNode(fn)
 }
 
-func (i *StateImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *StateImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.StateData.ForEachReference(fn)
 }
 
-func (i *StateImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameActions:
-		return core.FieldInfos{Multi: true, Reference: true}
-	case fieldNameName:
-		return core.FieldInfos{Multi: false, Reference: false}
-	case fieldNameTransitions:
-		return core.FieldInfos{Multi: true, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *StateImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *StateImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, index := path.Shift()
 	switch field {
 	case fieldNameTransitions:
-		index, err := strconv.Atoi(fieldAndIndex[1])
-		if err != nil {
-			return nil, fmt.Errorf("StateImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
-		}
 		if index >= len(i.Transitions()) {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("StateImpl.GetByPath: index %d exceeds length of slice in 'transitions' (length=%d) in node '%s'", index, len(i.Transitions()), nodePath)
 		}
 		child := i.Transitions()[index]
 		if child == nil {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("StateImpl.GetByPath: item %d of slice in field 'transitions' is nil in node '%s'", index, nodePath)
 		}
-		if len(parts) == 1 {
+		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(parts[1])
+		return child.GetByPath(path)
 	case fieldNameName:
 		return nil, fmt.Errorf("StateImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
 	case fieldNameActions:
 		return nil, fmt.Errorf("StateImpl.GetByPath: field 'actions' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("StateImpl.GetByPath: field '%s' does not exist in node '%s' of type 'State'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("StateImpl.GetByPath: field '%s' does not exist in node '%s' of type 'State'", field.Value(), nodePath)
 	}
 }
 
@@ -570,15 +480,15 @@ func NewTransitionData() TransitionData {
 
 func (i *TransitionData) IsTransition() {}
 
-func (i *TransitionData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *TransitionData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 }
 
-func (i *TransitionData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *TransitionData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	if i.event != nil {
-		fn(i.event, fieldNameEvent, 0)
+		fn(i.event, fieldNameEvent, -1)
 	}
 	if i.state != nil {
-		fn(i.state, fieldNameState, 0)
+		fn(i.state, fieldNameState, -1)
 	}
 }
 
@@ -611,41 +521,24 @@ type TransitionImpl struct {
 	TransitionData
 }
 
-func (i *TransitionImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *TransitionImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.TransitionData.ForEachNode(fn)
 }
 
-func (i *TransitionImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *TransitionImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.TransitionData.ForEachReference(fn)
 }
 
-func (i *TransitionImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameEvent:
-		return core.FieldInfos{Multi: false, Reference: true}
-	case fieldNameState:
-		return core.FieldInfos{Multi: false, Reference: true}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *TransitionImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *TransitionImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameEvent:
 		return nil, fmt.Errorf("TransitionImpl.GetByPath: field 'event' is a cross-reference instead of a container field")
 	case fieldNameState:
 		return nil, fmt.Errorf("TransitionImpl.GetByPath: field 'state' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("TransitionImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Transition'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("TransitionImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Transition'", field.Value(), nodePath)
 	}
 }
 

--- a/internal/generator/type_generator.go
+++ b/internal/generator/type_generator.go
@@ -5,8 +5,10 @@
 package generator
 
 import (
+	"context"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 
 	"typefox.dev/fastbelt/internal/grammar"
@@ -23,6 +25,7 @@ func GenerateTypes(grammr grammar.Grammar, packageName string) string {
 	node.AppendLine("import (")
 	node.Indent(func(n codegen.Node) {
 		n.AppendLine("core \"typefox.dev/fastbelt\"")
+		n.AppendLine("\"unique\"")
 	})
 	node.AppendLine(")")
 	node.AppendLine()
@@ -31,6 +34,8 @@ func GenerateTypes(grammr grammar.Grammar, packageName string) string {
 	}
 
 	node.AppendNode(generateSyntheticFactories(grammr))
+
+	node.AppendNode(generateFieldInfos(grammr))
 
 	return FormatIfPossible(node.String())
 }
@@ -232,7 +237,7 @@ func generateImplStruct(node codegen.Node, grammr grammar.Grammar, iface grammar
 	node.AppendLine("}")
 	node.AppendLine()
 
-	node.AppendLine("func (i *", iface.Name(), "Impl) ForEachNode(fn func(core.AstNode)) {")
+	node.AppendLine("func (i *", iface.Name(), "Impl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {")
 	node.Indent(func(n codegen.Node) {
 		for _, extends := range getAllExtends(grammr, iface) {
 			n.AppendLine("i.", extends, "Data.ForEachNode(fn)")
@@ -241,12 +246,18 @@ func generateImplStruct(node codegen.Node, grammr grammar.Grammar, iface grammar
 	})
 	node.AppendLine("}")
 	node.AppendLine()
-	node.AppendLine("func (i *", iface.Name(), "Impl) ForEachReference(fn func(core.UntypedReference)) {")
+	node.AppendLine("func (i *", iface.Name(), "Impl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {")
 	node.Indent(func(n codegen.Node) {
 		for _, extends := range getAllExtends(grammr, iface) {
 			n.AppendLine("i.", extends, "Data.ForEachReference(fn)")
 		}
 		n.AppendLine("i.", iface.Name(), "Data.ForEachReference(fn)")
+	})
+	node.AppendLine("}")
+	node.AppendLine()
+	node.AppendLine("func (i *", iface.Name(), "Impl) FieldInfos(field unique.Handle[string]) core.FieldInfos {")
+	node.Indent(func(n codegen.Node) {
+		n.AppendLine("return ", grammr.Name(), "FieldInfos[\"", iface.Name(), "\"][field.Value()]")
 	})
 	node.AppendLine("}")
 	node.AppendLine()
@@ -283,7 +294,7 @@ func generateDataStruct(node codegen.Node, iface grammar.Interface, fields []Fie
 	node.AppendLine()
 	node.AppendLine("func (i *", iface.Name(), "Data) Is", iface.Name(), "() {}")
 	node.AppendLine()
-	node.AppendLine("func (i *", iface.Name(), "Data) ForEachNode(fn func(core.AstNode)) {")
+	node.AppendLine("func (i *", iface.Name(), "Data) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {")
 	node.Indent(func(n codegen.Node) {
 		for _, field := range fields {
 			if field.GType == TOKEN_TYPE || field.Reference {
@@ -291,15 +302,15 @@ func generateDataStruct(node codegen.Node, iface grammar.Interface, fields []Fie
 			}
 			name := field.PName
 			if field.Array {
-				n.AppendLine("for _, item := range i.", name, " {")
+				n.AppendLine("for j, item := range i.", name, " {")
 				n.Indent(func(n2 codegen.Node) {
-					n2.AppendLine("fn(item)")
+					n2.AppendLine("fn(item, unique.Make(\"", name, "\"), uint16(j))")
 				})
 				n.AppendLine("}")
 			} else {
 				n.AppendLine("if i.", name, " != nil {")
 				n.Indent(func(n2 codegen.Node) {
-					n2.AppendLine("fn(i.", name, ")")
+					n2.AppendLine("fn(i.", name, ", unique.Make(\"", name, "\"), 0)")
 				})
 				n.AppendLine("}")
 			}
@@ -307,7 +318,7 @@ func generateDataStruct(node codegen.Node, iface grammar.Interface, fields []Fie
 	})
 	node.AppendLine("}")
 	node.AppendLine()
-	node.AppendLine("func (i *", iface.Name(), "Data) ForEachReference(fn func(core.UntypedReference)) {")
+	node.AppendLine("func (i *", iface.Name(), "Data) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {")
 	node.Indent(func(n codegen.Node) {
 		for _, field := range fields {
 			if !field.Reference {
@@ -315,15 +326,15 @@ func generateDataStruct(node codegen.Node, iface grammar.Interface, fields []Fie
 			}
 			name := field.PName
 			if field.Array {
-				n.AppendLine("for _, item := range i.", name, " {")
+				n.AppendLine("for j, item := range i.", name, " {")
 				n.Indent(func(n2 codegen.Node) {
-					n2.AppendLine("fn(item)")
+					n2.AppendLine("fn(item, unique.Make(\"", name, "\"), uint16(j))")
 				})
 				n.AppendLine("}")
 			} else {
 				n.AppendLine("if i.", name, " != nil {")
 				n.Indent(func(n2 codegen.Node) {
-					n2.AppendLine("fn(i.", name, ")")
+					n2.AppendLine("fn(i.", name, ", unique.Make(\"", name, "\"), 0)")
 				})
 				n.AppendLine("}")
 			}
@@ -434,6 +445,68 @@ func generateSyntheticFactories(grammr grammar.Grammar) codegen.Node {
 	node.Indent(func(n codegen.Node) {
 		for _, e := range entries {
 			n.AppendLine(`"`, e.key, `": func() core.AstNode { return New`, e.typeName, "() },")
+		}
+	})
+	node.AppendLine("}")
+	node.AppendLine()
+	return node
+}
+
+func generateFieldInfos(grammr grammar.Grammar) codegen.Node {
+	node := codegen.NewNode()
+	name := grammr.Name()
+
+	type fieldsByIface struct {
+		name   string
+		fields []FieldInfo
+	}
+	fieldsByIfaces := []fieldsByIface{}
+
+	for _, iface := range grammr.Interfaces() {
+		fields := []FieldInfo{}
+		visited := map[string]bool{}
+		queue := []grammar.Interface{iface}
+		for len(queue) > 0 {
+			current := queue[0]
+			queue = queue[1:]
+			if visited[current.Name()] {
+				continue
+			}
+			visited[current.Name()] = true
+			for _, field := range current.Fields() {
+				fields = append(fields, getFieldInfo(field))
+			}
+			for _, ext := range current.Extends() {
+				parent := ext.Ref(context.Background())
+				if parent != nil && !visited[parent.Name()] {
+					queue = append(queue, parent)
+				}
+			}
+		}
+
+		sort.Slice(fields, func(i, j int) bool { return fields[i].Name < fields[j].Name })
+
+		fieldsByIfaces = append(fieldsByIfaces, fieldsByIface{
+			name:   iface.Name(),
+			fields: fields,
+		})
+	}
+	// Sort for stable output.
+	sort.Slice(fieldsByIfaces, func(i, j int) bool { return fieldsByIfaces[i].name < fieldsByIfaces[j].name })
+
+	node.AppendLine("var ", name, "FieldInfos = map[string]map[string]core.FieldInfos{")
+	node.Indent(func(n codegen.Node) {
+		for _, e := range fieldsByIfaces {
+			n.AppendLine(`"`, e.name, `": map[string]core.FieldInfos{`)
+			n.Indent(func(n2 codegen.Node) {
+				for _, field := range e.fields {
+					n2.AppendLine("\"", field.PName, "\": {")
+					n2.AppendLine("Multi: ", strconv.FormatBool(field.Array), ",")
+					n2.AppendLine("Reference: ", strconv.FormatBool(field.Reference), ",")
+					n2.AppendLine("},")
+				}
+			})
+			n.AppendLine("},")
 		}
 	})
 	node.AppendLine("}")

--- a/internal/generator/type_generator.go
+++ b/internal/generator/type_generator.go
@@ -570,19 +570,28 @@ func generateGetByPath(node codegen.Node, iface grammar.Interface) struct{ needs
 						needsStrconv = true
 						n2.AppendLine("index, err := strconv.Atoi(fieldAndIndex[1])")
 						n2.AppendLine("if err != nil {")
-						n2.Indent(func(n3 codegen.Node) { n3.AppendLine("return nil, err") })
-						n2.AppendLine("} else if index >= len(i.", f.Name, "()) {")
+						n2.Indent(func(n3 codegen.Node) {
+							n3.AppendLine(`return nil, fmt.Errorf("`, implName, `.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)`)
+						})
+						n2.AppendLine("}")
+						n2.AppendLine("if index >= len(i.", f.Name, "()) {")
 						n2.Indent(func(n3 codegen.Node) {
 							n3.AppendLine("nodePath, _ := i.AstNodeBase.NodePath()")
-							n3.AppendLine(`return nil, fmt.Errorf("`, implName, `.GetByPath: index %d exceeds slice length of '`, f.PName, `' (%d) at '%s'", index, len(i.`, f.Name, `()), nodePath)`)
+							n3.AppendLine(`return nil, fmt.Errorf("`, implName, `.GetByPath: index %d exceeds length of slice in '`, f.PName, `' (length=%d) in node '%s'", index, len(i.`, f.Name, `()), nodePath)`)
 						})
 						n2.AppendLine("}")
 						n2.AppendLine("child := i.", f.Name, "()[index]")
+						n2.AppendLine("if child == nil {")
+						n2.Indent(func(n3 codegen.Node) {
+							n3.AppendLine("nodePath, _ := i.AstNodeBase.NodePath()")
+							n3.AppendLine(`return nil, fmt.Errorf("`, implName, `.GetByPath: item %d of slice in field '`, f.PName, `' is nil in node '%s'", index, nodePath)`)
+						})
+						n2.AppendLine("}")
 					} else {
 						n2.AppendLine("if i.", f.Name, "() == nil {")
 						n2.Indent(func(n3 codegen.Node) {
 							n3.AppendLine("nodePath, _ := i.AstNodeBase.NodePath()")
-							n3.AppendLine(`return nil, fmt.Errorf("`, implName, `.GetByPath: field '`, f.PName, `' is nil at '%s'", nodePath)`)
+							n3.AppendLine(`return nil, fmt.Errorf("`, implName, `.GetByPath: field '`, f.PName, `' is nil in node '%s'", nodePath)`)
 						})
 						n2.AppendLine("}")
 						n2.AppendLine("child := i.", f.Name, "()")

--- a/internal/generator/type_generator.go
+++ b/internal/generator/type_generator.go
@@ -22,16 +22,28 @@ func GenerateTypes(grammr grammar.Grammar, packageName string) string {
 	node := NewRootNode()
 	node.AppendLine("package ", packageName)
 	node.AppendLine()
+
+	var needsStrconv bool
+	interfaces := codegen.NewNode()
+	for _, iface := range grammr.Interfaces() {
+		res := generateInterface(interfaces, grammr, iface)
+		needsStrconv = needsStrconv || res.needsStrconv
+	}
+
 	node.AppendLine("import (")
 	node.Indent(func(n codegen.Node) {
-		n.AppendLine("core \"typefox.dev/fastbelt\"")
+		n.AppendLine("\"fmt\"")
+		if needsStrconv {
+			n.AppendLine("\"strconv\"")
+		}
+		n.AppendLine("\"strings\"")
 		n.AppendLine("\"unique\"")
+		n.AppendLine()
+		n.AppendLine("core \"typefox.dev/fastbelt\"")
 	})
 	node.AppendLine(")")
 	node.AppendLine()
-	for _, iface := range grammr.Interfaces() {
-		generateInterface(node, grammr, iface)
-	}
+	node.AppendNode(interfaces)
 
 	node.AppendNode(generateFieldHandles(grammr))
 	node.AppendNode(generateSyntheticFactories(grammr))
@@ -165,7 +177,7 @@ func llExtends(grammr grammar.Grammar, iface grammar.Interface, result []string)
 	return result
 }
 
-func generateInterface(node codegen.Node, grammr grammar.Grammar, iface grammar.Interface) {
+func generateInterface(node codegen.Node, grammr grammar.Grammar, iface grammar.Interface) struct{ needsStrconv bool } {
 	fields := []FieldInfo{}
 	for _, field := range iface.Fields() {
 		fields = append(fields, getFieldInfo(field))
@@ -221,10 +233,10 @@ func generateInterface(node codegen.Node, grammr grammar.Grammar, iface grammar.
 	node.AppendLine("}")
 	node.AppendLine()
 	generateDataStruct(node, iface, fields)
-	generateImplStruct(node, grammr, iface)
+	return generateImplStruct(node, grammr, iface)
 }
 
-func generateImplStruct(node codegen.Node, grammr grammar.Grammar, iface grammar.Interface) {
+func generateImplStruct(node codegen.Node, grammr grammar.Grammar, iface grammar.Interface) struct{ needsStrconv bool } {
 	node.AppendLine("type ", iface.Name(), "Impl struct {")
 	node.Indent(func(n codegen.Node) {
 		n.AppendLine("core.AstNodeBase")
@@ -277,6 +289,7 @@ func generateImplStruct(node codegen.Node, grammr grammar.Grammar, iface grammar
 	})
 	node.AppendLine("}")
 	node.AppendLine()
+	return generateGetByPath(node, iface)
 }
 
 func generateDataStruct(node codegen.Node, iface grammar.Interface, fields []FieldInfo) {
@@ -512,4 +525,90 @@ func collectAllFields(iface grammar.Interface, visited map[string]struct{}) []Fi
 		fields = append(fields, getFieldInfo(field))
 	}
 	return fields
+}
+
+func generateGetByPath(node codegen.Node, iface grammar.Interface) struct{ needsStrconv bool } {
+	var needsStrconv bool
+	allFields := collectAllFields(iface, map[string]struct{}{})
+	sort.Slice(allFields, func(i, j int) bool { return allFields[i].Name < allFields[j].Name })
+
+	var containmentFields, primitiveFields []FieldInfo
+	for _, f := range allFields {
+		if f.Reference {
+			continue
+		}
+		if f.GType == TOKEN_TYPE || f.GType == COMPOSITE_TYPE {
+			primitiveFields = append(primitiveFields, f)
+		} else {
+			containmentFields = append(containmentFields, f)
+		}
+	}
+
+	name := iface.Name()
+	implName := name + "Impl"
+	hasCases := len(containmentFields) > 0 || len(primitiveFields) > 0
+
+	node.AppendLine("func (i *", implName, ") GetByPath(path string) (core.AstNode, error) {")
+	node.Indent(func(n codegen.Node) {
+		n.AppendLine(`path = strings.TrimLeft(path, "/")`)
+		n.AppendLine(`if path == "" {`)
+		n.Indent(func(n2 codegen.Node) { n2.AppendLine("return i, nil") })
+		n.AppendLine("}")
+		n.AppendLine(`parts := strings.SplitN(path, "/", 2)`)
+		n.AppendLine(`fieldAndIndex := strings.SplitN(parts[0], "@", 2)`)
+
+		if !hasCases {
+			n.AppendLine("nodePath, _ := i.AstNodeBase.NodePath()")
+			n.AppendLine(`return nil, fmt.Errorf("`, implName, `.GetByPath: field '%s' does not exist in node '%s' of type '`, name, `'", fieldAndIndex[0], nodePath)`)
+		} else {
+			n.AppendLine("field := unique.Make(fieldAndIndex[0])")
+			n.AppendLine("switch field {")
+			for _, f := range containmentFields {
+				n.AppendLine("case ", fieldHandleVarName(f.PName), ":")
+				n.Indent(func(n2 codegen.Node) {
+					if f.Array {
+						needsStrconv = true
+						n2.AppendLine("index, err := strconv.Atoi(fieldAndIndex[1])")
+						n2.AppendLine("if err != nil {")
+						n2.Indent(func(n3 codegen.Node) { n3.AppendLine("return nil, err") })
+						n2.AppendLine("} else if index >= len(i.", f.Name, "()) {")
+						n2.Indent(func(n3 codegen.Node) {
+							n3.AppendLine("nodePath, _ := i.AstNodeBase.NodePath()")
+							n3.AppendLine(`return nil, fmt.Errorf("`, implName, `.GetByPath: index %d exceeds slice length of '`, f.PName, `' (%d) at '%s'", index, len(i.`, f.Name, `()), nodePath)`)
+						})
+						n2.AppendLine("}")
+						n2.AppendLine("child := i.", f.Name, "()[index]")
+					} else {
+						n2.AppendLine("if i.", f.Name, "() == nil {")
+						n2.Indent(func(n3 codegen.Node) {
+							n3.AppendLine("nodePath, _ := i.AstNodeBase.NodePath()")
+							n3.AppendLine(`return nil, fmt.Errorf("`, implName, `.GetByPath: field '`, f.PName, `' is nil at '%s'", nodePath)`)
+						})
+						n2.AppendLine("}")
+						n2.AppendLine("child := i.", f.Name, "()")
+					}
+					n2.AppendLine("if len(parts) == 1 {")
+					n2.Indent(func(n3 codegen.Node) { n3.AppendLine("return child, nil") })
+					n2.AppendLine("}")
+					n2.AppendLine("return child.GetByPath(parts[1])")
+				})
+			}
+			for _, f := range primitiveFields {
+				n.AppendLine("case ", fieldHandleVarName(f.PName), ":")
+				n.Indent(func(n2 codegen.Node) {
+					n2.AppendLine(`return nil, fmt.Errorf("`, implName, `.GetByPath: field '`, f.PName, `' holds a primitive value and cannot be navigated")`)
+				})
+			}
+			n.AppendLine("default:")
+			n.Indent(func(n2 codegen.Node) {
+				n2.AppendLine("nodePath, _ := i.AstNodeBase.NodePath()")
+				n2.AppendLine(`return nil, fmt.Errorf("`, implName, `.GetByPath: field '%s' does not exist in node '%s' of type '`, name, `'", fieldAndIndex[0], nodePath)`)
+			})
+			n.AppendLine("}")
+		}
+	})
+	node.AppendLine("}")
+	node.AppendLine()
+
+	return struct{ needsStrconv bool }{needsStrconv}
 }

--- a/internal/generator/type_generator.go
+++ b/internal/generator/type_generator.go
@@ -33,9 +33,8 @@ func GenerateTypes(grammr grammar.Grammar, packageName string) string {
 		generateInterface(node, grammr, iface)
 	}
 
+	node.AppendNode(generateFieldHandles(grammr))
 	node.AppendNode(generateSyntheticFactories(grammr))
-
-	node.AppendNode(generateFieldInfos(grammr))
 
 	return FormatIfPossible(node.String())
 }
@@ -257,7 +256,24 @@ func generateImplStruct(node codegen.Node, grammr grammar.Grammar, iface grammar
 	node.AppendLine()
 	node.AppendLine("func (i *", iface.Name(), "Impl) FieldInfos(field unique.Handle[string]) core.FieldInfos {")
 	node.Indent(func(n codegen.Node) {
-		n.AppendLine("return ", grammr.Name(), "FieldInfos[\"", iface.Name(), "\"][field.Value()]")
+		fields := collectAllFields(iface, map[string]struct{}{})
+		sort.Slice(fields, func(i, j int) bool { return fields[i].Name < fields[j].Name })
+		if len(fields) == 0 {
+			n.AppendLine("return core.FieldInfos{}")
+		} else {
+			n.AppendLine("switch field {")
+			for _, f := range fields {
+				n.AppendLine("case ", fieldHandleVarName(f.PName), ":")
+				n.Indent(func(n2 codegen.Node) {
+					n2.AppendLine("return core.FieldInfos{Multi: ", strconv.FormatBool(f.Array), ", Reference: ", strconv.FormatBool(f.Reference), "}")
+				})
+			}
+			n.AppendLine("default:")
+			n.Indent(func(n2 codegen.Node) {
+				n2.AppendLine("return core.FieldInfos{}")
+			})
+			n.AppendLine("}")
+		}
 	})
 	node.AppendLine("}")
 	node.AppendLine()
@@ -304,13 +320,13 @@ func generateDataStruct(node codegen.Node, iface grammar.Interface, fields []Fie
 			if field.Array {
 				n.AppendLine("for j, item := range i.", name, " {")
 				n.Indent(func(n2 codegen.Node) {
-					n2.AppendLine("fn(item, unique.Make(\"", name, "\"), uint16(j))")
+					n2.AppendLine("fn(item, ", fieldHandleVarName(name), ", uint16(j))")
 				})
 				n.AppendLine("}")
 			} else {
 				n.AppendLine("if i.", name, " != nil {")
 				n.Indent(func(n2 codegen.Node) {
-					n2.AppendLine("fn(i.", name, ", unique.Make(\"", name, "\"), 0)")
+					n2.AppendLine("fn(i.", name, ", ", fieldHandleVarName(name), ", 0)")
 				})
 				n.AppendLine("}")
 			}
@@ -328,13 +344,13 @@ func generateDataStruct(node codegen.Node, iface grammar.Interface, fields []Fie
 			if field.Array {
 				n.AppendLine("for j, item := range i.", name, " {")
 				n.Indent(func(n2 codegen.Node) {
-					n2.AppendLine("fn(item, unique.Make(\"", name, "\"), uint16(j))")
+					n2.AppendLine("fn(item, ", fieldHandleVarName(name), ", uint16(j))")
 				})
 				n.AppendLine("}")
 			} else {
 				n.AppendLine("if i.", name, " != nil {")
 				n.Indent(func(n2 codegen.Node) {
-					n2.AppendLine("fn(i.", name, ", unique.Make(\"", name, "\"), 0)")
+					n2.AppendLine("fn(i.", name, ", ", fieldHandleVarName(name), ", 0)")
 				})
 				n.AppendLine("}")
 			}
@@ -452,64 +468,48 @@ func generateSyntheticFactories(grammr grammar.Grammar) codegen.Node {
 	return node
 }
 
-func generateFieldInfos(grammr grammar.Grammar) codegen.Node {
+func fieldHandleVarName(pname string) string {
+	clean := strings.TrimLeft(pname, "_")
+	return "fieldName" + strings.ToUpper(clean[:1]) + clean[1:]
+}
+
+func generateFieldHandles(grammr grammar.Grammar) codegen.Node {
 	node := codegen.NewNode()
-	name := grammr.Name()
-
-	type fieldsByIface struct {
-		name   string
-		fields []FieldInfo
-	}
-	fieldsByIfaces := []fieldsByIface{}
-
+	seen := map[string]bool{}
+	var pnames []string
 	for _, iface := range grammr.Interfaces() {
-		fields := []FieldInfo{}
-		visited := map[string]bool{}
-		queue := []grammar.Interface{iface}
-		for len(queue) > 0 {
-			current := queue[0]
-			queue = queue[1:]
-			if visited[current.Name()] {
-				continue
-			}
-			visited[current.Name()] = true
-			for _, field := range current.Fields() {
-				fields = append(fields, getFieldInfo(field))
-			}
-			for _, ext := range current.Extends() {
-				parent := ext.Ref(context.Background())
-				if parent != nil && !visited[parent.Name()] {
-					queue = append(queue, parent)
-				}
+		for _, f := range collectAllFields(iface, map[string]struct{}{}) {
+			if !seen[f.PName] {
+				seen[f.PName] = true
+				pnames = append(pnames, f.PName)
 			}
 		}
-
-		sort.Slice(fields, func(i, j int) bool { return fields[i].Name < fields[j].Name })
-
-		fieldsByIfaces = append(fieldsByIfaces, fieldsByIface{
-			name:   iface.Name(),
-			fields: fields,
-		})
 	}
-	// Sort for stable output.
-	sort.Slice(fieldsByIfaces, func(i, j int) bool { return fieldsByIfaces[i].name < fieldsByIfaces[j].name })
-
-	node.AppendLine("var ", name, "FieldInfos = map[string]map[string]core.FieldInfos{")
+	sort.Strings(pnames)
+	node.AppendLine("var (")
 	node.Indent(func(n codegen.Node) {
-		for _, e := range fieldsByIfaces {
-			n.AppendLine(`"`, e.name, `": map[string]core.FieldInfos{`)
-			n.Indent(func(n2 codegen.Node) {
-				for _, field := range e.fields {
-					n2.AppendLine("\"", field.PName, "\": {")
-					n2.AppendLine("Multi: ", strconv.FormatBool(field.Array), ",")
-					n2.AppendLine("Reference: ", strconv.FormatBool(field.Reference), ",")
-					n2.AppendLine("},")
-				}
-			})
-			n.AppendLine("},")
+		for _, pname := range pnames {
+			n.AppendLine(fieldHandleVarName(pname), ` = unique.Make("`, pname, `")`)
 		}
 	})
-	node.AppendLine("}")
+	node.AppendLine(")")
 	node.AppendLine()
 	return node
+}
+
+func collectAllFields(iface grammar.Interface, visited map[string]struct{}) []FieldInfo {
+	if _, seen := visited[iface.Name()]; seen {
+		return nil
+	}
+	visited[iface.Name()] = struct{}{}
+	fields := []FieldInfo{}
+	for _, ext := range iface.Extends() {
+		if parent := ext.Ref(context.TODO()); parent != nil {
+			fields = append(fields, collectAllFields(parent, visited)...)
+		}
+	}
+	for _, field := range iface.Fields() {
+		fields = append(fields, getFieldInfo(field))
+	}
+	return fields
 }

--- a/internal/generator/type_generator.go
+++ b/internal/generator/type_generator.go
@@ -481,11 +481,6 @@ func generateSyntheticFactories(grammr grammar.Grammar) codegen.Node {
 	return node
 }
 
-func fieldHandleVarName(pname string) string {
-	clean := strings.TrimLeft(pname, "_")
-	return "fieldName" + strings.ToUpper(clean[:1]) + clean[1:]
-}
-
 func generateFieldHandles(grammr grammar.Grammar) codegen.Node {
 	node := codegen.NewNode()
 	seen := map[string]bool{}
@@ -527,26 +522,31 @@ func collectAllFields(iface grammar.Interface, visited map[string]struct{}) []Fi
 	return fields
 }
 
+func fieldHandleVarName(pname string) string {
+	clean := strings.TrimLeft(pname, "_")
+	return "fieldName" + strings.ToUpper(clean[:1]) + clean[1:]
+}
+
 func generateGetByPath(node codegen.Node, iface grammar.Interface) struct{ needsStrconv bool } {
 	var needsStrconv bool
 	allFields := collectAllFields(iface, map[string]struct{}{})
 	sort.Slice(allFields, func(i, j int) bool { return allFields[i].Name < allFields[j].Name })
 
-	var containmentFields, primitiveFields []FieldInfo
+	var containmentFields, primitiveFields, referenceFields []FieldInfo
 	for _, f := range allFields {
-		if f.Reference {
-			continue
-		}
-		if f.GType == TOKEN_TYPE || f.GType == COMPOSITE_TYPE {
+		switch {
+		case f.Reference:
+			referenceFields = append(referenceFields, f)
+		case f.GType == TOKEN_TYPE || f.GType == COMPOSITE_TYPE:
 			primitiveFields = append(primitiveFields, f)
-		} else {
+		default:
 			containmentFields = append(containmentFields, f)
 		}
 	}
 
 	name := iface.Name()
 	implName := name + "Impl"
-	hasCases := len(containmentFields) > 0 || len(primitiveFields) > 0
+	hasCases := len(containmentFields) > 0 || len(primitiveFields) > 0 || len(referenceFields) > 0
 
 	node.AppendLine("func (i *", implName, ") GetByPath(path string) (core.AstNode, error) {")
 	node.Indent(func(n codegen.Node) {
@@ -596,7 +596,13 @@ func generateGetByPath(node codegen.Node, iface grammar.Interface) struct{ needs
 			for _, f := range primitiveFields {
 				n.AppendLine("case ", fieldHandleVarName(f.PName), ":")
 				n.Indent(func(n2 codegen.Node) {
-					n2.AppendLine(`return nil, fmt.Errorf("`, implName, `.GetByPath: field '`, f.PName, `' holds a primitive value and cannot be navigated")`)
+					n2.AppendLine(`return nil, fmt.Errorf("`, implName, `.GetByPath: field '`, f.PName, `' holds a primitive value instead of an ast node")`)
+				})
+			}
+			for _, f := range referenceFields {
+				n.AppendLine("case ", fieldHandleVarName(f.PName), ":")
+				n.Indent(func(n2 codegen.Node) {
+					n2.AppendLine(`return nil, fmt.Errorf("`, implName, `.GetByPath: field '`, f.PName, `' is a cross-reference instead of a container field")`)
 				})
 			}
 			n.AppendLine("default:")

--- a/internal/generator/type_generator.go
+++ b/internal/generator/type_generator.go
@@ -256,7 +256,7 @@ func generateImplStruct(node codegen.Node, grammr grammar.Grammar, iface grammar
 	})
 	node.AppendLine("}")
 	node.AppendLine()
-	generateGetByPath(node, iface)
+	generateResolve(node, iface)
 }
 
 func generateDataStruct(node codegen.Node, iface grammar.Interface, fields []FieldInfo) {
@@ -494,7 +494,7 @@ func fieldHandleVarName(pname string) string {
 	return "fieldName" + strings.ToUpper(clean[:1]) + clean[1:]
 }
 
-func generateGetByPath(node codegen.Node, iface grammar.Interface) {
+func generateResolve(node codegen.Node, iface grammar.Interface) {
 	allFields := collectAllFields(iface, map[string]struct{}{})
 	sort.Slice(allFields, func(i, j int) bool { return allFields[i].Name < allFields[j].Name })
 
@@ -514,13 +514,13 @@ func generateGetByPath(node codegen.Node, iface grammar.Interface) {
 	implName := name + "Impl"
 	hasCases := len(containmentFields) > 0 || len(primitiveFields) > 0 || len(referenceFields) > 0
 
-	node.AppendLine("func (i *", implName, ") GetByPath(path *core.PathSegments) (core.AstNode, error) {")
+	node.AppendLine("func (i *", implName, ") Resolve(path core.FragmentPath) (core.AstNode, error) {")
 	node.Indent(func(n codegen.Node) {
-		var needIndex bool = false
+		needIndex := false
 		n2 := codegen.NewNode()
 		if !hasCases {
-			n2.AppendLine("nodePath, _ := core.NodePath(i)")
-			n2.AppendLine(`return nil, fmt.Errorf("`, implName, `.GetByPath: field '%s' does not exist in node '%s' of type '`, name, `'", field.Value(), nodePath)`)
+			n2.AppendLine("nodePath, _ := core.PathOf(i)")
+			n2.AppendLine(`return nil, fmt.Errorf("`, implName, `.Resolve: field '%s' does not exist in node '%s' of type '`, name, `'", field.Value(), nodePath)`)
 		} else {
 			n2.AppendLine("switch field {")
 			for _, f := range containmentFields {
@@ -530,22 +530,22 @@ func generateGetByPath(node codegen.Node, iface grammar.Interface) {
 						needIndex = true
 						n2.AppendLine("if index >= len(i.", f.Name, "()) {")
 						n2.Indent(func(n3 codegen.Node) {
-							n3.AppendLine("nodePath, _ := core.NodePath(i)")
-							n3.AppendLine(`return nil, fmt.Errorf("`, implName, `.GetByPath: index %d exceeds length of slice in '`, f.PName, `' (length=%d) in node '%s'", index, len(i.`, f.Name, `()), nodePath)`)
+							n3.AppendLine("nodePath, _ := core.PathOf(i)")
+							n3.AppendLine(`return nil, fmt.Errorf("`, implName, `.Resolve: index %d exceeds length of slice in '`, f.PName, `' (length=%d) in node '%s'", index, len(i.`, f.Name, `()), nodePath)`)
 						})
 						n2.AppendLine("}")
 						n2.AppendLine("child := i.", f.Name, "()[index]")
 						n2.AppendLine("if child == nil {")
 						n2.Indent(func(n3 codegen.Node) {
-							n3.AppendLine("nodePath, _ := core.NodePath(i)")
-							n3.AppendLine(`return nil, fmt.Errorf("`, implName, `.GetByPath: item %d of slice in field '`, f.PName, `' is nil in node '%s'", index, nodePath)`)
+							n3.AppendLine("nodePath, _ := core.PathOf(i)")
+							n3.AppendLine(`return nil, fmt.Errorf("`, implName, `.Resolve: item %d of slice in field '`, f.PName, `' is nil in node '%s'", index, nodePath)`)
 						})
 						n2.AppendLine("}")
 					} else {
 						n2.AppendLine("if i.", f.Name, "() == nil {")
 						n2.Indent(func(n3 codegen.Node) {
-							n3.AppendLine("nodePath, _ := core.NodePath(i)")
-							n3.AppendLine(`return nil, fmt.Errorf("`, implName, `.GetByPath: field '`, f.PName, `' is nil in node '%s'", nodePath)`)
+							n3.AppendLine("nodePath, _ := core.PathOf(i)")
+							n3.AppendLine(`return nil, fmt.Errorf("`, implName, `.Resolve: field '`, f.PName, `' is nil in node '%s'", nodePath)`)
 						})
 						n2.AppendLine("}")
 						n2.AppendLine("child := i.", f.Name, "()")
@@ -553,25 +553,25 @@ func generateGetByPath(node codegen.Node, iface grammar.Interface) {
 					n2.AppendLine("if path.Empty() {")
 					n2.Indent(func(n3 codegen.Node) { n3.AppendLine("return child, nil") })
 					n2.AppendLine("}")
-					n2.AppendLine("return child.GetByPath(path)")
+					n2.AppendLine("return child.Resolve(path)")
 				})
 			}
 			for _, f := range primitiveFields {
 				n2.AppendLine("case ", fieldHandleVarName(f.PName), ":")
 				n2.Indent(func(n2 codegen.Node) {
-					n2.AppendLine(`return nil, fmt.Errorf("`, implName, `.GetByPath: field '`, f.PName, `' holds a primitive value instead of an ast node")`)
+					n2.AppendLine(`return nil, fmt.Errorf("`, implName, `.Resolve: field '`, f.PName, `' holds a primitive value instead of an ast node")`)
 				})
 			}
 			for _, f := range referenceFields {
 				n2.AppendLine("case ", fieldHandleVarName(f.PName), ":")
 				n2.Indent(func(n2 codegen.Node) {
-					n2.AppendLine(`return nil, fmt.Errorf("`, implName, `.GetByPath: field '`, f.PName, `' is a cross-reference instead of a container field")`)
+					n2.AppendLine(`return nil, fmt.Errorf("`, implName, `.Resolve: field '`, f.PName, `' is a cross-reference instead of a container field")`)
 				})
 			}
 			n2.AppendLine("default:")
 			n2.Indent(func(n2 codegen.Node) {
-				n2.AppendLine("nodePath, _ := core.NodePath(i)")
-				n2.AppendLine(`return nil, fmt.Errorf("`, implName, `.GetByPath: field '%s' does not exist in node '%s' of type '`, name, `'", field.Value(), nodePath)`)
+				n2.AppendLine("nodePath, _ := core.PathOf(i)")
+				n2.AppendLine(`return nil, fmt.Errorf("`, implName, `.Resolve: field '%s' does not exist in node '%s' of type '`, name, `'", field.Value(), nodePath)`)
 			})
 			n2.AppendLine("}")
 		}

--- a/internal/generator/type_generator.go
+++ b/internal/generator/type_generator.go
@@ -12,6 +12,7 @@ import (
 
 	"typefox.dev/fastbelt/internal/grammar"
 	"typefox.dev/fastbelt/util/codegen"
+	"typefox.dev/fastbelt/util/collections"
 )
 
 const TOKEN_TYPE = "*core.Token"
@@ -450,21 +451,18 @@ func generateSyntheticFactories(grammr grammar.Grammar) codegen.Node {
 
 func generateFieldHandles(grammr grammar.Grammar) codegen.Node {
 	node := codegen.NewNode()
-	seen := map[string]bool{}
-	var pnames []string
+	set := collections.NewSet[string]()
 	for _, iface := range grammr.Interfaces() {
 		for _, f := range collectAllFields(iface, map[string]struct{}{}) {
-			if !seen[f.PName] {
-				seen[f.PName] = true
-				pnames = append(pnames, f.PName)
-			}
+			set.Add(f.PName)
 		}
 	}
-	sort.Strings(pnames)
+	pNames := slices.Collect(set.All())
+	slices.Sort(pNames)
 	node.AppendLine("var (")
 	node.Indent(func(n codegen.Node) {
-		for _, pname := range pnames {
-			n.AppendLine(fieldHandleVarName(pname), ` = unique.Make("`, pname, `")`)
+		for _, pName := range pNames {
+			n.AppendLine(fieldHandleVarName(pName), ` = unique.Make("`, pName, `")`)
 		}
 	})
 	node.AppendLine(")")
@@ -479,7 +477,7 @@ func collectAllFields(iface grammar.Interface, visited map[string]struct{}) []Fi
 	visited[iface.Name()] = struct{}{}
 	fields := []FieldInfo{}
 	for _, ext := range iface.Extends() {
-		if parent := ext.Ref(context.TODO()); parent != nil {
+		if parent := ext.Ref(context.Background()); parent != nil {
 			fields = append(fields, collectAllFields(parent, visited)...)
 		}
 	}

--- a/internal/generator/type_generator.go
+++ b/internal/generator/type_generator.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"slices"
 	"sort"
-	"strconv"
 	"strings"
 
 	"typefox.dev/fastbelt/internal/grammar"
@@ -23,27 +22,18 @@ func GenerateTypes(grammr grammar.Grammar, packageName string) string {
 	node.AppendLine("package ", packageName)
 	node.AppendLine()
 
-	var needsStrconv bool
-	interfaces := codegen.NewNode()
-	for _, iface := range grammr.Interfaces() {
-		res := generateInterface(interfaces, grammr, iface)
-		needsStrconv = needsStrconv || res.needsStrconv
-	}
-
 	node.AppendLine("import (")
 	node.Indent(func(n codegen.Node) {
 		n.AppendLine("\"fmt\"")
-		if needsStrconv {
-			n.AppendLine("\"strconv\"")
-		}
-		n.AppendLine("\"strings\"")
 		n.AppendLine("\"unique\"")
 		n.AppendLine()
 		n.AppendLine("core \"typefox.dev/fastbelt\"")
 	})
 	node.AppendLine(")")
 	node.AppendLine()
-	node.AppendNode(interfaces)
+	for _, iface := range grammr.Interfaces() {
+		generateInterface(node, grammr, iface)
+	}
 
 	node.AppendNode(generateFieldHandles(grammr))
 	node.AppendNode(generateSyntheticFactories(grammr))
@@ -177,7 +167,7 @@ func llExtends(grammr grammar.Grammar, iface grammar.Interface, result []string)
 	return result
 }
 
-func generateInterface(node codegen.Node, grammr grammar.Grammar, iface grammar.Interface) struct{ needsStrconv bool } {
+func generateInterface(node codegen.Node, grammr grammar.Grammar, iface grammar.Interface) {
 	fields := []FieldInfo{}
 	for _, field := range iface.Fields() {
 		fields = append(fields, getFieldInfo(field))
@@ -233,10 +223,10 @@ func generateInterface(node codegen.Node, grammr grammar.Grammar, iface grammar.
 	node.AppendLine("}")
 	node.AppendLine()
 	generateDataStruct(node, iface, fields)
-	return generateImplStruct(node, grammr, iface)
+	generateImplStruct(node, grammr, iface)
 }
 
-func generateImplStruct(node codegen.Node, grammr grammar.Grammar, iface grammar.Interface) struct{ needsStrconv bool } {
+func generateImplStruct(node codegen.Node, grammr grammar.Grammar, iface grammar.Interface) {
 	node.AppendLine("type ", iface.Name(), "Impl struct {")
 	node.Indent(func(n codegen.Node) {
 		n.AppendLine("core.AstNodeBase")
@@ -248,7 +238,7 @@ func generateImplStruct(node codegen.Node, grammr grammar.Grammar, iface grammar
 	node.AppendLine("}")
 	node.AppendLine()
 
-	node.AppendLine("func (i *", iface.Name(), "Impl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {")
+	node.AppendLine("func (i *", iface.Name(), "Impl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {")
 	node.Indent(func(n codegen.Node) {
 		for _, extends := range getAllExtends(grammr, iface) {
 			n.AppendLine("i.", extends, "Data.ForEachNode(fn)")
@@ -257,7 +247,7 @@ func generateImplStruct(node codegen.Node, grammr grammar.Grammar, iface grammar
 	})
 	node.AppendLine("}")
 	node.AppendLine()
-	node.AppendLine("func (i *", iface.Name(), "Impl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {")
+	node.AppendLine("func (i *", iface.Name(), "Impl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {")
 	node.Indent(func(n codegen.Node) {
 		for _, extends := range getAllExtends(grammr, iface) {
 			n.AppendLine("i.", extends, "Data.ForEachReference(fn)")
@@ -266,30 +256,7 @@ func generateImplStruct(node codegen.Node, grammr grammar.Grammar, iface grammar
 	})
 	node.AppendLine("}")
 	node.AppendLine()
-	node.AppendLine("func (i *", iface.Name(), "Impl) FieldInfos(field unique.Handle[string]) core.FieldInfos {")
-	node.Indent(func(n codegen.Node) {
-		fields := collectAllFields(iface, map[string]struct{}{})
-		sort.Slice(fields, func(i, j int) bool { return fields[i].Name < fields[j].Name })
-		if len(fields) == 0 {
-			n.AppendLine("return core.FieldInfos{}")
-		} else {
-			n.AppendLine("switch field {")
-			for _, f := range fields {
-				n.AppendLine("case ", fieldHandleVarName(f.PName), ":")
-				n.Indent(func(n2 codegen.Node) {
-					n2.AppendLine("return core.FieldInfos{Multi: ", strconv.FormatBool(f.Array), ", Reference: ", strconv.FormatBool(f.Reference), "}")
-				})
-			}
-			n.AppendLine("default:")
-			n.Indent(func(n2 codegen.Node) {
-				n2.AppendLine("return core.FieldInfos{}")
-			})
-			n.AppendLine("}")
-		}
-	})
-	node.AppendLine("}")
-	node.AppendLine()
-	return generateGetByPath(node, iface)
+	generateGetByPath(node, iface)
 }
 
 func generateDataStruct(node codegen.Node, iface grammar.Interface, fields []FieldInfo) {
@@ -323,7 +290,7 @@ func generateDataStruct(node codegen.Node, iface grammar.Interface, fields []Fie
 	node.AppendLine()
 	node.AppendLine("func (i *", iface.Name(), "Data) Is", iface.Name(), "() {}")
 	node.AppendLine()
-	node.AppendLine("func (i *", iface.Name(), "Data) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {")
+	node.AppendLine("func (i *", iface.Name(), "Data) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {")
 	node.Indent(func(n codegen.Node) {
 		for _, field := range fields {
 			if field.GType == TOKEN_TYPE || field.Reference {
@@ -333,13 +300,13 @@ func generateDataStruct(node codegen.Node, iface grammar.Interface, fields []Fie
 			if field.Array {
 				n.AppendLine("for j, item := range i.", name, " {")
 				n.Indent(func(n2 codegen.Node) {
-					n2.AppendLine("fn(item, ", fieldHandleVarName(name), ", uint16(j))")
+					n2.AppendLine("fn(item, ", fieldHandleVarName(name), ", j)")
 				})
 				n.AppendLine("}")
 			} else {
 				n.AppendLine("if i.", name, " != nil {")
 				n.Indent(func(n2 codegen.Node) {
-					n2.AppendLine("fn(i.", name, ", ", fieldHandleVarName(name), ", 0)")
+					n2.AppendLine("fn(i.", name, ", ", fieldHandleVarName(name), ", -1)")
 				})
 				n.AppendLine("}")
 			}
@@ -347,7 +314,7 @@ func generateDataStruct(node codegen.Node, iface grammar.Interface, fields []Fie
 	})
 	node.AppendLine("}")
 	node.AppendLine()
-	node.AppendLine("func (i *", iface.Name(), "Data) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {")
+	node.AppendLine("func (i *", iface.Name(), "Data) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {")
 	node.Indent(func(n codegen.Node) {
 		for _, field := range fields {
 			if !field.Reference {
@@ -357,13 +324,13 @@ func generateDataStruct(node codegen.Node, iface grammar.Interface, fields []Fie
 			if field.Array {
 				n.AppendLine("for j, item := range i.", name, " {")
 				n.Indent(func(n2 codegen.Node) {
-					n2.AppendLine("fn(item, ", fieldHandleVarName(name), ", uint16(j))")
+					n2.AppendLine("fn(item, ", fieldHandleVarName(name), ", j)")
 				})
 				n.AppendLine("}")
 			} else {
 				n.AppendLine("if i.", name, " != nil {")
 				n.Indent(func(n2 codegen.Node) {
-					n2.AppendLine("fn(i.", name, ", ", fieldHandleVarName(name), ", 0)")
+					n2.AppendLine("fn(i.", name, ", ", fieldHandleVarName(name), ", -1)")
 				})
 				n.AppendLine("}")
 			}
@@ -527,8 +494,7 @@ func fieldHandleVarName(pname string) string {
 	return "fieldName" + strings.ToUpper(clean[:1]) + clean[1:]
 }
 
-func generateGetByPath(node codegen.Node, iface grammar.Interface) struct{ needsStrconv bool } {
-	var needsStrconv bool
+func generateGetByPath(node codegen.Node, iface grammar.Interface) {
 	allFields := collectAllFields(iface, map[string]struct{}{})
 	sort.Slice(allFields, func(i, j int) bool { return allFields[i].Name < allFields[j].Name })
 
@@ -548,82 +514,76 @@ func generateGetByPath(node codegen.Node, iface grammar.Interface) struct{ needs
 	implName := name + "Impl"
 	hasCases := len(containmentFields) > 0 || len(primitiveFields) > 0 || len(referenceFields) > 0
 
-	node.AppendLine("func (i *", implName, ") GetByPath(path string) (core.AstNode, error) {")
+	node.AppendLine("func (i *", implName, ") GetByPath(path *core.PathSegments) (core.AstNode, error) {")
 	node.Indent(func(n codegen.Node) {
-		n.AppendLine(`path = strings.TrimLeft(path, "/")`)
-		n.AppendLine(`if path == "" {`)
-		n.Indent(func(n2 codegen.Node) { n2.AppendLine("return i, nil") })
-		n.AppendLine("}")
-		n.AppendLine(`parts := strings.SplitN(path, "/", 2)`)
-		n.AppendLine(`fieldAndIndex := strings.SplitN(parts[0], "@", 2)`)
-
+		var needIndex bool = false
+		n2 := codegen.NewNode()
 		if !hasCases {
-			n.AppendLine("nodePath, _ := i.AstNodeBase.NodePath()")
-			n.AppendLine(`return nil, fmt.Errorf("`, implName, `.GetByPath: field '%s' does not exist in node '%s' of type '`, name, `'", fieldAndIndex[0], nodePath)`)
+			n2.AppendLine("nodePath, _ := core.NodePath(i)")
+			n2.AppendLine(`return nil, fmt.Errorf("`, implName, `.GetByPath: field '%s' does not exist in node '%s' of type '`, name, `'", field.Value(), nodePath)`)
 		} else {
-			n.AppendLine("field := unique.Make(fieldAndIndex[0])")
-			n.AppendLine("switch field {")
+			n2.AppendLine("switch field {")
 			for _, f := range containmentFields {
-				n.AppendLine("case ", fieldHandleVarName(f.PName), ":")
-				n.Indent(func(n2 codegen.Node) {
+				n2.AppendLine("case ", fieldHandleVarName(f.PName), ":")
+				n2.Indent(func(n2 codegen.Node) {
 					if f.Array {
-						needsStrconv = true
-						n2.AppendLine("index, err := strconv.Atoi(fieldAndIndex[1])")
-						n2.AppendLine("if err != nil {")
-						n2.Indent(func(n3 codegen.Node) {
-							n3.AppendLine(`return nil, fmt.Errorf("`, implName, `.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)`)
-						})
-						n2.AppendLine("}")
+						needIndex = true
 						n2.AppendLine("if index >= len(i.", f.Name, "()) {")
 						n2.Indent(func(n3 codegen.Node) {
-							n3.AppendLine("nodePath, _ := i.AstNodeBase.NodePath()")
+							n3.AppendLine("nodePath, _ := core.NodePath(i)")
 							n3.AppendLine(`return nil, fmt.Errorf("`, implName, `.GetByPath: index %d exceeds length of slice in '`, f.PName, `' (length=%d) in node '%s'", index, len(i.`, f.Name, `()), nodePath)`)
 						})
 						n2.AppendLine("}")
 						n2.AppendLine("child := i.", f.Name, "()[index]")
 						n2.AppendLine("if child == nil {")
 						n2.Indent(func(n3 codegen.Node) {
-							n3.AppendLine("nodePath, _ := i.AstNodeBase.NodePath()")
+							n3.AppendLine("nodePath, _ := core.NodePath(i)")
 							n3.AppendLine(`return nil, fmt.Errorf("`, implName, `.GetByPath: item %d of slice in field '`, f.PName, `' is nil in node '%s'", index, nodePath)`)
 						})
 						n2.AppendLine("}")
 					} else {
 						n2.AppendLine("if i.", f.Name, "() == nil {")
 						n2.Indent(func(n3 codegen.Node) {
-							n3.AppendLine("nodePath, _ := i.AstNodeBase.NodePath()")
+							n3.AppendLine("nodePath, _ := core.NodePath(i)")
 							n3.AppendLine(`return nil, fmt.Errorf("`, implName, `.GetByPath: field '`, f.PName, `' is nil in node '%s'", nodePath)`)
 						})
 						n2.AppendLine("}")
 						n2.AppendLine("child := i.", f.Name, "()")
 					}
-					n2.AppendLine("if len(parts) == 1 {")
+					n2.AppendLine("if path.Empty() {")
 					n2.Indent(func(n3 codegen.Node) { n3.AppendLine("return child, nil") })
 					n2.AppendLine("}")
-					n2.AppendLine("return child.GetByPath(parts[1])")
+					n2.AppendLine("return child.GetByPath(path)")
 				})
 			}
 			for _, f := range primitiveFields {
-				n.AppendLine("case ", fieldHandleVarName(f.PName), ":")
-				n.Indent(func(n2 codegen.Node) {
+				n2.AppendLine("case ", fieldHandleVarName(f.PName), ":")
+				n2.Indent(func(n2 codegen.Node) {
 					n2.AppendLine(`return nil, fmt.Errorf("`, implName, `.GetByPath: field '`, f.PName, `' holds a primitive value instead of an ast node")`)
 				})
 			}
 			for _, f := range referenceFields {
-				n.AppendLine("case ", fieldHandleVarName(f.PName), ":")
-				n.Indent(func(n2 codegen.Node) {
+				n2.AppendLine("case ", fieldHandleVarName(f.PName), ":")
+				n2.Indent(func(n2 codegen.Node) {
 					n2.AppendLine(`return nil, fmt.Errorf("`, implName, `.GetByPath: field '`, f.PName, `' is a cross-reference instead of a container field")`)
 				})
 			}
-			n.AppendLine("default:")
-			n.Indent(func(n2 codegen.Node) {
-				n2.AppendLine("nodePath, _ := i.AstNodeBase.NodePath()")
-				n2.AppendLine(`return nil, fmt.Errorf("`, implName, `.GetByPath: field '%s' does not exist in node '%s' of type '`, name, `'", fieldAndIndex[0], nodePath)`)
+			n2.AppendLine("default:")
+			n2.Indent(func(n2 codegen.Node) {
+				n2.AppendLine("nodePath, _ := core.NodePath(i)")
+				n2.AppendLine(`return nil, fmt.Errorf("`, implName, `.GetByPath: field '%s' does not exist in node '%s' of type '`, name, `'", field.Value(), nodePath)`)
 			})
-			n.AppendLine("}")
+			n2.AppendLine("}")
 		}
+
+		if needIndex {
+			n.AppendLine("field, index := path.Shift()")
+		} else {
+			n.AppendLine("field, _ := path.Shift()")
+		}
+
+		n.AppendNode(n2)
 	})
 	node.AppendLine("}")
 	node.AppendLine()
-
-	return struct{ needsStrconv bool }{needsStrconv}
 }

--- a/internal/generator/type_generator.go
+++ b/internal/generator/type_generator.go
@@ -516,6 +516,10 @@ func generateResolve(node codegen.Node, iface grammar.Interface) {
 
 	node.AppendLine("func (i *", implName, ") Resolve(path core.FragmentPath) (core.AstNode, error) {")
 	node.Indent(func(n codegen.Node) {
+		n.AppendLine("if path.Empty() {")
+		n.Indent(func(n3 codegen.Node) { n3.AppendLine("return i, nil") })
+		n.AppendLine("}")
+
 		needIndex := false
 		n2 := codegen.NewNode()
 		if !hasCases {
@@ -550,10 +554,7 @@ func generateResolve(node codegen.Node, iface grammar.Interface) {
 						n2.AppendLine("}")
 						n2.AppendLine("child := i.", f.Name, "()")
 					}
-					n2.AppendLine("if path.Empty() {")
-					n2.Indent(func(n3 codegen.Node) { n3.AppendLine("return child, nil") })
-					n2.AppendLine("}")
-					n2.AppendLine("return child.Resolve(path)")
+					n2.AppendLine("return child.Resolve(path.Tail())")
 				})
 			}
 			for _, f := range primitiveFields {
@@ -577,9 +578,9 @@ func generateResolve(node codegen.Node, iface grammar.Interface) {
 		}
 
 		if needIndex {
-			n.AppendLine("field, index := path.Shift()")
+			n.AppendLine("field, index := path.Head()")
 		} else {
-			n.AppendLine("field, _ := path.Shift()")
+			n.AppendLine("field, _ := path.Head()")
 		}
 
 		n.AppendNode(n2)

--- a/internal/grammar/types_gen.go
+++ b/internal/grammar/types_gen.go
@@ -242,7 +242,7 @@ func (i *GrammarImpl) GetByPath(path string) (core.AstNode, error) {
 		}
 		return child.GetByPath(parts[1])
 	case fieldNameName:
-		return nil, fmt.Errorf("GrammarImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("GrammarImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("GrammarImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Grammar'", fieldAndIndex[0], nodePath)
@@ -377,7 +377,9 @@ func (i *InterfaceImpl) GetByPath(path string) (core.AstNode, error) {
 		}
 		return child.GetByPath(parts[1])
 	case fieldNameName:
-		return nil, fmt.Errorf("InterfaceImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("InterfaceImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
+	case fieldNameExtends:
+		return nil, fmt.Errorf("InterfaceImpl.GetByPath: field 'extends' is a cross-reference instead of a container field")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("InterfaceImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Interface'", fieldAndIndex[0], nodePath)
@@ -494,7 +496,7 @@ func (i *FieldImpl) GetByPath(path string) (core.AstNode, error) {
 		}
 		return child.GetByPath(parts[1])
 	case fieldNameName:
-		return nil, fmt.Errorf("FieldImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("FieldImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("FieldImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Field'", fieldAndIndex[0], nodePath)
@@ -735,8 +737,14 @@ func (i *ReferenceTypeImpl) GetByPath(path string) (core.AstNode, error) {
 	}
 	parts := strings.SplitN(path, "/", 2)
 	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	nodePath, _ := i.AstNodeBase.NodePath()
-	return nil, fmt.Errorf("ReferenceTypeImpl.GetByPath: field '%s' does not exist in node '%s' of type 'ReferenceType'", fieldAndIndex[0], nodePath)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameType:
+		return nil, fmt.Errorf("ReferenceTypeImpl.GetByPath: field '_Type' is a cross-reference instead of a container field")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("ReferenceTypeImpl.GetByPath: field '%s' does not exist in node '%s' of type 'ReferenceType'", fieldAndIndex[0], nodePath)
+	}
 }
 
 type SimpleType interface {
@@ -819,8 +827,14 @@ func (i *SimpleTypeImpl) GetByPath(path string) (core.AstNode, error) {
 	}
 	parts := strings.SplitN(path, "/", 2)
 	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	nodePath, _ := i.AstNodeBase.NodePath()
-	return nil, fmt.Errorf("SimpleTypeImpl.GetByPath: field '%s' does not exist in node '%s' of type 'SimpleType'", fieldAndIndex[0], nodePath)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameType:
+		return nil, fmt.Errorf("SimpleTypeImpl.GetByPath: field '_Type' is a cross-reference instead of a container field")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("SimpleTypeImpl.GetByPath: field '%s' does not exist in node '%s' of type 'SimpleType'", fieldAndIndex[0], nodePath)
+	}
 }
 
 type PrimitiveType interface {
@@ -908,7 +922,7 @@ func (i *PrimitiveTypeImpl) GetByPath(path string) (core.AstNode, error) {
 	field := unique.Make(fieldAndIndex[0])
 	switch field {
 	case fieldNameType:
-		return nil, fmt.Errorf("PrimitiveTypeImpl.GetByPath: field '_Type' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("PrimitiveTypeImpl.GetByPath: field '_Type' holds a primitive value instead of an ast node")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("PrimitiveTypeImpl.GetByPath: field '%s' does not exist in node '%s' of type 'PrimitiveType'", fieldAndIndex[0], nodePath)
@@ -995,7 +1009,7 @@ func (i *AbstractRuleImpl) GetByPath(path string) (core.AstNode, error) {
 	field := unique.Make(fieldAndIndex[0])
 	switch field {
 	case fieldNameName:
-		return nil, fmt.Errorf("AbstractRuleImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("AbstractRuleImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("AbstractRuleImpl.GetByPath: field '%s' does not exist in node '%s' of type 'AbstractRule'", fieldAndIndex[0], nodePath)
@@ -1097,7 +1111,7 @@ func (i *AbstractRuleWithBodyImpl) GetByPath(path string) (core.AstNode, error) 
 		}
 		return child.GetByPath(parts[1])
 	case fieldNameName:
-		return nil, fmt.Errorf("AbstractRuleWithBodyImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("AbstractRuleWithBodyImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("AbstractRuleWithBodyImpl.GetByPath: field '%s' does not exist in node '%s' of type 'AbstractRuleWithBody'", fieldAndIndex[0], nodePath)
@@ -1169,7 +1183,7 @@ func (i *AbstractTokenRuleImpl) GetByPath(path string) (core.AstNode, error) {
 	field := unique.Make(fieldAndIndex[0])
 	switch field {
 	case fieldNameName:
-		return nil, fmt.Errorf("AbstractTokenRuleImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("AbstractTokenRuleImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("AbstractTokenRuleImpl.GetByPath: field '%s' does not exist in node '%s' of type 'AbstractTokenRule'", fieldAndIndex[0], nodePath)
@@ -1295,9 +1309,11 @@ func (i *ParserRuleImpl) GetByPath(path string) (core.AstNode, error) {
 		}
 		return child.GetByPath(parts[1])
 	case fieldNameEntry:
-		return nil, fmt.Errorf("ParserRuleImpl.GetByPath: field 'entry' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("ParserRuleImpl.GetByPath: field 'entry' holds a primitive value instead of an ast node")
 	case fieldNameName:
-		return nil, fmt.Errorf("ParserRuleImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("ParserRuleImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
+	case fieldNameReturnType:
+		return nil, fmt.Errorf("ParserRuleImpl.GetByPath: field 'returnType' is a cross-reference instead of a container field")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("ParserRuleImpl.GetByPath: field '%s' does not exist in node '%s' of type 'ParserRule'", fieldAndIndex[0], nodePath)
@@ -1417,11 +1433,11 @@ func (i *TokenImpl) GetByPath(path string) (core.AstNode, error) {
 	field := unique.Make(fieldAndIndex[0])
 	switch field {
 	case fieldNameName:
-		return nil, fmt.Errorf("TokenImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("TokenImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
 	case fieldNameRegexp:
-		return nil, fmt.Errorf("TokenImpl.GetByPath: field 'regexp' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("TokenImpl.GetByPath: field 'regexp' holds a primitive value instead of an ast node")
 	case fieldNameType:
-		return nil, fmt.Errorf("TokenImpl.GetByPath: field '_Type' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("TokenImpl.GetByPath: field '_Type' holds a primitive value instead of an ast node")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("TokenImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Token'", fieldAndIndex[0], nodePath)
@@ -1559,9 +1575,11 @@ func (i *TokenGroupImpl) GetByPath(path string) (core.AstNode, error) {
 		}
 		return child.GetByPath(parts[1])
 	case fieldNameName:
-		return nil, fmt.Errorf("TokenGroupImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("TokenGroupImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
 	case fieldNameRegexps:
-		return nil, fmt.Errorf("TokenGroupImpl.GetByPath: field 'regexps' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("TokenGroupImpl.GetByPath: field 'regexps' holds a primitive value instead of an ast node")
+	case fieldNameTokenRefs:
+		return nil, fmt.Errorf("TokenGroupImpl.GetByPath: field 'tokenRefs' is a cross-reference instead of a container field")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("TokenGroupImpl.GetByPath: field '%s' does not exist in node '%s' of type 'TokenGroup'", fieldAndIndex[0], nodePath)
@@ -1648,7 +1666,7 @@ func (i *ElementImpl) GetByPath(path string) (core.AstNode, error) {
 	field := unique.Make(fieldAndIndex[0])
 	switch field {
 	case fieldNameCardinality:
-		return nil, fmt.Errorf("ElementImpl.GetByPath: field 'cardinality' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("ElementImpl.GetByPath: field 'cardinality' holds a primitive value instead of an ast node")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("ElementImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Element'", fieldAndIndex[0], nodePath)
@@ -1755,7 +1773,7 @@ func (i *AlternativesImpl) GetByPath(path string) (core.AstNode, error) {
 		}
 		return child.GetByPath(parts[1])
 	case fieldNameCardinality:
-		return nil, fmt.Errorf("AlternativesImpl.GetByPath: field 'cardinality' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("AlternativesImpl.GetByPath: field 'cardinality' holds a primitive value instead of an ast node")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("AlternativesImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Alternatives'", fieldAndIndex[0], nodePath)
@@ -1858,7 +1876,7 @@ func (i *GroupImpl) GetByPath(path string) (core.AstNode, error) {
 		}
 		return child.GetByPath(parts[1])
 	case fieldNameCardinality:
-		return nil, fmt.Errorf("GroupImpl.GetByPath: field 'cardinality' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("GroupImpl.GetByPath: field 'cardinality' holds a primitive value instead of an ast node")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("GroupImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Group'", fieldAndIndex[0], nodePath)
@@ -1956,9 +1974,9 @@ func (i *KeywordImpl) GetByPath(path string) (core.AstNode, error) {
 	field := unique.Make(fieldAndIndex[0])
 	switch field {
 	case fieldNameCardinality:
-		return nil, fmt.Errorf("KeywordImpl.GetByPath: field 'cardinality' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("KeywordImpl.GetByPath: field 'cardinality' holds a primitive value instead of an ast node")
 	case fieldNameValue:
-		return nil, fmt.Errorf("KeywordImpl.GetByPath: field 'value' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("KeywordImpl.GetByPath: field 'value' holds a primitive value instead of an ast node")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("KeywordImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Keyword'", fieldAndIndex[0], nodePath)
@@ -2102,9 +2120,11 @@ func (i *AssignmentImpl) GetByPath(path string) (core.AstNode, error) {
 		}
 		return child.GetByPath(parts[1])
 	case fieldNameCardinality:
-		return nil, fmt.Errorf("AssignmentImpl.GetByPath: field 'cardinality' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("AssignmentImpl.GetByPath: field 'cardinality' holds a primitive value instead of an ast node")
 	case fieldNameOperator:
-		return nil, fmt.Errorf("AssignmentImpl.GetByPath: field 'operator' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("AssignmentImpl.GetByPath: field 'operator' holds a primitive value instead of an ast node")
+	case fieldNameProperty:
+		return nil, fmt.Errorf("AssignmentImpl.GetByPath: field 'property' is a cross-reference instead of a container field")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("AssignmentImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Assignment'", fieldAndIndex[0], nodePath)
@@ -2176,7 +2196,7 @@ func (i *AssignableImpl) GetByPath(path string) (core.AstNode, error) {
 	field := unique.Make(fieldAndIndex[0])
 	switch field {
 	case fieldNameCardinality:
-		return nil, fmt.Errorf("AssignableImpl.GetByPath: field 'cardinality' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("AssignableImpl.GetByPath: field 'cardinality' holds a primitive value instead of an ast node")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("AssignableImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Assignable'", fieldAndIndex[0], nodePath)
@@ -2302,7 +2322,9 @@ func (i *CrossRefImpl) GetByPath(path string) (core.AstNode, error) {
 		}
 		return child.GetByPath(parts[1])
 	case fieldNameCardinality:
-		return nil, fmt.Errorf("CrossRefImpl.GetByPath: field 'cardinality' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("CrossRefImpl.GetByPath: field 'cardinality' holds a primitive value instead of an ast node")
+	case fieldNameType:
+		return nil, fmt.Errorf("CrossRefImpl.GetByPath: field '_Type' is a cross-reference instead of a container field")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("CrossRefImpl.GetByPath: field '%s' does not exist in node '%s' of type 'CrossRef'", fieldAndIndex[0], nodePath)
@@ -2398,7 +2420,9 @@ func (i *RuleCallImpl) GetByPath(path string) (core.AstNode, error) {
 	field := unique.Make(fieldAndIndex[0])
 	switch field {
 	case fieldNameCardinality:
-		return nil, fmt.Errorf("RuleCallImpl.GetByPath: field 'cardinality' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("RuleCallImpl.GetByPath: field 'cardinality' holds a primitive value instead of an ast node")
+	case fieldNameRule:
+		return nil, fmt.Errorf("RuleCallImpl.GetByPath: field 'rule' is a cross-reference instead of a container field")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("RuleCallImpl.GetByPath: field '%s' does not exist in node '%s' of type 'RuleCall'", fieldAndIndex[0], nodePath)
@@ -2532,9 +2556,13 @@ func (i *ActionImpl) GetByPath(path string) (core.AstNode, error) {
 	field := unique.Make(fieldAndIndex[0])
 	switch field {
 	case fieldNameCardinality:
-		return nil, fmt.Errorf("ActionImpl.GetByPath: field 'cardinality' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("ActionImpl.GetByPath: field 'cardinality' holds a primitive value instead of an ast node")
 	case fieldNameOperator:
-		return nil, fmt.Errorf("ActionImpl.GetByPath: field 'operator' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("ActionImpl.GetByPath: field 'operator' holds a primitive value instead of an ast node")
+	case fieldNameProperty:
+		return nil, fmt.Errorf("ActionImpl.GetByPath: field 'property' is a cross-reference instead of a container field")
+	case fieldNameType:
+		return nil, fmt.Errorf("ActionImpl.GetByPath: field '_Type' is a cross-reference instead of a container field")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("ActionImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Action'", fieldAndIndex[0], nodePath)
@@ -2622,7 +2650,7 @@ func (i *CompositeRuleImpl) GetByPath(path string) (core.AstNode, error) {
 		}
 		return child.GetByPath(parts[1])
 	case fieldNameName:
-		return nil, fmt.Errorf("CompositeRuleImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("CompositeRuleImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("CompositeRuleImpl.GetByPath: field '%s' does not exist in node '%s' of type 'CompositeRule'", fieldAndIndex[0], nodePath)

--- a/internal/grammar/types_gen.go
+++ b/internal/grammar/types_gen.go
@@ -3,8 +3,12 @@
 package grammar
 
 import (
-	core "typefox.dev/fastbelt"
+	"fmt"
+	"strconv"
+	"strings"
 	"unique"
+
+	core "typefox.dev/fastbelt"
 )
 
 type Grammar interface {
@@ -163,6 +167,88 @@ func (i *GrammarImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
 	}
 }
 
+func (i *GrammarImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameComposites:
+		index, err := strconv.Atoi(fieldAndIndex[1])
+		if err != nil {
+			return nil, err
+		} else if index >= len(i.Composites()) {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("GrammarImpl.GetByPath: index %d exceeds slice length of 'composites' (%d) at '%s'", index, len(i.Composites()), nodePath)
+		}
+		child := i.Composites()[index]
+		if len(parts) == 1 {
+			return child, nil
+		}
+		return child.GetByPath(parts[1])
+	case fieldNameInterfaces:
+		index, err := strconv.Atoi(fieldAndIndex[1])
+		if err != nil {
+			return nil, err
+		} else if index >= len(i.Interfaces()) {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("GrammarImpl.GetByPath: index %d exceeds slice length of 'interfaces' (%d) at '%s'", index, len(i.Interfaces()), nodePath)
+		}
+		child := i.Interfaces()[index]
+		if len(parts) == 1 {
+			return child, nil
+		}
+		return child.GetByPath(parts[1])
+	case fieldNameRules:
+		index, err := strconv.Atoi(fieldAndIndex[1])
+		if err != nil {
+			return nil, err
+		} else if index >= len(i.Rules()) {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("GrammarImpl.GetByPath: index %d exceeds slice length of 'rules' (%d) at '%s'", index, len(i.Rules()), nodePath)
+		}
+		child := i.Rules()[index]
+		if len(parts) == 1 {
+			return child, nil
+		}
+		return child.GetByPath(parts[1])
+	case fieldNameTerminals:
+		index, err := strconv.Atoi(fieldAndIndex[1])
+		if err != nil {
+			return nil, err
+		} else if index >= len(i.Terminals()) {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("GrammarImpl.GetByPath: index %d exceeds slice length of 'terminals' (%d) at '%s'", index, len(i.Terminals()), nodePath)
+		}
+		child := i.Terminals()[index]
+		if len(parts) == 1 {
+			return child, nil
+		}
+		return child.GetByPath(parts[1])
+	case fieldNameTokenGroups:
+		index, err := strconv.Atoi(fieldAndIndex[1])
+		if err != nil {
+			return nil, err
+		} else if index >= len(i.TokenGroups()) {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("GrammarImpl.GetByPath: index %d exceeds slice length of 'tokenGroups' (%d) at '%s'", index, len(i.TokenGroups()), nodePath)
+		}
+		child := i.TokenGroups()[index]
+		if len(parts) == 1 {
+			return child, nil
+		}
+		return child.GetByPath(parts[1])
+	case fieldNameName:
+		return nil, fmt.Errorf("GrammarImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("GrammarImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Grammar'", fieldAndIndex[0], nodePath)
+	}
+}
+
 type Interface interface {
 	core.AstNode
 
@@ -268,6 +354,36 @@ func (i *InterfaceImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos 
 	}
 }
 
+func (i *InterfaceImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameFields:
+		index, err := strconv.Atoi(fieldAndIndex[1])
+		if err != nil {
+			return nil, err
+		} else if index >= len(i.Fields()) {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("InterfaceImpl.GetByPath: index %d exceeds slice length of 'fields' (%d) at '%s'", index, len(i.Fields()), nodePath)
+		}
+		child := i.Fields()[index]
+		if len(parts) == 1 {
+			return child, nil
+		}
+		return child.GetByPath(parts[1])
+	case fieldNameName:
+		return nil, fmt.Errorf("InterfaceImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("InterfaceImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Interface'", fieldAndIndex[0], nodePath)
+	}
+}
+
 type Field interface {
 	core.AstNode
 
@@ -358,6 +474,33 @@ func (i *FieldImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
 	}
 }
 
+func (i *FieldImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameType:
+		if i.Type() == nil {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("FieldImpl.GetByPath: field '_Type' is nil at '%s'", nodePath)
+		}
+		child := i.Type()
+		if len(parts) == 1 {
+			return child, nil
+		}
+		return child.GetByPath(parts[1])
+	case fieldNameName:
+		return nil, fmt.Errorf("FieldImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("FieldImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Field'", fieldAndIndex[0], nodePath)
+	}
+}
+
 type FieldType interface {
 	core.AstNode
 
@@ -401,6 +544,17 @@ func (i *FieldTypeImpl) ForEachReference(fn func(core.UntypedReference, unique.H
 
 func (i *FieldTypeImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
 	return core.FieldInfos{}
+}
+
+func (i *FieldTypeImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	nodePath, _ := i.AstNodeBase.NodePath()
+	return nil, fmt.Errorf("FieldTypeImpl.GetByPath: field '%s' does not exist in node '%s' of type 'FieldType'", fieldAndIndex[0], nodePath)
 }
 
 type ArrayType interface {
@@ -473,6 +627,31 @@ func (i *ArrayTypeImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos 
 		return core.FieldInfos{Multi: false, Reference: false}
 	default:
 		return core.FieldInfos{}
+	}
+}
+
+func (i *ArrayTypeImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameInternalType:
+		if i.InternalType() == nil {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("ArrayTypeImpl.GetByPath: field 'internalType' is nil at '%s'", nodePath)
+		}
+		child := i.InternalType()
+		if len(parts) == 1 {
+			return child, nil
+		}
+		return child.GetByPath(parts[1])
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("ArrayTypeImpl.GetByPath: field '%s' does not exist in node '%s' of type 'ArrayType'", fieldAndIndex[0], nodePath)
 	}
 }
 
@@ -549,6 +728,17 @@ func (i *ReferenceTypeImpl) FieldInfos(field unique.Handle[string]) core.FieldIn
 	}
 }
 
+func (i *ReferenceTypeImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	nodePath, _ := i.AstNodeBase.NodePath()
+	return nil, fmt.Errorf("ReferenceTypeImpl.GetByPath: field '%s' does not exist in node '%s' of type 'ReferenceType'", fieldAndIndex[0], nodePath)
+}
+
 type SimpleType interface {
 	core.AstNode
 	FieldType
@@ -620,6 +810,17 @@ func (i *SimpleTypeImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos
 	default:
 		return core.FieldInfos{}
 	}
+}
+
+func (i *SimpleTypeImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	nodePath, _ := i.AstNodeBase.NodePath()
+	return nil, fmt.Errorf("SimpleTypeImpl.GetByPath: field '%s' does not exist in node '%s' of type 'SimpleType'", fieldAndIndex[0], nodePath)
 }
 
 type PrimitiveType interface {
@@ -697,6 +898,23 @@ func (i *PrimitiveTypeImpl) FieldInfos(field unique.Handle[string]) core.FieldIn
 	}
 }
 
+func (i *PrimitiveTypeImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameType:
+		return nil, fmt.Errorf("PrimitiveTypeImpl.GetByPath: field '_Type' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("PrimitiveTypeImpl.GetByPath: field '%s' does not exist in node '%s' of type 'PrimitiveType'", fieldAndIndex[0], nodePath)
+	}
+}
+
 type AbstractRule interface {
 	core.AstNode
 
@@ -764,6 +982,23 @@ func (i *AbstractRuleImpl) FieldInfos(field unique.Handle[string]) core.FieldInf
 		return core.FieldInfos{Multi: false, Reference: false}
 	default:
 		return core.FieldInfos{}
+	}
+}
+
+func (i *AbstractRuleImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameName:
+		return nil, fmt.Errorf("AbstractRuleImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("AbstractRuleImpl.GetByPath: field '%s' does not exist in node '%s' of type 'AbstractRule'", fieldAndIndex[0], nodePath)
 	}
 }
 
@@ -842,6 +1077,33 @@ func (i *AbstractRuleWithBodyImpl) FieldInfos(field unique.Handle[string]) core.
 	}
 }
 
+func (i *AbstractRuleWithBodyImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameBody:
+		if i.Body() == nil {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("AbstractRuleWithBodyImpl.GetByPath: field 'body' is nil at '%s'", nodePath)
+		}
+		child := i.Body()
+		if len(parts) == 1 {
+			return child, nil
+		}
+		return child.GetByPath(parts[1])
+	case fieldNameName:
+		return nil, fmt.Errorf("AbstractRuleWithBodyImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("AbstractRuleWithBodyImpl.GetByPath: field '%s' does not exist in node '%s' of type 'AbstractRuleWithBody'", fieldAndIndex[0], nodePath)
+	}
+}
+
 type AbstractTokenRule interface {
 	core.AstNode
 	AbstractRule
@@ -894,6 +1156,23 @@ func (i *AbstractTokenRuleImpl) FieldInfos(field unique.Handle[string]) core.Fie
 		return core.FieldInfos{Multi: false, Reference: false}
 	default:
 		return core.FieldInfos{}
+	}
+}
+
+func (i *AbstractTokenRuleImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameName:
+		return nil, fmt.Errorf("AbstractTokenRuleImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("AbstractTokenRuleImpl.GetByPath: field '%s' does not exist in node '%s' of type 'AbstractTokenRule'", fieldAndIndex[0], nodePath)
 	}
 }
 
@@ -993,6 +1272,35 @@ func (i *ParserRuleImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos
 		return core.FieldInfos{Multi: false, Reference: true}
 	default:
 		return core.FieldInfos{}
+	}
+}
+
+func (i *ParserRuleImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameBody:
+		if i.Body() == nil {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("ParserRuleImpl.GetByPath: field 'body' is nil at '%s'", nodePath)
+		}
+		child := i.Body()
+		if len(parts) == 1 {
+			return child, nil
+		}
+		return child.GetByPath(parts[1])
+	case fieldNameEntry:
+		return nil, fmt.Errorf("ParserRuleImpl.GetByPath: field 'entry' holds a primitive value and cannot be navigated")
+	case fieldNameName:
+		return nil, fmt.Errorf("ParserRuleImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("ParserRuleImpl.GetByPath: field '%s' does not exist in node '%s' of type 'ParserRule'", fieldAndIndex[0], nodePath)
 	}
 }
 
@@ -1096,6 +1404,27 @@ func (i *TokenImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
 		return core.FieldInfos{Multi: false, Reference: false}
 	default:
 		return core.FieldInfos{}
+	}
+}
+
+func (i *TokenImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameName:
+		return nil, fmt.Errorf("TokenImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+	case fieldNameRegexp:
+		return nil, fmt.Errorf("TokenImpl.GetByPath: field 'regexp' holds a primitive value and cannot be navigated")
+	case fieldNameType:
+		return nil, fmt.Errorf("TokenImpl.GetByPath: field '_Type' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("TokenImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Token'", fieldAndIndex[0], nodePath)
 	}
 }
 
@@ -1207,6 +1536,38 @@ func (i *TokenGroupImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos
 	}
 }
 
+func (i *TokenGroupImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameKeywords:
+		index, err := strconv.Atoi(fieldAndIndex[1])
+		if err != nil {
+			return nil, err
+		} else if index >= len(i.Keywords()) {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("TokenGroupImpl.GetByPath: index %d exceeds slice length of 'keywords' (%d) at '%s'", index, len(i.Keywords()), nodePath)
+		}
+		child := i.Keywords()[index]
+		if len(parts) == 1 {
+			return child, nil
+		}
+		return child.GetByPath(parts[1])
+	case fieldNameName:
+		return nil, fmt.Errorf("TokenGroupImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+	case fieldNameRegexps:
+		return nil, fmt.Errorf("TokenGroupImpl.GetByPath: field 'regexps' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("TokenGroupImpl.GetByPath: field '%s' does not exist in node '%s' of type 'TokenGroup'", fieldAndIndex[0], nodePath)
+	}
+}
+
 type Element interface {
 	core.AstNode
 
@@ -1274,6 +1635,23 @@ func (i *ElementImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
 		return core.FieldInfos{Multi: false, Reference: false}
 	default:
 		return core.FieldInfos{}
+	}
+}
+
+func (i *ElementImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameCardinality:
+		return nil, fmt.Errorf("ElementImpl.GetByPath: field 'cardinality' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("ElementImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Element'", fieldAndIndex[0], nodePath)
 	}
 }
 
@@ -1354,6 +1732,36 @@ func (i *AlternativesImpl) FieldInfos(field unique.Handle[string]) core.FieldInf
 	}
 }
 
+func (i *AlternativesImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameAlts:
+		index, err := strconv.Atoi(fieldAndIndex[1])
+		if err != nil {
+			return nil, err
+		} else if index >= len(i.Alts()) {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("AlternativesImpl.GetByPath: index %d exceeds slice length of 'alts' (%d) at '%s'", index, len(i.Alts()), nodePath)
+		}
+		child := i.Alts()[index]
+		if len(parts) == 1 {
+			return child, nil
+		}
+		return child.GetByPath(parts[1])
+	case fieldNameCardinality:
+		return nil, fmt.Errorf("AlternativesImpl.GetByPath: field 'cardinality' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("AlternativesImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Alternatives'", fieldAndIndex[0], nodePath)
+	}
+}
+
 type Group interface {
 	core.AstNode
 	Element
@@ -1424,6 +1832,36 @@ func (i *GroupImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
 		return core.FieldInfos{Multi: true, Reference: false}
 	default:
 		return core.FieldInfos{}
+	}
+}
+
+func (i *GroupImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameElements:
+		index, err := strconv.Atoi(fieldAndIndex[1])
+		if err != nil {
+			return nil, err
+		} else if index >= len(i.Elements()) {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("GroupImpl.GetByPath: index %d exceeds slice length of 'elements' (%d) at '%s'", index, len(i.Elements()), nodePath)
+		}
+		child := i.Elements()[index]
+		if len(parts) == 1 {
+			return child, nil
+		}
+		return child.GetByPath(parts[1])
+	case fieldNameCardinality:
+		return nil, fmt.Errorf("GroupImpl.GetByPath: field 'cardinality' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("GroupImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Group'", fieldAndIndex[0], nodePath)
 	}
 }
 
@@ -1505,6 +1943,25 @@ func (i *KeywordImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
 		return core.FieldInfos{Multi: false, Reference: false}
 	default:
 		return core.FieldInfos{}
+	}
+}
+
+func (i *KeywordImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameCardinality:
+		return nil, fmt.Errorf("KeywordImpl.GetByPath: field 'cardinality' holds a primitive value and cannot be navigated")
+	case fieldNameValue:
+		return nil, fmt.Errorf("KeywordImpl.GetByPath: field 'value' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("KeywordImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Keyword'", fieldAndIndex[0], nodePath)
 	}
 }
 
@@ -1625,6 +2082,35 @@ func (i *AssignmentImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos
 	}
 }
 
+func (i *AssignmentImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameValue:
+		if i.Value() == nil {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("AssignmentImpl.GetByPath: field 'value' is nil at '%s'", nodePath)
+		}
+		child := i.Value()
+		if len(parts) == 1 {
+			return child, nil
+		}
+		return child.GetByPath(parts[1])
+	case fieldNameCardinality:
+		return nil, fmt.Errorf("AssignmentImpl.GetByPath: field 'cardinality' holds a primitive value and cannot be navigated")
+	case fieldNameOperator:
+		return nil, fmt.Errorf("AssignmentImpl.GetByPath: field 'operator' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("AssignmentImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Assignment'", fieldAndIndex[0], nodePath)
+	}
+}
+
 type Assignable interface {
 	core.AstNode
 	Element
@@ -1677,6 +2163,23 @@ func (i *AssignableImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos
 		return core.FieldInfos{Multi: false, Reference: false}
 	default:
 		return core.FieldInfos{}
+	}
+}
+
+func (i *AssignableImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameCardinality:
+		return nil, fmt.Errorf("AssignableImpl.GetByPath: field 'cardinality' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("AssignableImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Assignable'", fieldAndIndex[0], nodePath)
 	}
 }
 
@@ -1779,6 +2282,33 @@ func (i *CrossRefImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
 	}
 }
 
+func (i *CrossRefImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameRule:
+		if i.Rule() == nil {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("CrossRefImpl.GetByPath: field 'rule' is nil at '%s'", nodePath)
+		}
+		child := i.Rule()
+		if len(parts) == 1 {
+			return child, nil
+		}
+		return child.GetByPath(parts[1])
+	case fieldNameCardinality:
+		return nil, fmt.Errorf("CrossRefImpl.GetByPath: field 'cardinality' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("CrossRefImpl.GetByPath: field '%s' does not exist in node '%s' of type 'CrossRef'", fieldAndIndex[0], nodePath)
+	}
+}
+
 type RuleCall interface {
 	core.AstNode
 	Assignable
@@ -1855,6 +2385,23 @@ func (i *RuleCallImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
 		return core.FieldInfos{Multi: false, Reference: true}
 	default:
 		return core.FieldInfos{}
+	}
+}
+
+func (i *RuleCallImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameCardinality:
+		return nil, fmt.Errorf("RuleCallImpl.GetByPath: field 'cardinality' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("RuleCallImpl.GetByPath: field '%s' does not exist in node '%s' of type 'RuleCall'", fieldAndIndex[0], nodePath)
 	}
 }
 
@@ -1975,6 +2522,25 @@ func (i *ActionImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
 	}
 }
 
+func (i *ActionImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameCardinality:
+		return nil, fmt.Errorf("ActionImpl.GetByPath: field 'cardinality' holds a primitive value and cannot be navigated")
+	case fieldNameOperator:
+		return nil, fmt.Errorf("ActionImpl.GetByPath: field 'operator' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("ActionImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Action'", fieldAndIndex[0], nodePath)
+	}
+}
+
 type CompositeRule interface {
 	core.AstNode
 	AbstractRuleWithBody
@@ -2033,6 +2599,33 @@ func (i *CompositeRuleImpl) FieldInfos(field unique.Handle[string]) core.FieldIn
 		return core.FieldInfos{Multi: false, Reference: false}
 	default:
 		return core.FieldInfos{}
+	}
+}
+
+func (i *CompositeRuleImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameBody:
+		if i.Body() == nil {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("CompositeRuleImpl.GetByPath: field 'body' is nil at '%s'", nodePath)
+		}
+		child := i.Body()
+		if len(parts) == 1 {
+			return child, nil
+		}
+		return child.GetByPath(parts[1])
+	case fieldNameName:
+		return nil, fmt.Errorf("CompositeRuleImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("CompositeRuleImpl.GetByPath: field '%s' does not exist in node '%s' of type 'CompositeRule'", fieldAndIndex[0], nodePath)
 	}
 }
 

--- a/internal/grammar/types_gen.go
+++ b/internal/grammar/types_gen.go
@@ -179,12 +179,17 @@ func (i *GrammarImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameComposites:
 		index, err := strconv.Atoi(fieldAndIndex[1])
 		if err != nil {
-			return nil, err
-		} else if index >= len(i.Composites()) {
+			return nil, fmt.Errorf("GrammarImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
+		}
+		if index >= len(i.Composites()) {
 			nodePath, _ := i.AstNodeBase.NodePath()
-			return nil, fmt.Errorf("GrammarImpl.GetByPath: index %d exceeds slice length of 'composites' (%d) at '%s'", index, len(i.Composites()), nodePath)
+			return nil, fmt.Errorf("GrammarImpl.GetByPath: index %d exceeds length of slice in 'composites' (length=%d) in node '%s'", index, len(i.Composites()), nodePath)
 		}
 		child := i.Composites()[index]
+		if child == nil {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("GrammarImpl.GetByPath: item %d of slice in field 'composites' is nil in node '%s'", index, nodePath)
+		}
 		if len(parts) == 1 {
 			return child, nil
 		}
@@ -192,12 +197,17 @@ func (i *GrammarImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameInterfaces:
 		index, err := strconv.Atoi(fieldAndIndex[1])
 		if err != nil {
-			return nil, err
-		} else if index >= len(i.Interfaces()) {
+			return nil, fmt.Errorf("GrammarImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
+		}
+		if index >= len(i.Interfaces()) {
 			nodePath, _ := i.AstNodeBase.NodePath()
-			return nil, fmt.Errorf("GrammarImpl.GetByPath: index %d exceeds slice length of 'interfaces' (%d) at '%s'", index, len(i.Interfaces()), nodePath)
+			return nil, fmt.Errorf("GrammarImpl.GetByPath: index %d exceeds length of slice in 'interfaces' (length=%d) in node '%s'", index, len(i.Interfaces()), nodePath)
 		}
 		child := i.Interfaces()[index]
+		if child == nil {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("GrammarImpl.GetByPath: item %d of slice in field 'interfaces' is nil in node '%s'", index, nodePath)
+		}
 		if len(parts) == 1 {
 			return child, nil
 		}
@@ -205,12 +215,17 @@ func (i *GrammarImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameRules:
 		index, err := strconv.Atoi(fieldAndIndex[1])
 		if err != nil {
-			return nil, err
-		} else if index >= len(i.Rules()) {
+			return nil, fmt.Errorf("GrammarImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
+		}
+		if index >= len(i.Rules()) {
 			nodePath, _ := i.AstNodeBase.NodePath()
-			return nil, fmt.Errorf("GrammarImpl.GetByPath: index %d exceeds slice length of 'rules' (%d) at '%s'", index, len(i.Rules()), nodePath)
+			return nil, fmt.Errorf("GrammarImpl.GetByPath: index %d exceeds length of slice in 'rules' (length=%d) in node '%s'", index, len(i.Rules()), nodePath)
 		}
 		child := i.Rules()[index]
+		if child == nil {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("GrammarImpl.GetByPath: item %d of slice in field 'rules' is nil in node '%s'", index, nodePath)
+		}
 		if len(parts) == 1 {
 			return child, nil
 		}
@@ -218,12 +233,17 @@ func (i *GrammarImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameTerminals:
 		index, err := strconv.Atoi(fieldAndIndex[1])
 		if err != nil {
-			return nil, err
-		} else if index >= len(i.Terminals()) {
+			return nil, fmt.Errorf("GrammarImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
+		}
+		if index >= len(i.Terminals()) {
 			nodePath, _ := i.AstNodeBase.NodePath()
-			return nil, fmt.Errorf("GrammarImpl.GetByPath: index %d exceeds slice length of 'terminals' (%d) at '%s'", index, len(i.Terminals()), nodePath)
+			return nil, fmt.Errorf("GrammarImpl.GetByPath: index %d exceeds length of slice in 'terminals' (length=%d) in node '%s'", index, len(i.Terminals()), nodePath)
 		}
 		child := i.Terminals()[index]
+		if child == nil {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("GrammarImpl.GetByPath: item %d of slice in field 'terminals' is nil in node '%s'", index, nodePath)
+		}
 		if len(parts) == 1 {
 			return child, nil
 		}
@@ -231,12 +251,17 @@ func (i *GrammarImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameTokenGroups:
 		index, err := strconv.Atoi(fieldAndIndex[1])
 		if err != nil {
-			return nil, err
-		} else if index >= len(i.TokenGroups()) {
+			return nil, fmt.Errorf("GrammarImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
+		}
+		if index >= len(i.TokenGroups()) {
 			nodePath, _ := i.AstNodeBase.NodePath()
-			return nil, fmt.Errorf("GrammarImpl.GetByPath: index %d exceeds slice length of 'tokenGroups' (%d) at '%s'", index, len(i.TokenGroups()), nodePath)
+			return nil, fmt.Errorf("GrammarImpl.GetByPath: index %d exceeds length of slice in 'tokenGroups' (length=%d) in node '%s'", index, len(i.TokenGroups()), nodePath)
 		}
 		child := i.TokenGroups()[index]
+		if child == nil {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("GrammarImpl.GetByPath: item %d of slice in field 'tokenGroups' is nil in node '%s'", index, nodePath)
+		}
 		if len(parts) == 1 {
 			return child, nil
 		}
@@ -366,12 +391,17 @@ func (i *InterfaceImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameFields:
 		index, err := strconv.Atoi(fieldAndIndex[1])
 		if err != nil {
-			return nil, err
-		} else if index >= len(i.Fields()) {
+			return nil, fmt.Errorf("InterfaceImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
+		}
+		if index >= len(i.Fields()) {
 			nodePath, _ := i.AstNodeBase.NodePath()
-			return nil, fmt.Errorf("InterfaceImpl.GetByPath: index %d exceeds slice length of 'fields' (%d) at '%s'", index, len(i.Fields()), nodePath)
+			return nil, fmt.Errorf("InterfaceImpl.GetByPath: index %d exceeds length of slice in 'fields' (length=%d) in node '%s'", index, len(i.Fields()), nodePath)
 		}
 		child := i.Fields()[index]
+		if child == nil {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("InterfaceImpl.GetByPath: item %d of slice in field 'fields' is nil in node '%s'", index, nodePath)
+		}
 		if len(parts) == 1 {
 			return child, nil
 		}
@@ -488,7 +518,7 @@ func (i *FieldImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameType:
 		if i.Type() == nil {
 			nodePath, _ := i.AstNodeBase.NodePath()
-			return nil, fmt.Errorf("FieldImpl.GetByPath: field '_Type' is nil at '%s'", nodePath)
+			return nil, fmt.Errorf("FieldImpl.GetByPath: field '_Type' is nil in node '%s'", nodePath)
 		}
 		child := i.Type()
 		if len(parts) == 1 {
@@ -644,7 +674,7 @@ func (i *ArrayTypeImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameInternalType:
 		if i.InternalType() == nil {
 			nodePath, _ := i.AstNodeBase.NodePath()
-			return nil, fmt.Errorf("ArrayTypeImpl.GetByPath: field 'internalType' is nil at '%s'", nodePath)
+			return nil, fmt.Errorf("ArrayTypeImpl.GetByPath: field 'internalType' is nil in node '%s'", nodePath)
 		}
 		child := i.InternalType()
 		if len(parts) == 1 {
@@ -1103,7 +1133,7 @@ func (i *AbstractRuleWithBodyImpl) GetByPath(path string) (core.AstNode, error) 
 	case fieldNameBody:
 		if i.Body() == nil {
 			nodePath, _ := i.AstNodeBase.NodePath()
-			return nil, fmt.Errorf("AbstractRuleWithBodyImpl.GetByPath: field 'body' is nil at '%s'", nodePath)
+			return nil, fmt.Errorf("AbstractRuleWithBodyImpl.GetByPath: field 'body' is nil in node '%s'", nodePath)
 		}
 		child := i.Body()
 		if len(parts) == 1 {
@@ -1301,7 +1331,7 @@ func (i *ParserRuleImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameBody:
 		if i.Body() == nil {
 			nodePath, _ := i.AstNodeBase.NodePath()
-			return nil, fmt.Errorf("ParserRuleImpl.GetByPath: field 'body' is nil at '%s'", nodePath)
+			return nil, fmt.Errorf("ParserRuleImpl.GetByPath: field 'body' is nil in node '%s'", nodePath)
 		}
 		child := i.Body()
 		if len(parts) == 1 {
@@ -1564,12 +1594,17 @@ func (i *TokenGroupImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameKeywords:
 		index, err := strconv.Atoi(fieldAndIndex[1])
 		if err != nil {
-			return nil, err
-		} else if index >= len(i.Keywords()) {
+			return nil, fmt.Errorf("TokenGroupImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
+		}
+		if index >= len(i.Keywords()) {
 			nodePath, _ := i.AstNodeBase.NodePath()
-			return nil, fmt.Errorf("TokenGroupImpl.GetByPath: index %d exceeds slice length of 'keywords' (%d) at '%s'", index, len(i.Keywords()), nodePath)
+			return nil, fmt.Errorf("TokenGroupImpl.GetByPath: index %d exceeds length of slice in 'keywords' (length=%d) in node '%s'", index, len(i.Keywords()), nodePath)
 		}
 		child := i.Keywords()[index]
+		if child == nil {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("TokenGroupImpl.GetByPath: item %d of slice in field 'keywords' is nil in node '%s'", index, nodePath)
+		}
 		if len(parts) == 1 {
 			return child, nil
 		}
@@ -1762,12 +1797,17 @@ func (i *AlternativesImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameAlts:
 		index, err := strconv.Atoi(fieldAndIndex[1])
 		if err != nil {
-			return nil, err
-		} else if index >= len(i.Alts()) {
+			return nil, fmt.Errorf("AlternativesImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
+		}
+		if index >= len(i.Alts()) {
 			nodePath, _ := i.AstNodeBase.NodePath()
-			return nil, fmt.Errorf("AlternativesImpl.GetByPath: index %d exceeds slice length of 'alts' (%d) at '%s'", index, len(i.Alts()), nodePath)
+			return nil, fmt.Errorf("AlternativesImpl.GetByPath: index %d exceeds length of slice in 'alts' (length=%d) in node '%s'", index, len(i.Alts()), nodePath)
 		}
 		child := i.Alts()[index]
+		if child == nil {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("AlternativesImpl.GetByPath: item %d of slice in field 'alts' is nil in node '%s'", index, nodePath)
+		}
 		if len(parts) == 1 {
 			return child, nil
 		}
@@ -1865,12 +1905,17 @@ func (i *GroupImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameElements:
 		index, err := strconv.Atoi(fieldAndIndex[1])
 		if err != nil {
-			return nil, err
-		} else if index >= len(i.Elements()) {
+			return nil, fmt.Errorf("GroupImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
+		}
+		if index >= len(i.Elements()) {
 			nodePath, _ := i.AstNodeBase.NodePath()
-			return nil, fmt.Errorf("GroupImpl.GetByPath: index %d exceeds slice length of 'elements' (%d) at '%s'", index, len(i.Elements()), nodePath)
+			return nil, fmt.Errorf("GroupImpl.GetByPath: index %d exceeds length of slice in 'elements' (length=%d) in node '%s'", index, len(i.Elements()), nodePath)
 		}
 		child := i.Elements()[index]
+		if child == nil {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("GroupImpl.GetByPath: item %d of slice in field 'elements' is nil in node '%s'", index, nodePath)
+		}
 		if len(parts) == 1 {
 			return child, nil
 		}
@@ -2112,7 +2157,7 @@ func (i *AssignmentImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameValue:
 		if i.Value() == nil {
 			nodePath, _ := i.AstNodeBase.NodePath()
-			return nil, fmt.Errorf("AssignmentImpl.GetByPath: field 'value' is nil at '%s'", nodePath)
+			return nil, fmt.Errorf("AssignmentImpl.GetByPath: field 'value' is nil in node '%s'", nodePath)
 		}
 		child := i.Value()
 		if len(parts) == 1 {
@@ -2314,7 +2359,7 @@ func (i *CrossRefImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameRule:
 		if i.Rule() == nil {
 			nodePath, _ := i.AstNodeBase.NodePath()
-			return nil, fmt.Errorf("CrossRefImpl.GetByPath: field 'rule' is nil at '%s'", nodePath)
+			return nil, fmt.Errorf("CrossRefImpl.GetByPath: field 'rule' is nil in node '%s'", nodePath)
 		}
 		child := i.Rule()
 		if len(parts) == 1 {
@@ -2642,7 +2687,7 @@ func (i *CompositeRuleImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameBody:
 		if i.Body() == nil {
 			nodePath, _ := i.AstNodeBase.NodePath()
-			return nil, fmt.Errorf("CompositeRuleImpl.GetByPath: field 'body' is nil at '%s'", nodePath)
+			return nil, fmt.Errorf("CompositeRuleImpl.GetByPath: field 'body' is nil in node '%s'", nodePath)
 		}
 		child := i.Body()
 		if len(parts) == 1 {

--- a/internal/grammar/types_gen.go
+++ b/internal/grammar/types_gen.go
@@ -4,6 +4,7 @@ package grammar
 
 import (
 	core "typefox.dev/fastbelt"
+	"unique"
 )
 
 type Grammar interface {
@@ -53,25 +54,25 @@ func NewGrammarData() GrammarData {
 
 func (i *GrammarData) IsGrammar() {}
 
-func (i *GrammarData) ForEachNode(fn func(core.AstNode)) {
-	for _, item := range i.rules {
-		fn(item)
+func (i *GrammarData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+	for j, item := range i.rules {
+		fn(item, unique.Make("rules"), uint16(j))
 	}
-	for _, item := range i.composites {
-		fn(item)
+	for j, item := range i.composites {
+		fn(item, unique.Make("composites"), uint16(j))
 	}
-	for _, item := range i.terminals {
-		fn(item)
+	for j, item := range i.terminals {
+		fn(item, unique.Make("terminals"), uint16(j))
 	}
-	for _, item := range i.tokenGroups {
-		fn(item)
+	for j, item := range i.tokenGroups {
+		fn(item, unique.Make("tokenGroups"), uint16(j))
 	}
-	for _, item := range i.interfaces {
-		fn(item)
+	for j, item := range i.interfaces {
+		fn(item, unique.Make("interfaces"), uint16(j))
 	}
 }
 
-func (i *GrammarData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *GrammarData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 func (i *GrammarData) Name() string {
@@ -135,12 +136,16 @@ type GrammarImpl struct {
 	GrammarData
 }
 
-func (i *GrammarImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *GrammarImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.GrammarData.ForEachNode(fn)
 }
 
-func (i *GrammarImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *GrammarImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.GrammarData.ForEachReference(fn)
+}
+
+func (i *GrammarImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return FastbeltFieldInfos["Grammar"][field.Value()]
 }
 
 type Interface interface {
@@ -178,15 +183,15 @@ func NewInterfaceData() InterfaceData {
 
 func (i *InterfaceData) IsInterface() {}
 
-func (i *InterfaceData) ForEachNode(fn func(core.AstNode)) {
-	for _, item := range i.fields {
-		fn(item)
+func (i *InterfaceData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+	for j, item := range i.fields {
+		fn(item, unique.Make("fields"), uint16(j))
 	}
 }
 
-func (i *InterfaceData) ForEachReference(fn func(core.UntypedReference)) {
-	for _, item := range i.extends {
-		fn(item)
+func (i *InterfaceData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+	for j, item := range i.extends {
+		fn(item, unique.Make("extends"), uint16(j))
 	}
 }
 
@@ -227,12 +232,16 @@ type InterfaceImpl struct {
 	InterfaceData
 }
 
-func (i *InterfaceImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *InterfaceImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.InterfaceData.ForEachNode(fn)
 }
 
-func (i *InterfaceImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *InterfaceImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.InterfaceData.ForEachReference(fn)
+}
+
+func (i *InterfaceImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return FastbeltFieldInfos["Interface"][field.Value()]
 }
 
 type Field interface {
@@ -264,13 +273,13 @@ func NewFieldData() FieldData {
 
 func (i *FieldData) IsField() {}
 
-func (i *FieldData) ForEachNode(fn func(core.AstNode)) {
+func (i *FieldData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	if i._Type != nil {
-		fn(i._Type)
+		fn(i._Type, unique.Make("_Type"), 0)
 	}
 }
 
-func (i *FieldData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *FieldData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 func (i *FieldData) Name() string {
@@ -306,12 +315,16 @@ type FieldImpl struct {
 	FieldData
 }
 
-func (i *FieldImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *FieldImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.FieldData.ForEachNode(fn)
 }
 
-func (i *FieldImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *FieldImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.FieldData.ForEachReference(fn)
+}
+
+func (i *FieldImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return FastbeltFieldInfos["Field"][field.Value()]
 }
 
 type FieldType interface {
@@ -336,10 +349,10 @@ func NewFieldTypeData() FieldTypeData {
 
 func (i *FieldTypeData) IsFieldType() {}
 
-func (i *FieldTypeData) ForEachNode(fn func(core.AstNode)) {
+func (i *FieldTypeData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 }
 
-func (i *FieldTypeData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *FieldTypeData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 type FieldTypeImpl struct {
@@ -347,12 +360,16 @@ type FieldTypeImpl struct {
 	FieldTypeData
 }
 
-func (i *FieldTypeImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *FieldTypeImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.FieldTypeData.ForEachNode(fn)
 }
 
-func (i *FieldTypeImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *FieldTypeImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.FieldTypeData.ForEachReference(fn)
+}
+
+func (i *FieldTypeImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return FastbeltFieldInfos["FieldType"][field.Value()]
 }
 
 type ArrayType interface {
@@ -382,13 +399,13 @@ func NewArrayTypeData() ArrayTypeData {
 
 func (i *ArrayTypeData) IsArrayType() {}
 
-func (i *ArrayTypeData) ForEachNode(fn func(core.AstNode)) {
+func (i *ArrayTypeData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	if i.internalType != nil {
-		fn(i.internalType)
+		fn(i.internalType, unique.Make("internalType"), 0)
 	}
 }
 
-func (i *ArrayTypeData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *ArrayTypeData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 func (i *ArrayTypeData) InternalType() FieldType {
@@ -409,14 +426,18 @@ type ArrayTypeImpl struct {
 	ArrayTypeData
 }
 
-func (i *ArrayTypeImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *ArrayTypeImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.FieldTypeData.ForEachNode(fn)
 	i.ArrayTypeData.ForEachNode(fn)
 }
 
-func (i *ArrayTypeImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *ArrayTypeImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.FieldTypeData.ForEachReference(fn)
 	i.ArrayTypeData.ForEachReference(fn)
+}
+
+func (i *ArrayTypeImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return FastbeltFieldInfos["ArrayType"][field.Value()]
 }
 
 type ReferenceType interface {
@@ -446,12 +467,12 @@ func NewReferenceTypeData() ReferenceTypeData {
 
 func (i *ReferenceTypeData) IsReferenceType() {}
 
-func (i *ReferenceTypeData) ForEachNode(fn func(core.AstNode)) {
+func (i *ReferenceTypeData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 }
 
-func (i *ReferenceTypeData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *ReferenceTypeData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i._Type != nil {
-		fn(i._Type)
+		fn(i._Type, unique.Make("_Type"), 0)
 	}
 }
 
@@ -473,14 +494,18 @@ type ReferenceTypeImpl struct {
 	ReferenceTypeData
 }
 
-func (i *ReferenceTypeImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *ReferenceTypeImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.FieldTypeData.ForEachNode(fn)
 	i.ReferenceTypeData.ForEachNode(fn)
 }
 
-func (i *ReferenceTypeImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *ReferenceTypeImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.FieldTypeData.ForEachReference(fn)
 	i.ReferenceTypeData.ForEachReference(fn)
+}
+
+func (i *ReferenceTypeImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return FastbeltFieldInfos["ReferenceType"][field.Value()]
 }
 
 type SimpleType interface {
@@ -510,12 +535,12 @@ func NewSimpleTypeData() SimpleTypeData {
 
 func (i *SimpleTypeData) IsSimpleType() {}
 
-func (i *SimpleTypeData) ForEachNode(fn func(core.AstNode)) {
+func (i *SimpleTypeData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 }
 
-func (i *SimpleTypeData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *SimpleTypeData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i._Type != nil {
-		fn(i._Type)
+		fn(i._Type, unique.Make("_Type"), 0)
 	}
 }
 
@@ -537,14 +562,18 @@ type SimpleTypeImpl struct {
 	SimpleTypeData
 }
 
-func (i *SimpleTypeImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *SimpleTypeImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.FieldTypeData.ForEachNode(fn)
 	i.SimpleTypeData.ForEachNode(fn)
 }
 
-func (i *SimpleTypeImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *SimpleTypeImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.FieldTypeData.ForEachReference(fn)
 	i.SimpleTypeData.ForEachReference(fn)
+}
+
+func (i *SimpleTypeImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return FastbeltFieldInfos["SimpleType"][field.Value()]
 }
 
 type PrimitiveType interface {
@@ -575,10 +604,10 @@ func NewPrimitiveTypeData() PrimitiveTypeData {
 
 func (i *PrimitiveTypeData) IsPrimitiveType() {}
 
-func (i *PrimitiveTypeData) ForEachNode(fn func(core.AstNode)) {
+func (i *PrimitiveTypeData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 }
 
-func (i *PrimitiveTypeData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *PrimitiveTypeData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 func (i *PrimitiveTypeData) Type() string {
@@ -603,14 +632,18 @@ type PrimitiveTypeImpl struct {
 	PrimitiveTypeData
 }
 
-func (i *PrimitiveTypeImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *PrimitiveTypeImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.FieldTypeData.ForEachNode(fn)
 	i.PrimitiveTypeData.ForEachNode(fn)
 }
 
-func (i *PrimitiveTypeImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *PrimitiveTypeImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.FieldTypeData.ForEachReference(fn)
 	i.PrimitiveTypeData.ForEachReference(fn)
+}
+
+func (i *PrimitiveTypeImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return FastbeltFieldInfos["PrimitiveType"][field.Value()]
 }
 
 type AbstractRule interface {
@@ -639,10 +672,10 @@ func NewAbstractRuleData() AbstractRuleData {
 
 func (i *AbstractRuleData) IsAbstractRule() {}
 
-func (i *AbstractRuleData) ForEachNode(fn func(core.AstNode)) {
+func (i *AbstractRuleData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 }
 
-func (i *AbstractRuleData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *AbstractRuleData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 func (i *AbstractRuleData) Name() string {
@@ -666,12 +699,16 @@ type AbstractRuleImpl struct {
 	AbstractRuleData
 }
 
-func (i *AbstractRuleImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *AbstractRuleImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.AbstractRuleData.ForEachNode(fn)
 }
 
-func (i *AbstractRuleImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *AbstractRuleImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.AbstractRuleData.ForEachReference(fn)
+}
+
+func (i *AbstractRuleImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return FastbeltFieldInfos["AbstractRule"][field.Value()]
 }
 
 type AbstractRuleWithBody interface {
@@ -701,13 +738,13 @@ func NewAbstractRuleWithBodyData() AbstractRuleWithBodyData {
 
 func (i *AbstractRuleWithBodyData) IsAbstractRuleWithBody() {}
 
-func (i *AbstractRuleWithBodyData) ForEachNode(fn func(core.AstNode)) {
+func (i *AbstractRuleWithBodyData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	if i.body != nil {
-		fn(i.body)
+		fn(i.body, unique.Make("body"), 0)
 	}
 }
 
-func (i *AbstractRuleWithBodyData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *AbstractRuleWithBodyData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 func (i *AbstractRuleWithBodyData) Body() Element {
@@ -728,14 +765,18 @@ type AbstractRuleWithBodyImpl struct {
 	AbstractRuleWithBodyData
 }
 
-func (i *AbstractRuleWithBodyImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *AbstractRuleWithBodyImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.AbstractRuleData.ForEachNode(fn)
 	i.AbstractRuleWithBodyData.ForEachNode(fn)
 }
 
-func (i *AbstractRuleWithBodyImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *AbstractRuleWithBodyImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.AbstractRuleData.ForEachReference(fn)
 	i.AbstractRuleWithBodyData.ForEachReference(fn)
+}
+
+func (i *AbstractRuleWithBodyImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return FastbeltFieldInfos["AbstractRuleWithBody"][field.Value()]
 }
 
 type AbstractTokenRule interface {
@@ -762,10 +803,10 @@ func NewAbstractTokenRuleData() AbstractTokenRuleData {
 
 func (i *AbstractTokenRuleData) IsAbstractTokenRule() {}
 
-func (i *AbstractTokenRuleData) ForEachNode(fn func(core.AstNode)) {
+func (i *AbstractTokenRuleData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 }
 
-func (i *AbstractTokenRuleData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *AbstractTokenRuleData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 type AbstractTokenRuleImpl struct {
@@ -774,14 +815,18 @@ type AbstractTokenRuleImpl struct {
 	AbstractTokenRuleData
 }
 
-func (i *AbstractTokenRuleImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *AbstractTokenRuleImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.AbstractRuleData.ForEachNode(fn)
 	i.AbstractTokenRuleData.ForEachNode(fn)
 }
 
-func (i *AbstractTokenRuleImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *AbstractTokenRuleImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.AbstractRuleData.ForEachReference(fn)
 	i.AbstractTokenRuleData.ForEachReference(fn)
+}
+
+func (i *AbstractTokenRuleImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return FastbeltFieldInfos["AbstractTokenRule"][field.Value()]
 }
 
 type ParserRule interface {
@@ -816,12 +861,12 @@ func NewParserRuleData() ParserRuleData {
 
 func (i *ParserRuleData) IsParserRule() {}
 
-func (i *ParserRuleData) ForEachNode(fn func(core.AstNode)) {
+func (i *ParserRuleData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 }
 
-func (i *ParserRuleData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *ParserRuleData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i.returnType != nil {
-		fn(i.returnType)
+		fn(i.returnType, unique.Make("returnType"), 0)
 	}
 }
 
@@ -856,16 +901,20 @@ type ParserRuleImpl struct {
 	ParserRuleData
 }
 
-func (i *ParserRuleImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *ParserRuleImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.AbstractRuleWithBodyData.ForEachNode(fn)
 	i.AbstractRuleData.ForEachNode(fn)
 	i.ParserRuleData.ForEachNode(fn)
 }
 
-func (i *ParserRuleImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *ParserRuleImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.AbstractRuleWithBodyData.ForEachReference(fn)
 	i.AbstractRuleData.ForEachReference(fn)
 	i.ParserRuleData.ForEachReference(fn)
+}
+
+func (i *ParserRuleImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return FastbeltFieldInfos["ParserRule"][field.Value()]
 }
 
 type Token interface {
@@ -901,10 +950,10 @@ func NewTokenData() TokenData {
 
 func (i *TokenData) IsToken() {}
 
-func (i *TokenData) ForEachNode(fn func(core.AstNode)) {
+func (i *TokenData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 }
 
-func (i *TokenData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *TokenData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 func (i *TokenData) Type() string {
@@ -946,16 +995,20 @@ type TokenImpl struct {
 	TokenData
 }
 
-func (i *TokenImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *TokenImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.AbstractTokenRuleData.ForEachNode(fn)
 	i.AbstractRuleData.ForEachNode(fn)
 	i.TokenData.ForEachNode(fn)
 }
 
-func (i *TokenImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *TokenImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.AbstractTokenRuleData.ForEachReference(fn)
 	i.AbstractRuleData.ForEachReference(fn)
 	i.TokenData.ForEachReference(fn)
+}
+
+func (i *TokenImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return FastbeltFieldInfos["Token"][field.Value()]
 }
 
 type TokenGroup interface {
@@ -996,15 +1049,15 @@ func NewTokenGroupData() TokenGroupData {
 
 func (i *TokenGroupData) IsTokenGroup() {}
 
-func (i *TokenGroupData) ForEachNode(fn func(core.AstNode)) {
-	for _, item := range i.keywords {
-		fn(item)
+func (i *TokenGroupData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+	for j, item := range i.keywords {
+		fn(item, unique.Make("keywords"), uint16(j))
 	}
 }
 
-func (i *TokenGroupData) ForEachReference(fn func(core.UntypedReference)) {
-	for _, item := range i.tokenRefs {
-		fn(item)
+func (i *TokenGroupData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+	for j, item := range i.tokenRefs {
+		fn(item, unique.Make("tokenRefs"), uint16(j))
 	}
 }
 
@@ -1039,16 +1092,20 @@ type TokenGroupImpl struct {
 	TokenGroupData
 }
 
-func (i *TokenGroupImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *TokenGroupImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.AbstractTokenRuleData.ForEachNode(fn)
 	i.AbstractRuleData.ForEachNode(fn)
 	i.TokenGroupData.ForEachNode(fn)
 }
 
-func (i *TokenGroupImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *TokenGroupImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.AbstractTokenRuleData.ForEachReference(fn)
 	i.AbstractRuleData.ForEachReference(fn)
 	i.TokenGroupData.ForEachReference(fn)
+}
+
+func (i *TokenGroupImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return FastbeltFieldInfos["TokenGroup"][field.Value()]
 }
 
 type Element interface {
@@ -1077,10 +1134,10 @@ func NewElementData() ElementData {
 
 func (i *ElementData) IsElement() {}
 
-func (i *ElementData) ForEachNode(fn func(core.AstNode)) {
+func (i *ElementData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 }
 
-func (i *ElementData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *ElementData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 func (i *ElementData) Cardinality() string {
@@ -1104,12 +1161,16 @@ type ElementImpl struct {
 	ElementData
 }
 
-func (i *ElementImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *ElementImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.ElementData.ForEachNode(fn)
 }
 
-func (i *ElementImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *ElementImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.ElementData.ForEachReference(fn)
+}
+
+func (i *ElementImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return FastbeltFieldInfos["Element"][field.Value()]
 }
 
 type Alternatives interface {
@@ -1142,13 +1203,13 @@ func NewAlternativesData() AlternativesData {
 
 func (i *AlternativesData) IsAlternatives() {}
 
-func (i *AlternativesData) ForEachNode(fn func(core.AstNode)) {
-	for _, item := range i.alts {
-		fn(item)
+func (i *AlternativesData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+	for j, item := range i.alts {
+		fn(item, unique.Make("alts"), uint16(j))
 	}
 }
 
-func (i *AlternativesData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *AlternativesData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 func (i *AlternativesData) Alts() []Element {
@@ -1166,16 +1227,20 @@ type AlternativesImpl struct {
 	AlternativesData
 }
 
-func (i *AlternativesImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *AlternativesImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.AssignableData.ForEachNode(fn)
 	i.ElementData.ForEachNode(fn)
 	i.AlternativesData.ForEachNode(fn)
 }
 
-func (i *AlternativesImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *AlternativesImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.AssignableData.ForEachReference(fn)
 	i.ElementData.ForEachReference(fn)
 	i.AlternativesData.ForEachReference(fn)
+}
+
+func (i *AlternativesImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return FastbeltFieldInfos["Alternatives"][field.Value()]
 }
 
 type Group interface {
@@ -1207,13 +1272,13 @@ func NewGroupData() GroupData {
 
 func (i *GroupData) IsGroup() {}
 
-func (i *GroupData) ForEachNode(fn func(core.AstNode)) {
-	for _, item := range i.elements {
-		fn(item)
+func (i *GroupData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+	for j, item := range i.elements {
+		fn(item, unique.Make("elements"), uint16(j))
 	}
 }
 
-func (i *GroupData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *GroupData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 func (i *GroupData) Elements() []Element {
@@ -1230,14 +1295,18 @@ type GroupImpl struct {
 	GroupData
 }
 
-func (i *GroupImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *GroupImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.ElementData.ForEachNode(fn)
 	i.GroupData.ForEachNode(fn)
 }
 
-func (i *GroupImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *GroupImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.ElementData.ForEachReference(fn)
 	i.GroupData.ForEachReference(fn)
+}
+
+func (i *GroupImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return FastbeltFieldInfos["Group"][field.Value()]
 }
 
 type Keyword interface {
@@ -1269,10 +1338,10 @@ func NewKeywordData() KeywordData {
 
 func (i *KeywordData) IsKeyword() {}
 
-func (i *KeywordData) ForEachNode(fn func(core.AstNode)) {
+func (i *KeywordData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 }
 
-func (i *KeywordData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *KeywordData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 func (i *KeywordData) Value() string {
@@ -1298,16 +1367,20 @@ type KeywordImpl struct {
 	KeywordData
 }
 
-func (i *KeywordImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *KeywordImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.AssignableData.ForEachNode(fn)
 	i.ElementData.ForEachNode(fn)
 	i.KeywordData.ForEachNode(fn)
 }
 
-func (i *KeywordImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *KeywordImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.AssignableData.ForEachReference(fn)
 	i.ElementData.ForEachReference(fn)
 	i.KeywordData.ForEachReference(fn)
+}
+
+func (i *KeywordImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return FastbeltFieldInfos["Keyword"][field.Value()]
 }
 
 type Assignment interface {
@@ -1344,15 +1417,15 @@ func NewAssignmentData() AssignmentData {
 
 func (i *AssignmentData) IsAssignment() {}
 
-func (i *AssignmentData) ForEachNode(fn func(core.AstNode)) {
+func (i *AssignmentData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	if i.value != nil {
-		fn(i.value)
+		fn(i.value, unique.Make("value"), 0)
 	}
 }
 
-func (i *AssignmentData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *AssignmentData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i.property != nil {
-		fn(i.property)
+		fn(i.property, unique.Make("property"), 0)
 	}
 }
 
@@ -1402,14 +1475,18 @@ type AssignmentImpl struct {
 	AssignmentData
 }
 
-func (i *AssignmentImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *AssignmentImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.ElementData.ForEachNode(fn)
 	i.AssignmentData.ForEachNode(fn)
 }
 
-func (i *AssignmentImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *AssignmentImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.ElementData.ForEachReference(fn)
 	i.AssignmentData.ForEachReference(fn)
+}
+
+func (i *AssignmentImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return FastbeltFieldInfos["Assignment"][field.Value()]
 }
 
 type Assignable interface {
@@ -1436,10 +1513,10 @@ func NewAssignableData() AssignableData {
 
 func (i *AssignableData) IsAssignable() {}
 
-func (i *AssignableData) ForEachNode(fn func(core.AstNode)) {
+func (i *AssignableData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 }
 
-func (i *AssignableData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *AssignableData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 type AssignableImpl struct {
@@ -1448,14 +1525,18 @@ type AssignableImpl struct {
 	AssignableData
 }
 
-func (i *AssignableImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *AssignableImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.ElementData.ForEachNode(fn)
 	i.AssignableData.ForEachNode(fn)
 }
 
-func (i *AssignableImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *AssignableImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.ElementData.ForEachReference(fn)
 	i.AssignableData.ForEachReference(fn)
+}
+
+func (i *AssignableImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return FastbeltFieldInfos["Assignable"][field.Value()]
 }
 
 type CrossRef interface {
@@ -1489,15 +1570,15 @@ func NewCrossRefData() CrossRefData {
 
 func (i *CrossRefData) IsCrossRef() {}
 
-func (i *CrossRefData) ForEachNode(fn func(core.AstNode)) {
+func (i *CrossRefData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	if i.rule != nil {
-		fn(i.rule)
+		fn(i.rule, unique.Make("rule"), 0)
 	}
 }
 
-func (i *CrossRefData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *CrossRefData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i._Type != nil {
-		fn(i._Type)
+		fn(i._Type, unique.Make("_Type"), 0)
 	}
 }
 
@@ -1532,16 +1613,20 @@ type CrossRefImpl struct {
 	CrossRefData
 }
 
-func (i *CrossRefImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *CrossRefImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.AssignableData.ForEachNode(fn)
 	i.ElementData.ForEachNode(fn)
 	i.CrossRefData.ForEachNode(fn)
 }
 
-func (i *CrossRefImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *CrossRefImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.AssignableData.ForEachReference(fn)
 	i.ElementData.ForEachReference(fn)
 	i.CrossRefData.ForEachReference(fn)
+}
+
+func (i *CrossRefImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return FastbeltFieldInfos["CrossRef"][field.Value()]
 }
 
 type RuleCall interface {
@@ -1572,12 +1657,12 @@ func NewRuleCallData() RuleCallData {
 
 func (i *RuleCallData) IsRuleCall() {}
 
-func (i *RuleCallData) ForEachNode(fn func(core.AstNode)) {
+func (i *RuleCallData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 }
 
-func (i *RuleCallData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *RuleCallData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i.rule != nil {
-		fn(i.rule)
+		fn(i.rule, unique.Make("rule"), 0)
 	}
 }
 
@@ -1600,16 +1685,20 @@ type RuleCallImpl struct {
 	RuleCallData
 }
 
-func (i *RuleCallImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *RuleCallImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.AssignableData.ForEachNode(fn)
 	i.ElementData.ForEachNode(fn)
 	i.RuleCallData.ForEachNode(fn)
 }
 
-func (i *RuleCallImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *RuleCallImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.AssignableData.ForEachReference(fn)
 	i.ElementData.ForEachReference(fn)
 	i.RuleCallData.ForEachReference(fn)
+}
+
+func (i *RuleCallImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return FastbeltFieldInfos["RuleCall"][field.Value()]
 }
 
 type Action interface {
@@ -1646,15 +1735,15 @@ func NewActionData() ActionData {
 
 func (i *ActionData) IsAction() {}
 
-func (i *ActionData) ForEachNode(fn func(core.AstNode)) {
+func (i *ActionData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 }
 
-func (i *ActionData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *ActionData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i._Type != nil {
-		fn(i._Type)
+		fn(i._Type, unique.Make("_Type"), 0)
 	}
 	if i.property != nil {
-		fn(i.property)
+		fn(i.property, unique.Make("property"), 0)
 	}
 }
 
@@ -1704,14 +1793,18 @@ type ActionImpl struct {
 	ActionData
 }
 
-func (i *ActionImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *ActionImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.ElementData.ForEachNode(fn)
 	i.ActionData.ForEachNode(fn)
 }
 
-func (i *ActionImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *ActionImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.ElementData.ForEachReference(fn)
 	i.ActionData.ForEachReference(fn)
+}
+
+func (i *ActionImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return FastbeltFieldInfos["Action"][field.Value()]
 }
 
 type CompositeRule interface {
@@ -1739,10 +1832,10 @@ func NewCompositeRuleData() CompositeRuleData {
 
 func (i *CompositeRuleData) IsCompositeRule() {}
 
-func (i *CompositeRuleData) ForEachNode(fn func(core.AstNode)) {
+func (i *CompositeRuleData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 }
 
-func (i *CompositeRuleData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *CompositeRuleData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 type CompositeRuleImpl struct {
@@ -1752,16 +1845,20 @@ type CompositeRuleImpl struct {
 	CompositeRuleData
 }
 
-func (i *CompositeRuleImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *CompositeRuleImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.AbstractRuleWithBodyData.ForEachNode(fn)
 	i.AbstractRuleData.ForEachNode(fn)
 	i.CompositeRuleData.ForEachNode(fn)
 }
 
-func (i *CompositeRuleImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *CompositeRuleImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.AbstractRuleWithBodyData.ForEachReference(fn)
 	i.AbstractRuleData.ForEachReference(fn)
 	i.CompositeRuleData.ForEachReference(fn)
+}
+
+func (i *CompositeRuleImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return FastbeltFieldInfos["CompositeRule"][field.Value()]
 }
 
 var FastbeltSyntheticFactories = map[string]func() core.AstNode{
@@ -1789,4 +1886,266 @@ var FastbeltSyntheticFactories = map[string]func() core.AstNode{
 	"SimpleType":           func() core.AstNode { return NewSimpleType() },
 	"Token":                func() core.AstNode { return NewToken() },
 	"TokenGroup":           func() core.AstNode { return NewTokenGroup() },
+}
+
+var FastbeltFieldInfos = map[string]map[string]core.FieldInfos{
+	"AbstractRule": map[string]core.FieldInfos{
+		"name": {
+			Multi:     false,
+			Reference: false,
+		},
+	},
+	"AbstractRuleWithBody": map[string]core.FieldInfos{
+		"body": {
+			Multi:     false,
+			Reference: false,
+		},
+		"name": {
+			Multi:     false,
+			Reference: false,
+		},
+	},
+	"AbstractTokenRule": map[string]core.FieldInfos{
+		"name": {
+			Multi:     false,
+			Reference: false,
+		},
+	},
+	"Action": map[string]core.FieldInfos{
+		"cardinality": {
+			Multi:     false,
+			Reference: false,
+		},
+		"operator": {
+			Multi:     false,
+			Reference: false,
+		},
+		"property": {
+			Multi:     false,
+			Reference: true,
+		},
+		"_Type": {
+			Multi:     false,
+			Reference: true,
+		},
+	},
+	"Alternatives": map[string]core.FieldInfos{
+		"alts": {
+			Multi:     true,
+			Reference: false,
+		},
+		"cardinality": {
+			Multi:     false,
+			Reference: false,
+		},
+	},
+	"ArrayType": map[string]core.FieldInfos{
+		"internalType": {
+			Multi:     false,
+			Reference: false,
+		},
+	},
+	"Assignable": map[string]core.FieldInfos{
+		"cardinality": {
+			Multi:     false,
+			Reference: false,
+		},
+	},
+	"Assignment": map[string]core.FieldInfos{
+		"cardinality": {
+			Multi:     false,
+			Reference: false,
+		},
+		"operator": {
+			Multi:     false,
+			Reference: false,
+		},
+		"property": {
+			Multi:     false,
+			Reference: true,
+		},
+		"value": {
+			Multi:     false,
+			Reference: false,
+		},
+	},
+	"CompositeRule": map[string]core.FieldInfos{
+		"body": {
+			Multi:     false,
+			Reference: false,
+		},
+		"name": {
+			Multi:     false,
+			Reference: false,
+		},
+	},
+	"CrossRef": map[string]core.FieldInfos{
+		"cardinality": {
+			Multi:     false,
+			Reference: false,
+		},
+		"rule": {
+			Multi:     false,
+			Reference: false,
+		},
+		"_Type": {
+			Multi:     false,
+			Reference: true,
+		},
+	},
+	"Element": map[string]core.FieldInfos{
+		"cardinality": {
+			Multi:     false,
+			Reference: false,
+		},
+	},
+	"Field": map[string]core.FieldInfos{
+		"name": {
+			Multi:     false,
+			Reference: false,
+		},
+		"_Type": {
+			Multi:     false,
+			Reference: false,
+		},
+	},
+	"FieldType": map[string]core.FieldInfos{},
+	"Grammar": map[string]core.FieldInfos{
+		"composites": {
+			Multi:     true,
+			Reference: false,
+		},
+		"interfaces": {
+			Multi:     true,
+			Reference: false,
+		},
+		"name": {
+			Multi:     false,
+			Reference: false,
+		},
+		"rules": {
+			Multi:     true,
+			Reference: false,
+		},
+		"terminals": {
+			Multi:     true,
+			Reference: false,
+		},
+		"tokenGroups": {
+			Multi:     true,
+			Reference: false,
+		},
+	},
+	"Group": map[string]core.FieldInfos{
+		"cardinality": {
+			Multi:     false,
+			Reference: false,
+		},
+		"elements": {
+			Multi:     true,
+			Reference: false,
+		},
+	},
+	"Interface": map[string]core.FieldInfos{
+		"extends": {
+			Multi:     true,
+			Reference: true,
+		},
+		"fields": {
+			Multi:     true,
+			Reference: false,
+		},
+		"name": {
+			Multi:     false,
+			Reference: false,
+		},
+	},
+	"Keyword": map[string]core.FieldInfos{
+		"cardinality": {
+			Multi:     false,
+			Reference: false,
+		},
+		"value": {
+			Multi:     false,
+			Reference: false,
+		},
+	},
+	"ParserRule": map[string]core.FieldInfos{
+		"body": {
+			Multi:     false,
+			Reference: false,
+		},
+		"entry": {
+			Multi:     false,
+			Reference: false,
+		},
+		"name": {
+			Multi:     false,
+			Reference: false,
+		},
+		"returnType": {
+			Multi:     false,
+			Reference: true,
+		},
+	},
+	"PrimitiveType": map[string]core.FieldInfos{
+		"_Type": {
+			Multi:     false,
+			Reference: false,
+		},
+	},
+	"ReferenceType": map[string]core.FieldInfos{
+		"_Type": {
+			Multi:     false,
+			Reference: true,
+		},
+	},
+	"RuleCall": map[string]core.FieldInfos{
+		"cardinality": {
+			Multi:     false,
+			Reference: false,
+		},
+		"rule": {
+			Multi:     false,
+			Reference: true,
+		},
+	},
+	"SimpleType": map[string]core.FieldInfos{
+		"_Type": {
+			Multi:     false,
+			Reference: true,
+		},
+	},
+	"Token": map[string]core.FieldInfos{
+		"name": {
+			Multi:     false,
+			Reference: false,
+		},
+		"regexp": {
+			Multi:     false,
+			Reference: false,
+		},
+		"_Type": {
+			Multi:     false,
+			Reference: false,
+		},
+	},
+	"TokenGroup": map[string]core.FieldInfos{
+		"keywords": {
+			Multi:     true,
+			Reference: false,
+		},
+		"name": {
+			Multi:     false,
+			Reference: false,
+		},
+		"regexps": {
+			Multi:     true,
+			Reference: false,
+		},
+		"tokenRefs": {
+			Multi:     true,
+			Reference: true,
+		},
+	},
 }

--- a/internal/grammar/types_gen.go
+++ b/internal/grammar/types_gen.go
@@ -56,19 +56,19 @@ func (i *GrammarData) IsGrammar() {}
 
 func (i *GrammarData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	for j, item := range i.rules {
-		fn(item, unique.Make("rules"), uint16(j))
+		fn(item, fieldNameRules, uint16(j))
 	}
 	for j, item := range i.composites {
-		fn(item, unique.Make("composites"), uint16(j))
+		fn(item, fieldNameComposites, uint16(j))
 	}
 	for j, item := range i.terminals {
-		fn(item, unique.Make("terminals"), uint16(j))
+		fn(item, fieldNameTerminals, uint16(j))
 	}
 	for j, item := range i.tokenGroups {
-		fn(item, unique.Make("tokenGroups"), uint16(j))
+		fn(item, fieldNameTokenGroups, uint16(j))
 	}
 	for j, item := range i.interfaces {
-		fn(item, unique.Make("interfaces"), uint16(j))
+		fn(item, fieldNameInterfaces, uint16(j))
 	}
 }
 
@@ -145,7 +145,22 @@ func (i *GrammarImpl) ForEachReference(fn func(core.UntypedReference, unique.Han
 }
 
 func (i *GrammarImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return FastbeltFieldInfos["Grammar"][field.Value()]
+	switch field {
+	case fieldNameComposites:
+		return core.FieldInfos{Multi: true, Reference: false}
+	case fieldNameInterfaces:
+		return core.FieldInfos{Multi: true, Reference: false}
+	case fieldNameName:
+		return core.FieldInfos{Multi: false, Reference: false}
+	case fieldNameRules:
+		return core.FieldInfos{Multi: true, Reference: false}
+	case fieldNameTerminals:
+		return core.FieldInfos{Multi: true, Reference: false}
+	case fieldNameTokenGroups:
+		return core.FieldInfos{Multi: true, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type Interface interface {
@@ -185,13 +200,13 @@ func (i *InterfaceData) IsInterface() {}
 
 func (i *InterfaceData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	for j, item := range i.fields {
-		fn(item, unique.Make("fields"), uint16(j))
+		fn(item, fieldNameFields, uint16(j))
 	}
 }
 
 func (i *InterfaceData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	for j, item := range i.extends {
-		fn(item, unique.Make("extends"), uint16(j))
+		fn(item, fieldNameExtends, uint16(j))
 	}
 }
 
@@ -241,7 +256,16 @@ func (i *InterfaceImpl) ForEachReference(fn func(core.UntypedReference, unique.H
 }
 
 func (i *InterfaceImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return FastbeltFieldInfos["Interface"][field.Value()]
+	switch field {
+	case fieldNameExtends:
+		return core.FieldInfos{Multi: true, Reference: true}
+	case fieldNameFields:
+		return core.FieldInfos{Multi: true, Reference: false}
+	case fieldNameName:
+		return core.FieldInfos{Multi: false, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type Field interface {
@@ -275,7 +299,7 @@ func (i *FieldData) IsField() {}
 
 func (i *FieldData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	if i._Type != nil {
-		fn(i._Type, unique.Make("_Type"), 0)
+		fn(i._Type, fieldNameType, 0)
 	}
 }
 
@@ -324,7 +348,14 @@ func (i *FieldImpl) ForEachReference(fn func(core.UntypedReference, unique.Handl
 }
 
 func (i *FieldImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return FastbeltFieldInfos["Field"][field.Value()]
+	switch field {
+	case fieldNameName:
+		return core.FieldInfos{Multi: false, Reference: false}
+	case fieldNameType:
+		return core.FieldInfos{Multi: false, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type FieldType interface {
@@ -369,7 +400,7 @@ func (i *FieldTypeImpl) ForEachReference(fn func(core.UntypedReference, unique.H
 }
 
 func (i *FieldTypeImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return FastbeltFieldInfos["FieldType"][field.Value()]
+	return core.FieldInfos{}
 }
 
 type ArrayType interface {
@@ -401,7 +432,7 @@ func (i *ArrayTypeData) IsArrayType() {}
 
 func (i *ArrayTypeData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	if i.internalType != nil {
-		fn(i.internalType, unique.Make("internalType"), 0)
+		fn(i.internalType, fieldNameInternalType, 0)
 	}
 }
 
@@ -437,7 +468,12 @@ func (i *ArrayTypeImpl) ForEachReference(fn func(core.UntypedReference, unique.H
 }
 
 func (i *ArrayTypeImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return FastbeltFieldInfos["ArrayType"][field.Value()]
+	switch field {
+	case fieldNameInternalType:
+		return core.FieldInfos{Multi: false, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type ReferenceType interface {
@@ -472,7 +508,7 @@ func (i *ReferenceTypeData) ForEachNode(fn func(core.AstNode, unique.Handle[stri
 
 func (i *ReferenceTypeData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i._Type != nil {
-		fn(i._Type, unique.Make("_Type"), 0)
+		fn(i._Type, fieldNameType, 0)
 	}
 }
 
@@ -505,7 +541,12 @@ func (i *ReferenceTypeImpl) ForEachReference(fn func(core.UntypedReference, uniq
 }
 
 func (i *ReferenceTypeImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return FastbeltFieldInfos["ReferenceType"][field.Value()]
+	switch field {
+	case fieldNameType:
+		return core.FieldInfos{Multi: false, Reference: true}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type SimpleType interface {
@@ -540,7 +581,7 @@ func (i *SimpleTypeData) ForEachNode(fn func(core.AstNode, unique.Handle[string]
 
 func (i *SimpleTypeData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i._Type != nil {
-		fn(i._Type, unique.Make("_Type"), 0)
+		fn(i._Type, fieldNameType, 0)
 	}
 }
 
@@ -573,7 +614,12 @@ func (i *SimpleTypeImpl) ForEachReference(fn func(core.UntypedReference, unique.
 }
 
 func (i *SimpleTypeImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return FastbeltFieldInfos["SimpleType"][field.Value()]
+	switch field {
+	case fieldNameType:
+		return core.FieldInfos{Multi: false, Reference: true}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type PrimitiveType interface {
@@ -643,7 +689,12 @@ func (i *PrimitiveTypeImpl) ForEachReference(fn func(core.UntypedReference, uniq
 }
 
 func (i *PrimitiveTypeImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return FastbeltFieldInfos["PrimitiveType"][field.Value()]
+	switch field {
+	case fieldNameType:
+		return core.FieldInfos{Multi: false, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type AbstractRule interface {
@@ -708,7 +759,12 @@ func (i *AbstractRuleImpl) ForEachReference(fn func(core.UntypedReference, uniqu
 }
 
 func (i *AbstractRuleImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return FastbeltFieldInfos["AbstractRule"][field.Value()]
+	switch field {
+	case fieldNameName:
+		return core.FieldInfos{Multi: false, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type AbstractRuleWithBody interface {
@@ -740,7 +796,7 @@ func (i *AbstractRuleWithBodyData) IsAbstractRuleWithBody() {}
 
 func (i *AbstractRuleWithBodyData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	if i.body != nil {
-		fn(i.body, unique.Make("body"), 0)
+		fn(i.body, fieldNameBody, 0)
 	}
 }
 
@@ -776,7 +832,14 @@ func (i *AbstractRuleWithBodyImpl) ForEachReference(fn func(core.UntypedReferenc
 }
 
 func (i *AbstractRuleWithBodyImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return FastbeltFieldInfos["AbstractRuleWithBody"][field.Value()]
+	switch field {
+	case fieldNameBody:
+		return core.FieldInfos{Multi: false, Reference: false}
+	case fieldNameName:
+		return core.FieldInfos{Multi: false, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type AbstractTokenRule interface {
@@ -826,7 +889,12 @@ func (i *AbstractTokenRuleImpl) ForEachReference(fn func(core.UntypedReference, 
 }
 
 func (i *AbstractTokenRuleImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return FastbeltFieldInfos["AbstractTokenRule"][field.Value()]
+	switch field {
+	case fieldNameName:
+		return core.FieldInfos{Multi: false, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type ParserRule interface {
@@ -866,7 +934,7 @@ func (i *ParserRuleData) ForEachNode(fn func(core.AstNode, unique.Handle[string]
 
 func (i *ParserRuleData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i.returnType != nil {
-		fn(i.returnType, unique.Make("returnType"), 0)
+		fn(i.returnType, fieldNameReturnType, 0)
 	}
 }
 
@@ -914,7 +982,18 @@ func (i *ParserRuleImpl) ForEachReference(fn func(core.UntypedReference, unique.
 }
 
 func (i *ParserRuleImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return FastbeltFieldInfos["ParserRule"][field.Value()]
+	switch field {
+	case fieldNameBody:
+		return core.FieldInfos{Multi: false, Reference: false}
+	case fieldNameEntry:
+		return core.FieldInfos{Multi: false, Reference: false}
+	case fieldNameName:
+		return core.FieldInfos{Multi: false, Reference: false}
+	case fieldNameReturnType:
+		return core.FieldInfos{Multi: false, Reference: true}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type Token interface {
@@ -1008,7 +1087,16 @@ func (i *TokenImpl) ForEachReference(fn func(core.UntypedReference, unique.Handl
 }
 
 func (i *TokenImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return FastbeltFieldInfos["Token"][field.Value()]
+	switch field {
+	case fieldNameName:
+		return core.FieldInfos{Multi: false, Reference: false}
+	case fieldNameRegexp:
+		return core.FieldInfos{Multi: false, Reference: false}
+	case fieldNameType:
+		return core.FieldInfos{Multi: false, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type TokenGroup interface {
@@ -1051,13 +1139,13 @@ func (i *TokenGroupData) IsTokenGroup() {}
 
 func (i *TokenGroupData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	for j, item := range i.keywords {
-		fn(item, unique.Make("keywords"), uint16(j))
+		fn(item, fieldNameKeywords, uint16(j))
 	}
 }
 
 func (i *TokenGroupData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	for j, item := range i.tokenRefs {
-		fn(item, unique.Make("tokenRefs"), uint16(j))
+		fn(item, fieldNameTokenRefs, uint16(j))
 	}
 }
 
@@ -1105,7 +1193,18 @@ func (i *TokenGroupImpl) ForEachReference(fn func(core.UntypedReference, unique.
 }
 
 func (i *TokenGroupImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return FastbeltFieldInfos["TokenGroup"][field.Value()]
+	switch field {
+	case fieldNameKeywords:
+		return core.FieldInfos{Multi: true, Reference: false}
+	case fieldNameName:
+		return core.FieldInfos{Multi: false, Reference: false}
+	case fieldNameRegexps:
+		return core.FieldInfos{Multi: true, Reference: false}
+	case fieldNameTokenRefs:
+		return core.FieldInfos{Multi: true, Reference: true}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type Element interface {
@@ -1170,7 +1269,12 @@ func (i *ElementImpl) ForEachReference(fn func(core.UntypedReference, unique.Han
 }
 
 func (i *ElementImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return FastbeltFieldInfos["Element"][field.Value()]
+	switch field {
+	case fieldNameCardinality:
+		return core.FieldInfos{Multi: false, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type Alternatives interface {
@@ -1205,7 +1309,7 @@ func (i *AlternativesData) IsAlternatives() {}
 
 func (i *AlternativesData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	for j, item := range i.alts {
-		fn(item, unique.Make("alts"), uint16(j))
+		fn(item, fieldNameAlts, uint16(j))
 	}
 }
 
@@ -1240,7 +1344,14 @@ func (i *AlternativesImpl) ForEachReference(fn func(core.UntypedReference, uniqu
 }
 
 func (i *AlternativesImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return FastbeltFieldInfos["Alternatives"][field.Value()]
+	switch field {
+	case fieldNameAlts:
+		return core.FieldInfos{Multi: true, Reference: false}
+	case fieldNameCardinality:
+		return core.FieldInfos{Multi: false, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type Group interface {
@@ -1274,7 +1385,7 @@ func (i *GroupData) IsGroup() {}
 
 func (i *GroupData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	for j, item := range i.elements {
-		fn(item, unique.Make("elements"), uint16(j))
+		fn(item, fieldNameElements, uint16(j))
 	}
 }
 
@@ -1306,7 +1417,14 @@ func (i *GroupImpl) ForEachReference(fn func(core.UntypedReference, unique.Handl
 }
 
 func (i *GroupImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return FastbeltFieldInfos["Group"][field.Value()]
+	switch field {
+	case fieldNameCardinality:
+		return core.FieldInfos{Multi: false, Reference: false}
+	case fieldNameElements:
+		return core.FieldInfos{Multi: true, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type Keyword interface {
@@ -1380,7 +1498,14 @@ func (i *KeywordImpl) ForEachReference(fn func(core.UntypedReference, unique.Han
 }
 
 func (i *KeywordImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return FastbeltFieldInfos["Keyword"][field.Value()]
+	switch field {
+	case fieldNameCardinality:
+		return core.FieldInfos{Multi: false, Reference: false}
+	case fieldNameValue:
+		return core.FieldInfos{Multi: false, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type Assignment interface {
@@ -1419,13 +1544,13 @@ func (i *AssignmentData) IsAssignment() {}
 
 func (i *AssignmentData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	if i.value != nil {
-		fn(i.value, unique.Make("value"), 0)
+		fn(i.value, fieldNameValue, 0)
 	}
 }
 
 func (i *AssignmentData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i.property != nil {
-		fn(i.property, unique.Make("property"), 0)
+		fn(i.property, fieldNameProperty, 0)
 	}
 }
 
@@ -1486,7 +1611,18 @@ func (i *AssignmentImpl) ForEachReference(fn func(core.UntypedReference, unique.
 }
 
 func (i *AssignmentImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return FastbeltFieldInfos["Assignment"][field.Value()]
+	switch field {
+	case fieldNameCardinality:
+		return core.FieldInfos{Multi: false, Reference: false}
+	case fieldNameOperator:
+		return core.FieldInfos{Multi: false, Reference: false}
+	case fieldNameProperty:
+		return core.FieldInfos{Multi: false, Reference: true}
+	case fieldNameValue:
+		return core.FieldInfos{Multi: false, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type Assignable interface {
@@ -1536,7 +1672,12 @@ func (i *AssignableImpl) ForEachReference(fn func(core.UntypedReference, unique.
 }
 
 func (i *AssignableImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return FastbeltFieldInfos["Assignable"][field.Value()]
+	switch field {
+	case fieldNameCardinality:
+		return core.FieldInfos{Multi: false, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type CrossRef interface {
@@ -1572,13 +1713,13 @@ func (i *CrossRefData) IsCrossRef() {}
 
 func (i *CrossRefData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	if i.rule != nil {
-		fn(i.rule, unique.Make("rule"), 0)
+		fn(i.rule, fieldNameRule, 0)
 	}
 }
 
 func (i *CrossRefData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i._Type != nil {
-		fn(i._Type, unique.Make("_Type"), 0)
+		fn(i._Type, fieldNameType, 0)
 	}
 }
 
@@ -1626,7 +1767,16 @@ func (i *CrossRefImpl) ForEachReference(fn func(core.UntypedReference, unique.Ha
 }
 
 func (i *CrossRefImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return FastbeltFieldInfos["CrossRef"][field.Value()]
+	switch field {
+	case fieldNameCardinality:
+		return core.FieldInfos{Multi: false, Reference: false}
+	case fieldNameRule:
+		return core.FieldInfos{Multi: false, Reference: false}
+	case fieldNameType:
+		return core.FieldInfos{Multi: false, Reference: true}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type RuleCall interface {
@@ -1662,7 +1812,7 @@ func (i *RuleCallData) ForEachNode(fn func(core.AstNode, unique.Handle[string], 
 
 func (i *RuleCallData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i.rule != nil {
-		fn(i.rule, unique.Make("rule"), 0)
+		fn(i.rule, fieldNameRule, 0)
 	}
 }
 
@@ -1698,7 +1848,14 @@ func (i *RuleCallImpl) ForEachReference(fn func(core.UntypedReference, unique.Ha
 }
 
 func (i *RuleCallImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return FastbeltFieldInfos["RuleCall"][field.Value()]
+	switch field {
+	case fieldNameCardinality:
+		return core.FieldInfos{Multi: false, Reference: false}
+	case fieldNameRule:
+		return core.FieldInfos{Multi: false, Reference: true}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type Action interface {
@@ -1740,10 +1897,10 @@ func (i *ActionData) ForEachNode(fn func(core.AstNode, unique.Handle[string], ui
 
 func (i *ActionData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i._Type != nil {
-		fn(i._Type, unique.Make("_Type"), 0)
+		fn(i._Type, fieldNameType, 0)
 	}
 	if i.property != nil {
-		fn(i.property, unique.Make("property"), 0)
+		fn(i.property, fieldNameProperty, 0)
 	}
 }
 
@@ -1804,7 +1961,18 @@ func (i *ActionImpl) ForEachReference(fn func(core.UntypedReference, unique.Hand
 }
 
 func (i *ActionImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return FastbeltFieldInfos["Action"][field.Value()]
+	switch field {
+	case fieldNameCardinality:
+		return core.FieldInfos{Multi: false, Reference: false}
+	case fieldNameOperator:
+		return core.FieldInfos{Multi: false, Reference: false}
+	case fieldNameProperty:
+		return core.FieldInfos{Multi: false, Reference: true}
+	case fieldNameType:
+		return core.FieldInfos{Multi: false, Reference: true}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type CompositeRule interface {
@@ -1858,8 +2026,42 @@ func (i *CompositeRuleImpl) ForEachReference(fn func(core.UntypedReference, uniq
 }
 
 func (i *CompositeRuleImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return FastbeltFieldInfos["CompositeRule"][field.Value()]
+	switch field {
+	case fieldNameBody:
+		return core.FieldInfos{Multi: false, Reference: false}
+	case fieldNameName:
+		return core.FieldInfos{Multi: false, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
+
+var (
+	fieldNameType         = unique.Make("_Type")
+	fieldNameAlts         = unique.Make("alts")
+	fieldNameBody         = unique.Make("body")
+	fieldNameCardinality  = unique.Make("cardinality")
+	fieldNameComposites   = unique.Make("composites")
+	fieldNameElements     = unique.Make("elements")
+	fieldNameEntry        = unique.Make("entry")
+	fieldNameExtends      = unique.Make("extends")
+	fieldNameFields       = unique.Make("fields")
+	fieldNameInterfaces   = unique.Make("interfaces")
+	fieldNameInternalType = unique.Make("internalType")
+	fieldNameKeywords     = unique.Make("keywords")
+	fieldNameName         = unique.Make("name")
+	fieldNameOperator     = unique.Make("operator")
+	fieldNameProperty     = unique.Make("property")
+	fieldNameRegexp       = unique.Make("regexp")
+	fieldNameRegexps      = unique.Make("regexps")
+	fieldNameReturnType   = unique.Make("returnType")
+	fieldNameRule         = unique.Make("rule")
+	fieldNameRules        = unique.Make("rules")
+	fieldNameTerminals    = unique.Make("terminals")
+	fieldNameTokenGroups  = unique.Make("tokenGroups")
+	fieldNameTokenRefs    = unique.Make("tokenRefs")
+	fieldNameValue        = unique.Make("value")
+)
 
 var FastbeltSyntheticFactories = map[string]func() core.AstNode{
 	"AbstractRule":         func() core.AstNode { return NewAbstractRule() },
@@ -1886,266 +2088,4 @@ var FastbeltSyntheticFactories = map[string]func() core.AstNode{
 	"SimpleType":           func() core.AstNode { return NewSimpleType() },
 	"Token":                func() core.AstNode { return NewToken() },
 	"TokenGroup":           func() core.AstNode { return NewTokenGroup() },
-}
-
-var FastbeltFieldInfos = map[string]map[string]core.FieldInfos{
-	"AbstractRule": map[string]core.FieldInfos{
-		"name": {
-			Multi:     false,
-			Reference: false,
-		},
-	},
-	"AbstractRuleWithBody": map[string]core.FieldInfos{
-		"body": {
-			Multi:     false,
-			Reference: false,
-		},
-		"name": {
-			Multi:     false,
-			Reference: false,
-		},
-	},
-	"AbstractTokenRule": map[string]core.FieldInfos{
-		"name": {
-			Multi:     false,
-			Reference: false,
-		},
-	},
-	"Action": map[string]core.FieldInfos{
-		"cardinality": {
-			Multi:     false,
-			Reference: false,
-		},
-		"operator": {
-			Multi:     false,
-			Reference: false,
-		},
-		"property": {
-			Multi:     false,
-			Reference: true,
-		},
-		"_Type": {
-			Multi:     false,
-			Reference: true,
-		},
-	},
-	"Alternatives": map[string]core.FieldInfos{
-		"alts": {
-			Multi:     true,
-			Reference: false,
-		},
-		"cardinality": {
-			Multi:     false,
-			Reference: false,
-		},
-	},
-	"ArrayType": map[string]core.FieldInfos{
-		"internalType": {
-			Multi:     false,
-			Reference: false,
-		},
-	},
-	"Assignable": map[string]core.FieldInfos{
-		"cardinality": {
-			Multi:     false,
-			Reference: false,
-		},
-	},
-	"Assignment": map[string]core.FieldInfos{
-		"cardinality": {
-			Multi:     false,
-			Reference: false,
-		},
-		"operator": {
-			Multi:     false,
-			Reference: false,
-		},
-		"property": {
-			Multi:     false,
-			Reference: true,
-		},
-		"value": {
-			Multi:     false,
-			Reference: false,
-		},
-	},
-	"CompositeRule": map[string]core.FieldInfos{
-		"body": {
-			Multi:     false,
-			Reference: false,
-		},
-		"name": {
-			Multi:     false,
-			Reference: false,
-		},
-	},
-	"CrossRef": map[string]core.FieldInfos{
-		"cardinality": {
-			Multi:     false,
-			Reference: false,
-		},
-		"rule": {
-			Multi:     false,
-			Reference: false,
-		},
-		"_Type": {
-			Multi:     false,
-			Reference: true,
-		},
-	},
-	"Element": map[string]core.FieldInfos{
-		"cardinality": {
-			Multi:     false,
-			Reference: false,
-		},
-	},
-	"Field": map[string]core.FieldInfos{
-		"name": {
-			Multi:     false,
-			Reference: false,
-		},
-		"_Type": {
-			Multi:     false,
-			Reference: false,
-		},
-	},
-	"FieldType": map[string]core.FieldInfos{},
-	"Grammar": map[string]core.FieldInfos{
-		"composites": {
-			Multi:     true,
-			Reference: false,
-		},
-		"interfaces": {
-			Multi:     true,
-			Reference: false,
-		},
-		"name": {
-			Multi:     false,
-			Reference: false,
-		},
-		"rules": {
-			Multi:     true,
-			Reference: false,
-		},
-		"terminals": {
-			Multi:     true,
-			Reference: false,
-		},
-		"tokenGroups": {
-			Multi:     true,
-			Reference: false,
-		},
-	},
-	"Group": map[string]core.FieldInfos{
-		"cardinality": {
-			Multi:     false,
-			Reference: false,
-		},
-		"elements": {
-			Multi:     true,
-			Reference: false,
-		},
-	},
-	"Interface": map[string]core.FieldInfos{
-		"extends": {
-			Multi:     true,
-			Reference: true,
-		},
-		"fields": {
-			Multi:     true,
-			Reference: false,
-		},
-		"name": {
-			Multi:     false,
-			Reference: false,
-		},
-	},
-	"Keyword": map[string]core.FieldInfos{
-		"cardinality": {
-			Multi:     false,
-			Reference: false,
-		},
-		"value": {
-			Multi:     false,
-			Reference: false,
-		},
-	},
-	"ParserRule": map[string]core.FieldInfos{
-		"body": {
-			Multi:     false,
-			Reference: false,
-		},
-		"entry": {
-			Multi:     false,
-			Reference: false,
-		},
-		"name": {
-			Multi:     false,
-			Reference: false,
-		},
-		"returnType": {
-			Multi:     false,
-			Reference: true,
-		},
-	},
-	"PrimitiveType": map[string]core.FieldInfos{
-		"_Type": {
-			Multi:     false,
-			Reference: false,
-		},
-	},
-	"ReferenceType": map[string]core.FieldInfos{
-		"_Type": {
-			Multi:     false,
-			Reference: true,
-		},
-	},
-	"RuleCall": map[string]core.FieldInfos{
-		"cardinality": {
-			Multi:     false,
-			Reference: false,
-		},
-		"rule": {
-			Multi:     false,
-			Reference: true,
-		},
-	},
-	"SimpleType": map[string]core.FieldInfos{
-		"_Type": {
-			Multi:     false,
-			Reference: true,
-		},
-	},
-	"Token": map[string]core.FieldInfos{
-		"name": {
-			Multi:     false,
-			Reference: false,
-		},
-		"regexp": {
-			Multi:     false,
-			Reference: false,
-		},
-		"_Type": {
-			Multi:     false,
-			Reference: false,
-		},
-	},
-	"TokenGroup": map[string]core.FieldInfos{
-		"keywords": {
-			Multi:     true,
-			Reference: false,
-		},
-		"name": {
-			Multi:     false,
-			Reference: false,
-		},
-		"regexps": {
-			Multi:     true,
-			Reference: false,
-		},
-		"tokenRefs": {
-			Multi:     true,
-			Reference: true,
-		},
-	},
 }

--- a/internal/grammar/types_gen.go
+++ b/internal/grammar/types_gen.go
@@ -4,8 +4,6 @@ package grammar
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
 	"unique"
 
 	core "typefox.dev/fastbelt"
@@ -58,25 +56,25 @@ func NewGrammarData() GrammarData {
 
 func (i *GrammarData) IsGrammar() {}
 
-func (i *GrammarData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *GrammarData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	for j, item := range i.rules {
-		fn(item, fieldNameRules, uint16(j))
+		fn(item, fieldNameRules, j)
 	}
 	for j, item := range i.composites {
-		fn(item, fieldNameComposites, uint16(j))
+		fn(item, fieldNameComposites, j)
 	}
 	for j, item := range i.terminals {
-		fn(item, fieldNameTerminals, uint16(j))
+		fn(item, fieldNameTerminals, j)
 	}
 	for j, item := range i.tokenGroups {
-		fn(item, fieldNameTokenGroups, uint16(j))
+		fn(item, fieldNameTokenGroups, j)
 	}
 	for j, item := range i.interfaces {
-		fn(item, fieldNameInterfaces, uint16(j))
+		fn(item, fieldNameInterfaces, j)
 	}
 }
 
-func (i *GrammarData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *GrammarData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 func (i *GrammarData) Name() string {
@@ -140,137 +138,92 @@ type GrammarImpl struct {
 	GrammarData
 }
 
-func (i *GrammarImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *GrammarImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.GrammarData.ForEachNode(fn)
 }
 
-func (i *GrammarImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *GrammarImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.GrammarData.ForEachReference(fn)
 }
 
-func (i *GrammarImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+func (i *GrammarImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, index := path.Shift()
 	switch field {
 	case fieldNameComposites:
-		return core.FieldInfos{Multi: true, Reference: false}
-	case fieldNameInterfaces:
-		return core.FieldInfos{Multi: true, Reference: false}
-	case fieldNameName:
-		return core.FieldInfos{Multi: false, Reference: false}
-	case fieldNameRules:
-		return core.FieldInfos{Multi: true, Reference: false}
-	case fieldNameTerminals:
-		return core.FieldInfos{Multi: true, Reference: false}
-	case fieldNameTokenGroups:
-		return core.FieldInfos{Multi: true, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *GrammarImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
-	switch field {
-	case fieldNameComposites:
-		index, err := strconv.Atoi(fieldAndIndex[1])
-		if err != nil {
-			return nil, fmt.Errorf("GrammarImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
-		}
 		if index >= len(i.Composites()) {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("GrammarImpl.GetByPath: index %d exceeds length of slice in 'composites' (length=%d) in node '%s'", index, len(i.Composites()), nodePath)
 		}
 		child := i.Composites()[index]
 		if child == nil {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("GrammarImpl.GetByPath: item %d of slice in field 'composites' is nil in node '%s'", index, nodePath)
 		}
-		if len(parts) == 1 {
+		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(parts[1])
+		return child.GetByPath(path)
 	case fieldNameInterfaces:
-		index, err := strconv.Atoi(fieldAndIndex[1])
-		if err != nil {
-			return nil, fmt.Errorf("GrammarImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
-		}
 		if index >= len(i.Interfaces()) {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("GrammarImpl.GetByPath: index %d exceeds length of slice in 'interfaces' (length=%d) in node '%s'", index, len(i.Interfaces()), nodePath)
 		}
 		child := i.Interfaces()[index]
 		if child == nil {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("GrammarImpl.GetByPath: item %d of slice in field 'interfaces' is nil in node '%s'", index, nodePath)
 		}
-		if len(parts) == 1 {
+		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(parts[1])
+		return child.GetByPath(path)
 	case fieldNameRules:
-		index, err := strconv.Atoi(fieldAndIndex[1])
-		if err != nil {
-			return nil, fmt.Errorf("GrammarImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
-		}
 		if index >= len(i.Rules()) {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("GrammarImpl.GetByPath: index %d exceeds length of slice in 'rules' (length=%d) in node '%s'", index, len(i.Rules()), nodePath)
 		}
 		child := i.Rules()[index]
 		if child == nil {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("GrammarImpl.GetByPath: item %d of slice in field 'rules' is nil in node '%s'", index, nodePath)
 		}
-		if len(parts) == 1 {
+		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(parts[1])
+		return child.GetByPath(path)
 	case fieldNameTerminals:
-		index, err := strconv.Atoi(fieldAndIndex[1])
-		if err != nil {
-			return nil, fmt.Errorf("GrammarImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
-		}
 		if index >= len(i.Terminals()) {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("GrammarImpl.GetByPath: index %d exceeds length of slice in 'terminals' (length=%d) in node '%s'", index, len(i.Terminals()), nodePath)
 		}
 		child := i.Terminals()[index]
 		if child == nil {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("GrammarImpl.GetByPath: item %d of slice in field 'terminals' is nil in node '%s'", index, nodePath)
 		}
-		if len(parts) == 1 {
+		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(parts[1])
+		return child.GetByPath(path)
 	case fieldNameTokenGroups:
-		index, err := strconv.Atoi(fieldAndIndex[1])
-		if err != nil {
-			return nil, fmt.Errorf("GrammarImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
-		}
 		if index >= len(i.TokenGroups()) {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("GrammarImpl.GetByPath: index %d exceeds length of slice in 'tokenGroups' (length=%d) in node '%s'", index, len(i.TokenGroups()), nodePath)
 		}
 		child := i.TokenGroups()[index]
 		if child == nil {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("GrammarImpl.GetByPath: item %d of slice in field 'tokenGroups' is nil in node '%s'", index, nodePath)
 		}
-		if len(parts) == 1 {
+		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(parts[1])
+		return child.GetByPath(path)
 	case fieldNameName:
 		return nil, fmt.Errorf("GrammarImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("GrammarImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Grammar'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("GrammarImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Grammar'", field.Value(), nodePath)
 	}
 }
 
@@ -309,15 +262,15 @@ func NewInterfaceData() InterfaceData {
 
 func (i *InterfaceData) IsInterface() {}
 
-func (i *InterfaceData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *InterfaceData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	for j, item := range i.fields {
-		fn(item, fieldNameFields, uint16(j))
+		fn(item, fieldNameFields, j)
 	}
 }
 
-func (i *InterfaceData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *InterfaceData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	for j, item := range i.extends {
-		fn(item, fieldNameExtends, uint16(j))
+		fn(item, fieldNameExtends, j)
 	}
 }
 
@@ -358,61 +311,38 @@ type InterfaceImpl struct {
 	InterfaceData
 }
 
-func (i *InterfaceImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *InterfaceImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.InterfaceData.ForEachNode(fn)
 }
 
-func (i *InterfaceImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *InterfaceImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.InterfaceData.ForEachReference(fn)
 }
 
-func (i *InterfaceImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameExtends:
-		return core.FieldInfos{Multi: true, Reference: true}
-	case fieldNameFields:
-		return core.FieldInfos{Multi: true, Reference: false}
-	case fieldNameName:
-		return core.FieldInfos{Multi: false, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *InterfaceImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *InterfaceImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, index := path.Shift()
 	switch field {
 	case fieldNameFields:
-		index, err := strconv.Atoi(fieldAndIndex[1])
-		if err != nil {
-			return nil, fmt.Errorf("InterfaceImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
-		}
 		if index >= len(i.Fields()) {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("InterfaceImpl.GetByPath: index %d exceeds length of slice in 'fields' (length=%d) in node '%s'", index, len(i.Fields()), nodePath)
 		}
 		child := i.Fields()[index]
 		if child == nil {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("InterfaceImpl.GetByPath: item %d of slice in field 'fields' is nil in node '%s'", index, nodePath)
 		}
-		if len(parts) == 1 {
+		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(parts[1])
+		return child.GetByPath(path)
 	case fieldNameName:
 		return nil, fmt.Errorf("InterfaceImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
 	case fieldNameExtends:
 		return nil, fmt.Errorf("InterfaceImpl.GetByPath: field 'extends' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("InterfaceImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Interface'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("InterfaceImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Interface'", field.Value(), nodePath)
 	}
 }
 
@@ -445,13 +375,13 @@ func NewFieldData() FieldData {
 
 func (i *FieldData) IsField() {}
 
-func (i *FieldData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *FieldData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	if i._Type != nil {
-		fn(i._Type, fieldNameType, 0)
+		fn(i._Type, fieldNameType, -1)
 	}
 }
 
-func (i *FieldData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *FieldData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 func (i *FieldData) Name() string {
@@ -487,49 +417,32 @@ type FieldImpl struct {
 	FieldData
 }
 
-func (i *FieldImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *FieldImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.FieldData.ForEachNode(fn)
 }
 
-func (i *FieldImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *FieldImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.FieldData.ForEachReference(fn)
 }
 
-func (i *FieldImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameName:
-		return core.FieldInfos{Multi: false, Reference: false}
-	case fieldNameType:
-		return core.FieldInfos{Multi: false, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *FieldImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *FieldImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameType:
 		if i.Type() == nil {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("FieldImpl.GetByPath: field '_Type' is nil in node '%s'", nodePath)
 		}
 		child := i.Type()
-		if len(parts) == 1 {
+		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(parts[1])
+		return child.GetByPath(path)
 	case fieldNameName:
 		return nil, fmt.Errorf("FieldImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("FieldImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Field'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("FieldImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Field'", field.Value(), nodePath)
 	}
 }
 
@@ -555,10 +468,10 @@ func NewFieldTypeData() FieldTypeData {
 
 func (i *FieldTypeData) IsFieldType() {}
 
-func (i *FieldTypeData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *FieldTypeData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 }
 
-func (i *FieldTypeData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *FieldTypeData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 type FieldTypeImpl struct {
@@ -566,27 +479,18 @@ type FieldTypeImpl struct {
 	FieldTypeData
 }
 
-func (i *FieldTypeImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *FieldTypeImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.FieldTypeData.ForEachNode(fn)
 }
 
-func (i *FieldTypeImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *FieldTypeImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.FieldTypeData.ForEachReference(fn)
 }
 
-func (i *FieldTypeImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return core.FieldInfos{}
-}
-
-func (i *FieldTypeImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	nodePath, _ := i.AstNodeBase.NodePath()
-	return nil, fmt.Errorf("FieldTypeImpl.GetByPath: field '%s' does not exist in node '%s' of type 'FieldType'", fieldAndIndex[0], nodePath)
+func (i *FieldTypeImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
+	nodePath, _ := core.NodePath(i)
+	return nil, fmt.Errorf("FieldTypeImpl.GetByPath: field '%s' does not exist in node '%s' of type 'FieldType'", field.Value(), nodePath)
 }
 
 type ArrayType interface {
@@ -616,13 +520,13 @@ func NewArrayTypeData() ArrayTypeData {
 
 func (i *ArrayTypeData) IsArrayType() {}
 
-func (i *ArrayTypeData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *ArrayTypeData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	if i.internalType != nil {
-		fn(i.internalType, fieldNameInternalType, 0)
+		fn(i.internalType, fieldNameInternalType, -1)
 	}
 }
 
-func (i *ArrayTypeData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *ArrayTypeData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 func (i *ArrayTypeData) InternalType() FieldType {
@@ -643,47 +547,32 @@ type ArrayTypeImpl struct {
 	ArrayTypeData
 }
 
-func (i *ArrayTypeImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *ArrayTypeImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.FieldTypeData.ForEachNode(fn)
 	i.ArrayTypeData.ForEachNode(fn)
 }
 
-func (i *ArrayTypeImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *ArrayTypeImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.FieldTypeData.ForEachReference(fn)
 	i.ArrayTypeData.ForEachReference(fn)
 }
 
-func (i *ArrayTypeImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameInternalType:
-		return core.FieldInfos{Multi: false, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *ArrayTypeImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *ArrayTypeImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameInternalType:
 		if i.InternalType() == nil {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("ArrayTypeImpl.GetByPath: field 'internalType' is nil in node '%s'", nodePath)
 		}
 		child := i.InternalType()
-		if len(parts) == 1 {
+		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(parts[1])
+		return child.GetByPath(path)
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("ArrayTypeImpl.GetByPath: field '%s' does not exist in node '%s' of type 'ArrayType'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("ArrayTypeImpl.GetByPath: field '%s' does not exist in node '%s' of type 'ArrayType'", field.Value(), nodePath)
 	}
 }
 
@@ -714,12 +603,12 @@ func NewReferenceTypeData() ReferenceTypeData {
 
 func (i *ReferenceTypeData) IsReferenceType() {}
 
-func (i *ReferenceTypeData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *ReferenceTypeData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 }
 
-func (i *ReferenceTypeData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *ReferenceTypeData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	if i._Type != nil {
-		fn(i._Type, fieldNameType, 0)
+		fn(i._Type, fieldNameType, -1)
 	}
 }
 
@@ -741,39 +630,24 @@ type ReferenceTypeImpl struct {
 	ReferenceTypeData
 }
 
-func (i *ReferenceTypeImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *ReferenceTypeImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.FieldTypeData.ForEachNode(fn)
 	i.ReferenceTypeData.ForEachNode(fn)
 }
 
-func (i *ReferenceTypeImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *ReferenceTypeImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.FieldTypeData.ForEachReference(fn)
 	i.ReferenceTypeData.ForEachReference(fn)
 }
 
-func (i *ReferenceTypeImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameType:
-		return core.FieldInfos{Multi: false, Reference: true}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *ReferenceTypeImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *ReferenceTypeImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameType:
 		return nil, fmt.Errorf("ReferenceTypeImpl.GetByPath: field '_Type' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("ReferenceTypeImpl.GetByPath: field '%s' does not exist in node '%s' of type 'ReferenceType'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("ReferenceTypeImpl.GetByPath: field '%s' does not exist in node '%s' of type 'ReferenceType'", field.Value(), nodePath)
 	}
 }
 
@@ -804,12 +678,12 @@ func NewSimpleTypeData() SimpleTypeData {
 
 func (i *SimpleTypeData) IsSimpleType() {}
 
-func (i *SimpleTypeData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *SimpleTypeData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 }
 
-func (i *SimpleTypeData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *SimpleTypeData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	if i._Type != nil {
-		fn(i._Type, fieldNameType, 0)
+		fn(i._Type, fieldNameType, -1)
 	}
 }
 
@@ -831,39 +705,24 @@ type SimpleTypeImpl struct {
 	SimpleTypeData
 }
 
-func (i *SimpleTypeImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *SimpleTypeImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.FieldTypeData.ForEachNode(fn)
 	i.SimpleTypeData.ForEachNode(fn)
 }
 
-func (i *SimpleTypeImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *SimpleTypeImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.FieldTypeData.ForEachReference(fn)
 	i.SimpleTypeData.ForEachReference(fn)
 }
 
-func (i *SimpleTypeImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameType:
-		return core.FieldInfos{Multi: false, Reference: true}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *SimpleTypeImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *SimpleTypeImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameType:
 		return nil, fmt.Errorf("SimpleTypeImpl.GetByPath: field '_Type' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("SimpleTypeImpl.GetByPath: field '%s' does not exist in node '%s' of type 'SimpleType'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("SimpleTypeImpl.GetByPath: field '%s' does not exist in node '%s' of type 'SimpleType'", field.Value(), nodePath)
 	}
 }
 
@@ -895,10 +754,10 @@ func NewPrimitiveTypeData() PrimitiveTypeData {
 
 func (i *PrimitiveTypeData) IsPrimitiveType() {}
 
-func (i *PrimitiveTypeData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *PrimitiveTypeData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 }
 
-func (i *PrimitiveTypeData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *PrimitiveTypeData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 func (i *PrimitiveTypeData) Type() string {
@@ -923,39 +782,24 @@ type PrimitiveTypeImpl struct {
 	PrimitiveTypeData
 }
 
-func (i *PrimitiveTypeImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *PrimitiveTypeImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.FieldTypeData.ForEachNode(fn)
 	i.PrimitiveTypeData.ForEachNode(fn)
 }
 
-func (i *PrimitiveTypeImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *PrimitiveTypeImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.FieldTypeData.ForEachReference(fn)
 	i.PrimitiveTypeData.ForEachReference(fn)
 }
 
-func (i *PrimitiveTypeImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameType:
-		return core.FieldInfos{Multi: false, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *PrimitiveTypeImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *PrimitiveTypeImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameType:
 		return nil, fmt.Errorf("PrimitiveTypeImpl.GetByPath: field '_Type' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("PrimitiveTypeImpl.GetByPath: field '%s' does not exist in node '%s' of type 'PrimitiveType'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("PrimitiveTypeImpl.GetByPath: field '%s' does not exist in node '%s' of type 'PrimitiveType'", field.Value(), nodePath)
 	}
 }
 
@@ -985,10 +829,10 @@ func NewAbstractRuleData() AbstractRuleData {
 
 func (i *AbstractRuleData) IsAbstractRule() {}
 
-func (i *AbstractRuleData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *AbstractRuleData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 }
 
-func (i *AbstractRuleData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *AbstractRuleData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 func (i *AbstractRuleData) Name() string {
@@ -1012,37 +856,22 @@ type AbstractRuleImpl struct {
 	AbstractRuleData
 }
 
-func (i *AbstractRuleImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *AbstractRuleImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.AbstractRuleData.ForEachNode(fn)
 }
 
-func (i *AbstractRuleImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *AbstractRuleImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.AbstractRuleData.ForEachReference(fn)
 }
 
-func (i *AbstractRuleImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameName:
-		return core.FieldInfos{Multi: false, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *AbstractRuleImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *AbstractRuleImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameName:
 		return nil, fmt.Errorf("AbstractRuleImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("AbstractRuleImpl.GetByPath: field '%s' does not exist in node '%s' of type 'AbstractRule'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("AbstractRuleImpl.GetByPath: field '%s' does not exist in node '%s' of type 'AbstractRule'", field.Value(), nodePath)
 	}
 }
 
@@ -1073,13 +902,13 @@ func NewAbstractRuleWithBodyData() AbstractRuleWithBodyData {
 
 func (i *AbstractRuleWithBodyData) IsAbstractRuleWithBody() {}
 
-func (i *AbstractRuleWithBodyData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *AbstractRuleWithBodyData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	if i.body != nil {
-		fn(i.body, fieldNameBody, 0)
+		fn(i.body, fieldNameBody, -1)
 	}
 }
 
-func (i *AbstractRuleWithBodyData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *AbstractRuleWithBodyData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 func (i *AbstractRuleWithBodyData) Body() Element {
@@ -1100,51 +929,34 @@ type AbstractRuleWithBodyImpl struct {
 	AbstractRuleWithBodyData
 }
 
-func (i *AbstractRuleWithBodyImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *AbstractRuleWithBodyImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.AbstractRuleData.ForEachNode(fn)
 	i.AbstractRuleWithBodyData.ForEachNode(fn)
 }
 
-func (i *AbstractRuleWithBodyImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *AbstractRuleWithBodyImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.AbstractRuleData.ForEachReference(fn)
 	i.AbstractRuleWithBodyData.ForEachReference(fn)
 }
 
-func (i *AbstractRuleWithBodyImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameBody:
-		return core.FieldInfos{Multi: false, Reference: false}
-	case fieldNameName:
-		return core.FieldInfos{Multi: false, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *AbstractRuleWithBodyImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *AbstractRuleWithBodyImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameBody:
 		if i.Body() == nil {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("AbstractRuleWithBodyImpl.GetByPath: field 'body' is nil in node '%s'", nodePath)
 		}
 		child := i.Body()
-		if len(parts) == 1 {
+		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(parts[1])
+		return child.GetByPath(path)
 	case fieldNameName:
 		return nil, fmt.Errorf("AbstractRuleWithBodyImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("AbstractRuleWithBodyImpl.GetByPath: field '%s' does not exist in node '%s' of type 'AbstractRuleWithBody'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("AbstractRuleWithBodyImpl.GetByPath: field '%s' does not exist in node '%s' of type 'AbstractRuleWithBody'", field.Value(), nodePath)
 	}
 }
 
@@ -1172,10 +984,10 @@ func NewAbstractTokenRuleData() AbstractTokenRuleData {
 
 func (i *AbstractTokenRuleData) IsAbstractTokenRule() {}
 
-func (i *AbstractTokenRuleData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *AbstractTokenRuleData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 }
 
-func (i *AbstractTokenRuleData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *AbstractTokenRuleData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 type AbstractTokenRuleImpl struct {
@@ -1184,39 +996,24 @@ type AbstractTokenRuleImpl struct {
 	AbstractTokenRuleData
 }
 
-func (i *AbstractTokenRuleImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *AbstractTokenRuleImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.AbstractRuleData.ForEachNode(fn)
 	i.AbstractTokenRuleData.ForEachNode(fn)
 }
 
-func (i *AbstractTokenRuleImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *AbstractTokenRuleImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.AbstractRuleData.ForEachReference(fn)
 	i.AbstractTokenRuleData.ForEachReference(fn)
 }
 
-func (i *AbstractTokenRuleImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameName:
-		return core.FieldInfos{Multi: false, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *AbstractTokenRuleImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *AbstractTokenRuleImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameName:
 		return nil, fmt.Errorf("AbstractTokenRuleImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("AbstractTokenRuleImpl.GetByPath: field '%s' does not exist in node '%s' of type 'AbstractTokenRule'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("AbstractTokenRuleImpl.GetByPath: field '%s' does not exist in node '%s' of type 'AbstractTokenRule'", field.Value(), nodePath)
 	}
 }
 
@@ -1252,12 +1049,12 @@ func NewParserRuleData() ParserRuleData {
 
 func (i *ParserRuleData) IsParserRule() {}
 
-func (i *ParserRuleData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *ParserRuleData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 }
 
-func (i *ParserRuleData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *ParserRuleData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	if i.returnType != nil {
-		fn(i.returnType, fieldNameReturnType, 0)
+		fn(i.returnType, fieldNameReturnType, -1)
 	}
 }
 
@@ -1292,52 +1089,31 @@ type ParserRuleImpl struct {
 	ParserRuleData
 }
 
-func (i *ParserRuleImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *ParserRuleImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.AbstractRuleWithBodyData.ForEachNode(fn)
 	i.AbstractRuleData.ForEachNode(fn)
 	i.ParserRuleData.ForEachNode(fn)
 }
 
-func (i *ParserRuleImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *ParserRuleImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.AbstractRuleWithBodyData.ForEachReference(fn)
 	i.AbstractRuleData.ForEachReference(fn)
 	i.ParserRuleData.ForEachReference(fn)
 }
 
-func (i *ParserRuleImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameBody:
-		return core.FieldInfos{Multi: false, Reference: false}
-	case fieldNameEntry:
-		return core.FieldInfos{Multi: false, Reference: false}
-	case fieldNameName:
-		return core.FieldInfos{Multi: false, Reference: false}
-	case fieldNameReturnType:
-		return core.FieldInfos{Multi: false, Reference: true}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *ParserRuleImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *ParserRuleImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameBody:
 		if i.Body() == nil {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("ParserRuleImpl.GetByPath: field 'body' is nil in node '%s'", nodePath)
 		}
 		child := i.Body()
-		if len(parts) == 1 {
+		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(parts[1])
+		return child.GetByPath(path)
 	case fieldNameEntry:
 		return nil, fmt.Errorf("ParserRuleImpl.GetByPath: field 'entry' holds a primitive value instead of an ast node")
 	case fieldNameName:
@@ -1345,8 +1121,8 @@ func (i *ParserRuleImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameReturnType:
 		return nil, fmt.Errorf("ParserRuleImpl.GetByPath: field 'returnType' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("ParserRuleImpl.GetByPath: field '%s' does not exist in node '%s' of type 'ParserRule'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("ParserRuleImpl.GetByPath: field '%s' does not exist in node '%s' of type 'ParserRule'", field.Value(), nodePath)
 	}
 }
 
@@ -1383,10 +1159,10 @@ func NewTokenData() TokenData {
 
 func (i *TokenData) IsToken() {}
 
-func (i *TokenData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *TokenData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 }
 
-func (i *TokenData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *TokenData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 func (i *TokenData) Type() string {
@@ -1428,39 +1204,20 @@ type TokenImpl struct {
 	TokenData
 }
 
-func (i *TokenImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *TokenImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.AbstractTokenRuleData.ForEachNode(fn)
 	i.AbstractRuleData.ForEachNode(fn)
 	i.TokenData.ForEachNode(fn)
 }
 
-func (i *TokenImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *TokenImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.AbstractTokenRuleData.ForEachReference(fn)
 	i.AbstractRuleData.ForEachReference(fn)
 	i.TokenData.ForEachReference(fn)
 }
 
-func (i *TokenImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameName:
-		return core.FieldInfos{Multi: false, Reference: false}
-	case fieldNameRegexp:
-		return core.FieldInfos{Multi: false, Reference: false}
-	case fieldNameType:
-		return core.FieldInfos{Multi: false, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *TokenImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *TokenImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameName:
 		return nil, fmt.Errorf("TokenImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
@@ -1469,8 +1226,8 @@ func (i *TokenImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameType:
 		return nil, fmt.Errorf("TokenImpl.GetByPath: field '_Type' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("TokenImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Token'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("TokenImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Token'", field.Value(), nodePath)
 	}
 }
 
@@ -1512,15 +1269,15 @@ func NewTokenGroupData() TokenGroupData {
 
 func (i *TokenGroupData) IsTokenGroup() {}
 
-func (i *TokenGroupData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *TokenGroupData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	for j, item := range i.keywords {
-		fn(item, fieldNameKeywords, uint16(j))
+		fn(item, fieldNameKeywords, j)
 	}
 }
 
-func (i *TokenGroupData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *TokenGroupData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	for j, item := range i.tokenRefs {
-		fn(item, fieldNameTokenRefs, uint16(j))
+		fn(item, fieldNameTokenRefs, j)
 	}
 }
 
@@ -1555,60 +1312,35 @@ type TokenGroupImpl struct {
 	TokenGroupData
 }
 
-func (i *TokenGroupImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *TokenGroupImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.AbstractTokenRuleData.ForEachNode(fn)
 	i.AbstractRuleData.ForEachNode(fn)
 	i.TokenGroupData.ForEachNode(fn)
 }
 
-func (i *TokenGroupImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *TokenGroupImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.AbstractTokenRuleData.ForEachReference(fn)
 	i.AbstractRuleData.ForEachReference(fn)
 	i.TokenGroupData.ForEachReference(fn)
 }
 
-func (i *TokenGroupImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+func (i *TokenGroupImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, index := path.Shift()
 	switch field {
 	case fieldNameKeywords:
-		return core.FieldInfos{Multi: true, Reference: false}
-	case fieldNameName:
-		return core.FieldInfos{Multi: false, Reference: false}
-	case fieldNameRegexps:
-		return core.FieldInfos{Multi: true, Reference: false}
-	case fieldNameTokenRefs:
-		return core.FieldInfos{Multi: true, Reference: true}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *TokenGroupImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
-	switch field {
-	case fieldNameKeywords:
-		index, err := strconv.Atoi(fieldAndIndex[1])
-		if err != nil {
-			return nil, fmt.Errorf("TokenGroupImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
-		}
 		if index >= len(i.Keywords()) {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("TokenGroupImpl.GetByPath: index %d exceeds length of slice in 'keywords' (length=%d) in node '%s'", index, len(i.Keywords()), nodePath)
 		}
 		child := i.Keywords()[index]
 		if child == nil {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("TokenGroupImpl.GetByPath: item %d of slice in field 'keywords' is nil in node '%s'", index, nodePath)
 		}
-		if len(parts) == 1 {
+		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(parts[1])
+		return child.GetByPath(path)
 	case fieldNameName:
 		return nil, fmt.Errorf("TokenGroupImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
 	case fieldNameRegexps:
@@ -1616,8 +1348,8 @@ func (i *TokenGroupImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameTokenRefs:
 		return nil, fmt.Errorf("TokenGroupImpl.GetByPath: field 'tokenRefs' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("TokenGroupImpl.GetByPath: field '%s' does not exist in node '%s' of type 'TokenGroup'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("TokenGroupImpl.GetByPath: field '%s' does not exist in node '%s' of type 'TokenGroup'", field.Value(), nodePath)
 	}
 }
 
@@ -1647,10 +1379,10 @@ func NewElementData() ElementData {
 
 func (i *ElementData) IsElement() {}
 
-func (i *ElementData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *ElementData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 }
 
-func (i *ElementData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *ElementData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 func (i *ElementData) Cardinality() string {
@@ -1674,37 +1406,22 @@ type ElementImpl struct {
 	ElementData
 }
 
-func (i *ElementImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *ElementImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.ElementData.ForEachNode(fn)
 }
 
-func (i *ElementImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *ElementImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.ElementData.ForEachReference(fn)
 }
 
-func (i *ElementImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameCardinality:
-		return core.FieldInfos{Multi: false, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *ElementImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *ElementImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameCardinality:
 		return nil, fmt.Errorf("ElementImpl.GetByPath: field 'cardinality' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("ElementImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Element'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("ElementImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Element'", field.Value(), nodePath)
 	}
 }
 
@@ -1738,13 +1455,13 @@ func NewAlternativesData() AlternativesData {
 
 func (i *AlternativesData) IsAlternatives() {}
 
-func (i *AlternativesData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *AlternativesData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	for j, item := range i.alts {
-		fn(item, fieldNameAlts, uint16(j))
+		fn(item, fieldNameAlts, j)
 	}
 }
 
-func (i *AlternativesData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *AlternativesData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 func (i *AlternativesData) Alts() []Element {
@@ -1762,61 +1479,40 @@ type AlternativesImpl struct {
 	AlternativesData
 }
 
-func (i *AlternativesImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *AlternativesImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.AssignableData.ForEachNode(fn)
 	i.ElementData.ForEachNode(fn)
 	i.AlternativesData.ForEachNode(fn)
 }
 
-func (i *AlternativesImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *AlternativesImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.AssignableData.ForEachReference(fn)
 	i.ElementData.ForEachReference(fn)
 	i.AlternativesData.ForEachReference(fn)
 }
 
-func (i *AlternativesImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+func (i *AlternativesImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, index := path.Shift()
 	switch field {
 	case fieldNameAlts:
-		return core.FieldInfos{Multi: true, Reference: false}
-	case fieldNameCardinality:
-		return core.FieldInfos{Multi: false, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *AlternativesImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
-	switch field {
-	case fieldNameAlts:
-		index, err := strconv.Atoi(fieldAndIndex[1])
-		if err != nil {
-			return nil, fmt.Errorf("AlternativesImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
-		}
 		if index >= len(i.Alts()) {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("AlternativesImpl.GetByPath: index %d exceeds length of slice in 'alts' (length=%d) in node '%s'", index, len(i.Alts()), nodePath)
 		}
 		child := i.Alts()[index]
 		if child == nil {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("AlternativesImpl.GetByPath: item %d of slice in field 'alts' is nil in node '%s'", index, nodePath)
 		}
-		if len(parts) == 1 {
+		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(parts[1])
+		return child.GetByPath(path)
 	case fieldNameCardinality:
 		return nil, fmt.Errorf("AlternativesImpl.GetByPath: field 'cardinality' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("AlternativesImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Alternatives'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("AlternativesImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Alternatives'", field.Value(), nodePath)
 	}
 }
 
@@ -1849,13 +1545,13 @@ func NewGroupData() GroupData {
 
 func (i *GroupData) IsGroup() {}
 
-func (i *GroupData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *GroupData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	for j, item := range i.elements {
-		fn(item, fieldNameElements, uint16(j))
+		fn(item, fieldNameElements, j)
 	}
 }
 
-func (i *GroupData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *GroupData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 func (i *GroupData) Elements() []Element {
@@ -1872,59 +1568,38 @@ type GroupImpl struct {
 	GroupData
 }
 
-func (i *GroupImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *GroupImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.ElementData.ForEachNode(fn)
 	i.GroupData.ForEachNode(fn)
 }
 
-func (i *GroupImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *GroupImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.ElementData.ForEachReference(fn)
 	i.GroupData.ForEachReference(fn)
 }
 
-func (i *GroupImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameCardinality:
-		return core.FieldInfos{Multi: false, Reference: false}
-	case fieldNameElements:
-		return core.FieldInfos{Multi: true, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *GroupImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *GroupImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, index := path.Shift()
 	switch field {
 	case fieldNameElements:
-		index, err := strconv.Atoi(fieldAndIndex[1])
-		if err != nil {
-			return nil, fmt.Errorf("GroupImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
-		}
 		if index >= len(i.Elements()) {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("GroupImpl.GetByPath: index %d exceeds length of slice in 'elements' (length=%d) in node '%s'", index, len(i.Elements()), nodePath)
 		}
 		child := i.Elements()[index]
 		if child == nil {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("GroupImpl.GetByPath: item %d of slice in field 'elements' is nil in node '%s'", index, nodePath)
 		}
-		if len(parts) == 1 {
+		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(parts[1])
+		return child.GetByPath(path)
 	case fieldNameCardinality:
 		return nil, fmt.Errorf("GroupImpl.GetByPath: field 'cardinality' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("GroupImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Group'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("GroupImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Group'", field.Value(), nodePath)
 	}
 }
 
@@ -1957,10 +1632,10 @@ func NewKeywordData() KeywordData {
 
 func (i *KeywordData) IsKeyword() {}
 
-func (i *KeywordData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *KeywordData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 }
 
-func (i *KeywordData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *KeywordData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 func (i *KeywordData) Value() string {
@@ -1986,45 +1661,28 @@ type KeywordImpl struct {
 	KeywordData
 }
 
-func (i *KeywordImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *KeywordImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.AssignableData.ForEachNode(fn)
 	i.ElementData.ForEachNode(fn)
 	i.KeywordData.ForEachNode(fn)
 }
 
-func (i *KeywordImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *KeywordImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.AssignableData.ForEachReference(fn)
 	i.ElementData.ForEachReference(fn)
 	i.KeywordData.ForEachReference(fn)
 }
 
-func (i *KeywordImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameCardinality:
-		return core.FieldInfos{Multi: false, Reference: false}
-	case fieldNameValue:
-		return core.FieldInfos{Multi: false, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *KeywordImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *KeywordImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameCardinality:
 		return nil, fmt.Errorf("KeywordImpl.GetByPath: field 'cardinality' holds a primitive value instead of an ast node")
 	case fieldNameValue:
 		return nil, fmt.Errorf("KeywordImpl.GetByPath: field 'value' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("KeywordImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Keyword'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("KeywordImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Keyword'", field.Value(), nodePath)
 	}
 }
 
@@ -2062,15 +1720,15 @@ func NewAssignmentData() AssignmentData {
 
 func (i *AssignmentData) IsAssignment() {}
 
-func (i *AssignmentData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *AssignmentData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	if i.value != nil {
-		fn(i.value, fieldNameValue, 0)
+		fn(i.value, fieldNameValue, -1)
 	}
 }
 
-func (i *AssignmentData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *AssignmentData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	if i.property != nil {
-		fn(i.property, fieldNameProperty, 0)
+		fn(i.property, fieldNameProperty, -1)
 	}
 }
 
@@ -2120,50 +1778,29 @@ type AssignmentImpl struct {
 	AssignmentData
 }
 
-func (i *AssignmentImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *AssignmentImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.ElementData.ForEachNode(fn)
 	i.AssignmentData.ForEachNode(fn)
 }
 
-func (i *AssignmentImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *AssignmentImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.ElementData.ForEachReference(fn)
 	i.AssignmentData.ForEachReference(fn)
 }
 
-func (i *AssignmentImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameCardinality:
-		return core.FieldInfos{Multi: false, Reference: false}
-	case fieldNameOperator:
-		return core.FieldInfos{Multi: false, Reference: false}
-	case fieldNameProperty:
-		return core.FieldInfos{Multi: false, Reference: true}
-	case fieldNameValue:
-		return core.FieldInfos{Multi: false, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *AssignmentImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *AssignmentImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameValue:
 		if i.Value() == nil {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("AssignmentImpl.GetByPath: field 'value' is nil in node '%s'", nodePath)
 		}
 		child := i.Value()
-		if len(parts) == 1 {
+		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(parts[1])
+		return child.GetByPath(path)
 	case fieldNameCardinality:
 		return nil, fmt.Errorf("AssignmentImpl.GetByPath: field 'cardinality' holds a primitive value instead of an ast node")
 	case fieldNameOperator:
@@ -2171,8 +1808,8 @@ func (i *AssignmentImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameProperty:
 		return nil, fmt.Errorf("AssignmentImpl.GetByPath: field 'property' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("AssignmentImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Assignment'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("AssignmentImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Assignment'", field.Value(), nodePath)
 	}
 }
 
@@ -2200,10 +1837,10 @@ func NewAssignableData() AssignableData {
 
 func (i *AssignableData) IsAssignable() {}
 
-func (i *AssignableData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *AssignableData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 }
 
-func (i *AssignableData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *AssignableData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 type AssignableImpl struct {
@@ -2212,39 +1849,24 @@ type AssignableImpl struct {
 	AssignableData
 }
 
-func (i *AssignableImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *AssignableImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.ElementData.ForEachNode(fn)
 	i.AssignableData.ForEachNode(fn)
 }
 
-func (i *AssignableImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *AssignableImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.ElementData.ForEachReference(fn)
 	i.AssignableData.ForEachReference(fn)
 }
 
-func (i *AssignableImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameCardinality:
-		return core.FieldInfos{Multi: false, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *AssignableImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *AssignableImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameCardinality:
 		return nil, fmt.Errorf("AssignableImpl.GetByPath: field 'cardinality' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("AssignableImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Assignable'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("AssignableImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Assignable'", field.Value(), nodePath)
 	}
 }
 
@@ -2279,15 +1901,15 @@ func NewCrossRefData() CrossRefData {
 
 func (i *CrossRefData) IsCrossRef() {}
 
-func (i *CrossRefData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *CrossRefData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	if i.rule != nil {
-		fn(i.rule, fieldNameRule, 0)
+		fn(i.rule, fieldNameRule, -1)
 	}
 }
 
-func (i *CrossRefData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *CrossRefData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	if i._Type != nil {
-		fn(i._Type, fieldNameType, 0)
+		fn(i._Type, fieldNameType, -1)
 	}
 }
 
@@ -2322,57 +1944,38 @@ type CrossRefImpl struct {
 	CrossRefData
 }
 
-func (i *CrossRefImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *CrossRefImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.AssignableData.ForEachNode(fn)
 	i.ElementData.ForEachNode(fn)
 	i.CrossRefData.ForEachNode(fn)
 }
 
-func (i *CrossRefImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *CrossRefImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.AssignableData.ForEachReference(fn)
 	i.ElementData.ForEachReference(fn)
 	i.CrossRefData.ForEachReference(fn)
 }
 
-func (i *CrossRefImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameCardinality:
-		return core.FieldInfos{Multi: false, Reference: false}
-	case fieldNameRule:
-		return core.FieldInfos{Multi: false, Reference: false}
-	case fieldNameType:
-		return core.FieldInfos{Multi: false, Reference: true}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *CrossRefImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *CrossRefImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameRule:
 		if i.Rule() == nil {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("CrossRefImpl.GetByPath: field 'rule' is nil in node '%s'", nodePath)
 		}
 		child := i.Rule()
-		if len(parts) == 1 {
+		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(parts[1])
+		return child.GetByPath(path)
 	case fieldNameCardinality:
 		return nil, fmt.Errorf("CrossRefImpl.GetByPath: field 'cardinality' holds a primitive value instead of an ast node")
 	case fieldNameType:
 		return nil, fmt.Errorf("CrossRefImpl.GetByPath: field '_Type' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("CrossRefImpl.GetByPath: field '%s' does not exist in node '%s' of type 'CrossRef'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("CrossRefImpl.GetByPath: field '%s' does not exist in node '%s' of type 'CrossRef'", field.Value(), nodePath)
 	}
 }
 
@@ -2404,12 +2007,12 @@ func NewRuleCallData() RuleCallData {
 
 func (i *RuleCallData) IsRuleCall() {}
 
-func (i *RuleCallData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *RuleCallData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 }
 
-func (i *RuleCallData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *RuleCallData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	if i.rule != nil {
-		fn(i.rule, fieldNameRule, 0)
+		fn(i.rule, fieldNameRule, -1)
 	}
 }
 
@@ -2432,45 +2035,28 @@ type RuleCallImpl struct {
 	RuleCallData
 }
 
-func (i *RuleCallImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *RuleCallImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.AssignableData.ForEachNode(fn)
 	i.ElementData.ForEachNode(fn)
 	i.RuleCallData.ForEachNode(fn)
 }
 
-func (i *RuleCallImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *RuleCallImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.AssignableData.ForEachReference(fn)
 	i.ElementData.ForEachReference(fn)
 	i.RuleCallData.ForEachReference(fn)
 }
 
-func (i *RuleCallImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameCardinality:
-		return core.FieldInfos{Multi: false, Reference: false}
-	case fieldNameRule:
-		return core.FieldInfos{Multi: false, Reference: true}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *RuleCallImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *RuleCallImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameCardinality:
 		return nil, fmt.Errorf("RuleCallImpl.GetByPath: field 'cardinality' holds a primitive value instead of an ast node")
 	case fieldNameRule:
 		return nil, fmt.Errorf("RuleCallImpl.GetByPath: field 'rule' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("RuleCallImpl.GetByPath: field '%s' does not exist in node '%s' of type 'RuleCall'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("RuleCallImpl.GetByPath: field '%s' does not exist in node '%s' of type 'RuleCall'", field.Value(), nodePath)
 	}
 }
 
@@ -2508,15 +2094,15 @@ func NewActionData() ActionData {
 
 func (i *ActionData) IsAction() {}
 
-func (i *ActionData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *ActionData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 }
 
-func (i *ActionData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *ActionData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	if i._Type != nil {
-		fn(i._Type, fieldNameType, 0)
+		fn(i._Type, fieldNameType, -1)
 	}
 	if i.property != nil {
-		fn(i.property, fieldNameProperty, 0)
+		fn(i.property, fieldNameProperty, -1)
 	}
 }
 
@@ -2566,39 +2152,18 @@ type ActionImpl struct {
 	ActionData
 }
 
-func (i *ActionImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *ActionImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.ElementData.ForEachNode(fn)
 	i.ActionData.ForEachNode(fn)
 }
 
-func (i *ActionImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *ActionImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.ElementData.ForEachReference(fn)
 	i.ActionData.ForEachReference(fn)
 }
 
-func (i *ActionImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameCardinality:
-		return core.FieldInfos{Multi: false, Reference: false}
-	case fieldNameOperator:
-		return core.FieldInfos{Multi: false, Reference: false}
-	case fieldNameProperty:
-		return core.FieldInfos{Multi: false, Reference: true}
-	case fieldNameType:
-		return core.FieldInfos{Multi: false, Reference: true}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *ActionImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *ActionImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameCardinality:
 		return nil, fmt.Errorf("ActionImpl.GetByPath: field 'cardinality' holds a primitive value instead of an ast node")
@@ -2609,8 +2174,8 @@ func (i *ActionImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameType:
 		return nil, fmt.Errorf("ActionImpl.GetByPath: field '_Type' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("ActionImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Action'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("ActionImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Action'", field.Value(), nodePath)
 	}
 }
 
@@ -2639,10 +2204,10 @@ func NewCompositeRuleData() CompositeRuleData {
 
 func (i *CompositeRuleData) IsCompositeRule() {}
 
-func (i *CompositeRuleData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *CompositeRuleData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 }
 
-func (i *CompositeRuleData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *CompositeRuleData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 type CompositeRuleImpl struct {
@@ -2652,53 +2217,36 @@ type CompositeRuleImpl struct {
 	CompositeRuleData
 }
 
-func (i *CompositeRuleImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *CompositeRuleImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.AbstractRuleWithBodyData.ForEachNode(fn)
 	i.AbstractRuleData.ForEachNode(fn)
 	i.CompositeRuleData.ForEachNode(fn)
 }
 
-func (i *CompositeRuleImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *CompositeRuleImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.AbstractRuleWithBodyData.ForEachReference(fn)
 	i.AbstractRuleData.ForEachReference(fn)
 	i.CompositeRuleData.ForEachReference(fn)
 }
 
-func (i *CompositeRuleImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameBody:
-		return core.FieldInfos{Multi: false, Reference: false}
-	case fieldNameName:
-		return core.FieldInfos{Multi: false, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *CompositeRuleImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *CompositeRuleImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameBody:
 		if i.Body() == nil {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("CompositeRuleImpl.GetByPath: field 'body' is nil in node '%s'", nodePath)
 		}
 		child := i.Body()
-		if len(parts) == 1 {
+		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(parts[1])
+		return child.GetByPath(path)
 	case fieldNameName:
 		return nil, fmt.Errorf("CompositeRuleImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("CompositeRuleImpl.GetByPath: field '%s' does not exist in node '%s' of type 'CompositeRule'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("CompositeRuleImpl.GetByPath: field '%s' does not exist in node '%s' of type 'CompositeRule'", field.Value(), nodePath)
 	}
 }
 

--- a/internal/grammar/types_gen.go
+++ b/internal/grammar/types_gen.go
@@ -147,7 +147,10 @@ func (i *GrammarImpl) ForEachReference(fn func(core.UntypedReference, unique.Han
 }
 
 func (i *GrammarImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, index := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, index := path.Head()
 	switch field {
 	case fieldNameComposites:
 		if index >= len(i.Composites()) {
@@ -159,10 +162,7 @@ func (i *GrammarImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 			nodePath, _ := core.PathOf(i)
 			return nil, fmt.Errorf("GrammarImpl.Resolve: item %d of slice in field 'composites' is nil in node '%s'", index, nodePath)
 		}
-		if path.Empty() {
-			return child, nil
-		}
-		return child.Resolve(path)
+		return child.Resolve(path.Tail())
 	case fieldNameInterfaces:
 		if index >= len(i.Interfaces()) {
 			nodePath, _ := core.PathOf(i)
@@ -173,10 +173,7 @@ func (i *GrammarImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 			nodePath, _ := core.PathOf(i)
 			return nil, fmt.Errorf("GrammarImpl.Resolve: item %d of slice in field 'interfaces' is nil in node '%s'", index, nodePath)
 		}
-		if path.Empty() {
-			return child, nil
-		}
-		return child.Resolve(path)
+		return child.Resolve(path.Tail())
 	case fieldNameRules:
 		if index >= len(i.Rules()) {
 			nodePath, _ := core.PathOf(i)
@@ -187,10 +184,7 @@ func (i *GrammarImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 			nodePath, _ := core.PathOf(i)
 			return nil, fmt.Errorf("GrammarImpl.Resolve: item %d of slice in field 'rules' is nil in node '%s'", index, nodePath)
 		}
-		if path.Empty() {
-			return child, nil
-		}
-		return child.Resolve(path)
+		return child.Resolve(path.Tail())
 	case fieldNameTerminals:
 		if index >= len(i.Terminals()) {
 			nodePath, _ := core.PathOf(i)
@@ -201,10 +195,7 @@ func (i *GrammarImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 			nodePath, _ := core.PathOf(i)
 			return nil, fmt.Errorf("GrammarImpl.Resolve: item %d of slice in field 'terminals' is nil in node '%s'", index, nodePath)
 		}
-		if path.Empty() {
-			return child, nil
-		}
-		return child.Resolve(path)
+		return child.Resolve(path.Tail())
 	case fieldNameTokenGroups:
 		if index >= len(i.TokenGroups()) {
 			nodePath, _ := core.PathOf(i)
@@ -215,10 +206,7 @@ func (i *GrammarImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 			nodePath, _ := core.PathOf(i)
 			return nil, fmt.Errorf("GrammarImpl.Resolve: item %d of slice in field 'tokenGroups' is nil in node '%s'", index, nodePath)
 		}
-		if path.Empty() {
-			return child, nil
-		}
-		return child.Resolve(path)
+		return child.Resolve(path.Tail())
 	case fieldNameName:
 		return nil, fmt.Errorf("GrammarImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
 	default:
@@ -320,7 +308,10 @@ func (i *InterfaceImpl) ForEachReference(fn func(core.UntypedReference, unique.H
 }
 
 func (i *InterfaceImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, index := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, index := path.Head()
 	switch field {
 	case fieldNameFields:
 		if index >= len(i.Fields()) {
@@ -332,10 +323,7 @@ func (i *InterfaceImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 			nodePath, _ := core.PathOf(i)
 			return nil, fmt.Errorf("InterfaceImpl.Resolve: item %d of slice in field 'fields' is nil in node '%s'", index, nodePath)
 		}
-		if path.Empty() {
-			return child, nil
-		}
-		return child.Resolve(path)
+		return child.Resolve(path.Tail())
 	case fieldNameName:
 		return nil, fmt.Errorf("InterfaceImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
 	case fieldNameExtends:
@@ -426,7 +414,10 @@ func (i *FieldImpl) ForEachReference(fn func(core.UntypedReference, unique.Handl
 }
 
 func (i *FieldImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameType:
 		if i.Type() == nil {
@@ -434,10 +425,7 @@ func (i *FieldImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 			return nil, fmt.Errorf("FieldImpl.Resolve: field '_Type' is nil in node '%s'", nodePath)
 		}
 		child := i.Type()
-		if path.Empty() {
-			return child, nil
-		}
-		return child.Resolve(path)
+		return child.Resolve(path.Tail())
 	case fieldNameName:
 		return nil, fmt.Errorf("FieldImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
 	default:
@@ -488,7 +476,10 @@ func (i *FieldTypeImpl) ForEachReference(fn func(core.UntypedReference, unique.H
 }
 
 func (i *FieldTypeImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	nodePath, _ := core.PathOf(i)
 	return nil, fmt.Errorf("FieldTypeImpl.Resolve: field '%s' does not exist in node '%s' of type 'FieldType'", field.Value(), nodePath)
 }
@@ -558,7 +549,10 @@ func (i *ArrayTypeImpl) ForEachReference(fn func(core.UntypedReference, unique.H
 }
 
 func (i *ArrayTypeImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameInternalType:
 		if i.InternalType() == nil {
@@ -566,10 +560,7 @@ func (i *ArrayTypeImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 			return nil, fmt.Errorf("ArrayTypeImpl.Resolve: field 'internalType' is nil in node '%s'", nodePath)
 		}
 		child := i.InternalType()
-		if path.Empty() {
-			return child, nil
-		}
-		return child.Resolve(path)
+		return child.Resolve(path.Tail())
 	default:
 		nodePath, _ := core.PathOf(i)
 		return nil, fmt.Errorf("ArrayTypeImpl.Resolve: field '%s' does not exist in node '%s' of type 'ArrayType'", field.Value(), nodePath)
@@ -641,7 +632,10 @@ func (i *ReferenceTypeImpl) ForEachReference(fn func(core.UntypedReference, uniq
 }
 
 func (i *ReferenceTypeImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameType:
 		return nil, fmt.Errorf("ReferenceTypeImpl.Resolve: field '_Type' is a cross-reference instead of a container field")
@@ -716,7 +710,10 @@ func (i *SimpleTypeImpl) ForEachReference(fn func(core.UntypedReference, unique.
 }
 
 func (i *SimpleTypeImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameType:
 		return nil, fmt.Errorf("SimpleTypeImpl.Resolve: field '_Type' is a cross-reference instead of a container field")
@@ -793,7 +790,10 @@ func (i *PrimitiveTypeImpl) ForEachReference(fn func(core.UntypedReference, uniq
 }
 
 func (i *PrimitiveTypeImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameType:
 		return nil, fmt.Errorf("PrimitiveTypeImpl.Resolve: field '_Type' holds a primitive value instead of an ast node")
@@ -865,7 +865,10 @@ func (i *AbstractRuleImpl) ForEachReference(fn func(core.UntypedReference, uniqu
 }
 
 func (i *AbstractRuleImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameName:
 		return nil, fmt.Errorf("AbstractRuleImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
@@ -940,7 +943,10 @@ func (i *AbstractRuleWithBodyImpl) ForEachReference(fn func(core.UntypedReferenc
 }
 
 func (i *AbstractRuleWithBodyImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameBody:
 		if i.Body() == nil {
@@ -948,10 +954,7 @@ func (i *AbstractRuleWithBodyImpl) Resolve(path core.FragmentPath) (core.AstNode
 			return nil, fmt.Errorf("AbstractRuleWithBodyImpl.Resolve: field 'body' is nil in node '%s'", nodePath)
 		}
 		child := i.Body()
-		if path.Empty() {
-			return child, nil
-		}
-		return child.Resolve(path)
+		return child.Resolve(path.Tail())
 	case fieldNameName:
 		return nil, fmt.Errorf("AbstractRuleWithBodyImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
 	default:
@@ -1007,7 +1010,10 @@ func (i *AbstractTokenRuleImpl) ForEachReference(fn func(core.UntypedReference, 
 }
 
 func (i *AbstractTokenRuleImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameName:
 		return nil, fmt.Errorf("AbstractTokenRuleImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
@@ -1102,7 +1108,10 @@ func (i *ParserRuleImpl) ForEachReference(fn func(core.UntypedReference, unique.
 }
 
 func (i *ParserRuleImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameBody:
 		if i.Body() == nil {
@@ -1110,10 +1119,7 @@ func (i *ParserRuleImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 			return nil, fmt.Errorf("ParserRuleImpl.Resolve: field 'body' is nil in node '%s'", nodePath)
 		}
 		child := i.Body()
-		if path.Empty() {
-			return child, nil
-		}
-		return child.Resolve(path)
+		return child.Resolve(path.Tail())
 	case fieldNameEntry:
 		return nil, fmt.Errorf("ParserRuleImpl.Resolve: field 'entry' holds a primitive value instead of an ast node")
 	case fieldNameName:
@@ -1217,7 +1223,10 @@ func (i *TokenImpl) ForEachReference(fn func(core.UntypedReference, unique.Handl
 }
 
 func (i *TokenImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameName:
 		return nil, fmt.Errorf("TokenImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
@@ -1325,7 +1334,10 @@ func (i *TokenGroupImpl) ForEachReference(fn func(core.UntypedReference, unique.
 }
 
 func (i *TokenGroupImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, index := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, index := path.Head()
 	switch field {
 	case fieldNameKeywords:
 		if index >= len(i.Keywords()) {
@@ -1337,10 +1349,7 @@ func (i *TokenGroupImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 			nodePath, _ := core.PathOf(i)
 			return nil, fmt.Errorf("TokenGroupImpl.Resolve: item %d of slice in field 'keywords' is nil in node '%s'", index, nodePath)
 		}
-		if path.Empty() {
-			return child, nil
-		}
-		return child.Resolve(path)
+		return child.Resolve(path.Tail())
 	case fieldNameName:
 		return nil, fmt.Errorf("TokenGroupImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
 	case fieldNameRegexps:
@@ -1415,7 +1424,10 @@ func (i *ElementImpl) ForEachReference(fn func(core.UntypedReference, unique.Han
 }
 
 func (i *ElementImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameCardinality:
 		return nil, fmt.Errorf("ElementImpl.Resolve: field 'cardinality' holds a primitive value instead of an ast node")
@@ -1492,7 +1504,10 @@ func (i *AlternativesImpl) ForEachReference(fn func(core.UntypedReference, uniqu
 }
 
 func (i *AlternativesImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, index := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, index := path.Head()
 	switch field {
 	case fieldNameAlts:
 		if index >= len(i.Alts()) {
@@ -1504,10 +1519,7 @@ func (i *AlternativesImpl) Resolve(path core.FragmentPath) (core.AstNode, error)
 			nodePath, _ := core.PathOf(i)
 			return nil, fmt.Errorf("AlternativesImpl.Resolve: item %d of slice in field 'alts' is nil in node '%s'", index, nodePath)
 		}
-		if path.Empty() {
-			return child, nil
-		}
-		return child.Resolve(path)
+		return child.Resolve(path.Tail())
 	case fieldNameCardinality:
 		return nil, fmt.Errorf("AlternativesImpl.Resolve: field 'cardinality' holds a primitive value instead of an ast node")
 	default:
@@ -1579,7 +1591,10 @@ func (i *GroupImpl) ForEachReference(fn func(core.UntypedReference, unique.Handl
 }
 
 func (i *GroupImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, index := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, index := path.Head()
 	switch field {
 	case fieldNameElements:
 		if index >= len(i.Elements()) {
@@ -1591,10 +1606,7 @@ func (i *GroupImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 			nodePath, _ := core.PathOf(i)
 			return nil, fmt.Errorf("GroupImpl.Resolve: item %d of slice in field 'elements' is nil in node '%s'", index, nodePath)
 		}
-		if path.Empty() {
-			return child, nil
-		}
-		return child.Resolve(path)
+		return child.Resolve(path.Tail())
 	case fieldNameCardinality:
 		return nil, fmt.Errorf("GroupImpl.Resolve: field 'cardinality' holds a primitive value instead of an ast node")
 	default:
@@ -1674,7 +1686,10 @@ func (i *KeywordImpl) ForEachReference(fn func(core.UntypedReference, unique.Han
 }
 
 func (i *KeywordImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameCardinality:
 		return nil, fmt.Errorf("KeywordImpl.Resolve: field 'cardinality' holds a primitive value instead of an ast node")
@@ -1789,7 +1804,10 @@ func (i *AssignmentImpl) ForEachReference(fn func(core.UntypedReference, unique.
 }
 
 func (i *AssignmentImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameValue:
 		if i.Value() == nil {
@@ -1797,10 +1815,7 @@ func (i *AssignmentImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 			return nil, fmt.Errorf("AssignmentImpl.Resolve: field 'value' is nil in node '%s'", nodePath)
 		}
 		child := i.Value()
-		if path.Empty() {
-			return child, nil
-		}
-		return child.Resolve(path)
+		return child.Resolve(path.Tail())
 	case fieldNameCardinality:
 		return nil, fmt.Errorf("AssignmentImpl.Resolve: field 'cardinality' holds a primitive value instead of an ast node")
 	case fieldNameOperator:
@@ -1860,7 +1875,10 @@ func (i *AssignableImpl) ForEachReference(fn func(core.UntypedReference, unique.
 }
 
 func (i *AssignableImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameCardinality:
 		return nil, fmt.Errorf("AssignableImpl.Resolve: field 'cardinality' holds a primitive value instead of an ast node")
@@ -1957,7 +1975,10 @@ func (i *CrossRefImpl) ForEachReference(fn func(core.UntypedReference, unique.Ha
 }
 
 func (i *CrossRefImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameRule:
 		if i.Rule() == nil {
@@ -1965,10 +1986,7 @@ func (i *CrossRefImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 			return nil, fmt.Errorf("CrossRefImpl.Resolve: field 'rule' is nil in node '%s'", nodePath)
 		}
 		child := i.Rule()
-		if path.Empty() {
-			return child, nil
-		}
-		return child.Resolve(path)
+		return child.Resolve(path.Tail())
 	case fieldNameCardinality:
 		return nil, fmt.Errorf("CrossRefImpl.Resolve: field 'cardinality' holds a primitive value instead of an ast node")
 	case fieldNameType:
@@ -2048,7 +2066,10 @@ func (i *RuleCallImpl) ForEachReference(fn func(core.UntypedReference, unique.Ha
 }
 
 func (i *RuleCallImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameCardinality:
 		return nil, fmt.Errorf("RuleCallImpl.Resolve: field 'cardinality' holds a primitive value instead of an ast node")
@@ -2163,7 +2184,10 @@ func (i *ActionImpl) ForEachReference(fn func(core.UntypedReference, unique.Hand
 }
 
 func (i *ActionImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameCardinality:
 		return nil, fmt.Errorf("ActionImpl.Resolve: field 'cardinality' holds a primitive value instead of an ast node")
@@ -2230,7 +2254,10 @@ func (i *CompositeRuleImpl) ForEachReference(fn func(core.UntypedReference, uniq
 }
 
 func (i *CompositeRuleImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameBody:
 		if i.Body() == nil {
@@ -2238,10 +2265,7 @@ func (i *CompositeRuleImpl) Resolve(path core.FragmentPath) (core.AstNode, error
 			return nil, fmt.Errorf("CompositeRuleImpl.Resolve: field 'body' is nil in node '%s'", nodePath)
 		}
 		child := i.Body()
-		if path.Empty() {
-			return child, nil
-		}
-		return child.Resolve(path)
+		return child.Resolve(path.Tail())
 	case fieldNameName:
 		return nil, fmt.Errorf("CompositeRuleImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
 	default:

--- a/internal/grammar/types_gen.go
+++ b/internal/grammar/types_gen.go
@@ -146,84 +146,84 @@ func (i *GrammarImpl) ForEachReference(fn func(core.UntypedReference, unique.Han
 	i.GrammarData.ForEachReference(fn)
 }
 
-func (i *GrammarImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *GrammarImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, index := path.Shift()
 	switch field {
 	case fieldNameComposites:
 		if index >= len(i.Composites()) {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("GrammarImpl.GetByPath: index %d exceeds length of slice in 'composites' (length=%d) in node '%s'", index, len(i.Composites()), nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("GrammarImpl.Resolve: index %d exceeds length of slice in 'composites' (length=%d) in node '%s'", index, len(i.Composites()), nodePath)
 		}
 		child := i.Composites()[index]
 		if child == nil {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("GrammarImpl.GetByPath: item %d of slice in field 'composites' is nil in node '%s'", index, nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("GrammarImpl.Resolve: item %d of slice in field 'composites' is nil in node '%s'", index, nodePath)
 		}
 		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(path)
+		return child.Resolve(path)
 	case fieldNameInterfaces:
 		if index >= len(i.Interfaces()) {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("GrammarImpl.GetByPath: index %d exceeds length of slice in 'interfaces' (length=%d) in node '%s'", index, len(i.Interfaces()), nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("GrammarImpl.Resolve: index %d exceeds length of slice in 'interfaces' (length=%d) in node '%s'", index, len(i.Interfaces()), nodePath)
 		}
 		child := i.Interfaces()[index]
 		if child == nil {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("GrammarImpl.GetByPath: item %d of slice in field 'interfaces' is nil in node '%s'", index, nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("GrammarImpl.Resolve: item %d of slice in field 'interfaces' is nil in node '%s'", index, nodePath)
 		}
 		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(path)
+		return child.Resolve(path)
 	case fieldNameRules:
 		if index >= len(i.Rules()) {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("GrammarImpl.GetByPath: index %d exceeds length of slice in 'rules' (length=%d) in node '%s'", index, len(i.Rules()), nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("GrammarImpl.Resolve: index %d exceeds length of slice in 'rules' (length=%d) in node '%s'", index, len(i.Rules()), nodePath)
 		}
 		child := i.Rules()[index]
 		if child == nil {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("GrammarImpl.GetByPath: item %d of slice in field 'rules' is nil in node '%s'", index, nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("GrammarImpl.Resolve: item %d of slice in field 'rules' is nil in node '%s'", index, nodePath)
 		}
 		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(path)
+		return child.Resolve(path)
 	case fieldNameTerminals:
 		if index >= len(i.Terminals()) {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("GrammarImpl.GetByPath: index %d exceeds length of slice in 'terminals' (length=%d) in node '%s'", index, len(i.Terminals()), nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("GrammarImpl.Resolve: index %d exceeds length of slice in 'terminals' (length=%d) in node '%s'", index, len(i.Terminals()), nodePath)
 		}
 		child := i.Terminals()[index]
 		if child == nil {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("GrammarImpl.GetByPath: item %d of slice in field 'terminals' is nil in node '%s'", index, nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("GrammarImpl.Resolve: item %d of slice in field 'terminals' is nil in node '%s'", index, nodePath)
 		}
 		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(path)
+		return child.Resolve(path)
 	case fieldNameTokenGroups:
 		if index >= len(i.TokenGroups()) {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("GrammarImpl.GetByPath: index %d exceeds length of slice in 'tokenGroups' (length=%d) in node '%s'", index, len(i.TokenGroups()), nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("GrammarImpl.Resolve: index %d exceeds length of slice in 'tokenGroups' (length=%d) in node '%s'", index, len(i.TokenGroups()), nodePath)
 		}
 		child := i.TokenGroups()[index]
 		if child == nil {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("GrammarImpl.GetByPath: item %d of slice in field 'tokenGroups' is nil in node '%s'", index, nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("GrammarImpl.Resolve: item %d of slice in field 'tokenGroups' is nil in node '%s'", index, nodePath)
 		}
 		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(path)
+		return child.Resolve(path)
 	case fieldNameName:
-		return nil, fmt.Errorf("GrammarImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("GrammarImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("GrammarImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Grammar'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("GrammarImpl.Resolve: field '%s' does not exist in node '%s' of type 'Grammar'", field.Value(), nodePath)
 	}
 }
 
@@ -319,30 +319,30 @@ func (i *InterfaceImpl) ForEachReference(fn func(core.UntypedReference, unique.H
 	i.InterfaceData.ForEachReference(fn)
 }
 
-func (i *InterfaceImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *InterfaceImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, index := path.Shift()
 	switch field {
 	case fieldNameFields:
 		if index >= len(i.Fields()) {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("InterfaceImpl.GetByPath: index %d exceeds length of slice in 'fields' (length=%d) in node '%s'", index, len(i.Fields()), nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("InterfaceImpl.Resolve: index %d exceeds length of slice in 'fields' (length=%d) in node '%s'", index, len(i.Fields()), nodePath)
 		}
 		child := i.Fields()[index]
 		if child == nil {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("InterfaceImpl.GetByPath: item %d of slice in field 'fields' is nil in node '%s'", index, nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("InterfaceImpl.Resolve: item %d of slice in field 'fields' is nil in node '%s'", index, nodePath)
 		}
 		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(path)
+		return child.Resolve(path)
 	case fieldNameName:
-		return nil, fmt.Errorf("InterfaceImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("InterfaceImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
 	case fieldNameExtends:
-		return nil, fmt.Errorf("InterfaceImpl.GetByPath: field 'extends' is a cross-reference instead of a container field")
+		return nil, fmt.Errorf("InterfaceImpl.Resolve: field 'extends' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("InterfaceImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Interface'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("InterfaceImpl.Resolve: field '%s' does not exist in node '%s' of type 'Interface'", field.Value(), nodePath)
 	}
 }
 
@@ -425,24 +425,24 @@ func (i *FieldImpl) ForEachReference(fn func(core.UntypedReference, unique.Handl
 	i.FieldData.ForEachReference(fn)
 }
 
-func (i *FieldImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *FieldImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameType:
 		if i.Type() == nil {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("FieldImpl.GetByPath: field '_Type' is nil in node '%s'", nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("FieldImpl.Resolve: field '_Type' is nil in node '%s'", nodePath)
 		}
 		child := i.Type()
 		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(path)
+		return child.Resolve(path)
 	case fieldNameName:
-		return nil, fmt.Errorf("FieldImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("FieldImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("FieldImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Field'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("FieldImpl.Resolve: field '%s' does not exist in node '%s' of type 'Field'", field.Value(), nodePath)
 	}
 }
 
@@ -487,10 +487,10 @@ func (i *FieldTypeImpl) ForEachReference(fn func(core.UntypedReference, unique.H
 	i.FieldTypeData.ForEachReference(fn)
 }
 
-func (i *FieldTypeImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *FieldTypeImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
-	nodePath, _ := core.NodePath(i)
-	return nil, fmt.Errorf("FieldTypeImpl.GetByPath: field '%s' does not exist in node '%s' of type 'FieldType'", field.Value(), nodePath)
+	nodePath, _ := core.PathOf(i)
+	return nil, fmt.Errorf("FieldTypeImpl.Resolve: field '%s' does not exist in node '%s' of type 'FieldType'", field.Value(), nodePath)
 }
 
 type ArrayType interface {
@@ -557,22 +557,22 @@ func (i *ArrayTypeImpl) ForEachReference(fn func(core.UntypedReference, unique.H
 	i.ArrayTypeData.ForEachReference(fn)
 }
 
-func (i *ArrayTypeImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *ArrayTypeImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameInternalType:
 		if i.InternalType() == nil {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("ArrayTypeImpl.GetByPath: field 'internalType' is nil in node '%s'", nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("ArrayTypeImpl.Resolve: field 'internalType' is nil in node '%s'", nodePath)
 		}
 		child := i.InternalType()
 		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(path)
+		return child.Resolve(path)
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("ArrayTypeImpl.GetByPath: field '%s' does not exist in node '%s' of type 'ArrayType'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("ArrayTypeImpl.Resolve: field '%s' does not exist in node '%s' of type 'ArrayType'", field.Value(), nodePath)
 	}
 }
 
@@ -640,14 +640,14 @@ func (i *ReferenceTypeImpl) ForEachReference(fn func(core.UntypedReference, uniq
 	i.ReferenceTypeData.ForEachReference(fn)
 }
 
-func (i *ReferenceTypeImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *ReferenceTypeImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameType:
-		return nil, fmt.Errorf("ReferenceTypeImpl.GetByPath: field '_Type' is a cross-reference instead of a container field")
+		return nil, fmt.Errorf("ReferenceTypeImpl.Resolve: field '_Type' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("ReferenceTypeImpl.GetByPath: field '%s' does not exist in node '%s' of type 'ReferenceType'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("ReferenceTypeImpl.Resolve: field '%s' does not exist in node '%s' of type 'ReferenceType'", field.Value(), nodePath)
 	}
 }
 
@@ -715,14 +715,14 @@ func (i *SimpleTypeImpl) ForEachReference(fn func(core.UntypedReference, unique.
 	i.SimpleTypeData.ForEachReference(fn)
 }
 
-func (i *SimpleTypeImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *SimpleTypeImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameType:
-		return nil, fmt.Errorf("SimpleTypeImpl.GetByPath: field '_Type' is a cross-reference instead of a container field")
+		return nil, fmt.Errorf("SimpleTypeImpl.Resolve: field '_Type' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("SimpleTypeImpl.GetByPath: field '%s' does not exist in node '%s' of type 'SimpleType'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("SimpleTypeImpl.Resolve: field '%s' does not exist in node '%s' of type 'SimpleType'", field.Value(), nodePath)
 	}
 }
 
@@ -792,14 +792,14 @@ func (i *PrimitiveTypeImpl) ForEachReference(fn func(core.UntypedReference, uniq
 	i.PrimitiveTypeData.ForEachReference(fn)
 }
 
-func (i *PrimitiveTypeImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *PrimitiveTypeImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameType:
-		return nil, fmt.Errorf("PrimitiveTypeImpl.GetByPath: field '_Type' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("PrimitiveTypeImpl.Resolve: field '_Type' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("PrimitiveTypeImpl.GetByPath: field '%s' does not exist in node '%s' of type 'PrimitiveType'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("PrimitiveTypeImpl.Resolve: field '%s' does not exist in node '%s' of type 'PrimitiveType'", field.Value(), nodePath)
 	}
 }
 
@@ -864,14 +864,14 @@ func (i *AbstractRuleImpl) ForEachReference(fn func(core.UntypedReference, uniqu
 	i.AbstractRuleData.ForEachReference(fn)
 }
 
-func (i *AbstractRuleImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *AbstractRuleImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameName:
-		return nil, fmt.Errorf("AbstractRuleImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("AbstractRuleImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("AbstractRuleImpl.GetByPath: field '%s' does not exist in node '%s' of type 'AbstractRule'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("AbstractRuleImpl.Resolve: field '%s' does not exist in node '%s' of type 'AbstractRule'", field.Value(), nodePath)
 	}
 }
 
@@ -939,24 +939,24 @@ func (i *AbstractRuleWithBodyImpl) ForEachReference(fn func(core.UntypedReferenc
 	i.AbstractRuleWithBodyData.ForEachReference(fn)
 }
 
-func (i *AbstractRuleWithBodyImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *AbstractRuleWithBodyImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameBody:
 		if i.Body() == nil {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("AbstractRuleWithBodyImpl.GetByPath: field 'body' is nil in node '%s'", nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("AbstractRuleWithBodyImpl.Resolve: field 'body' is nil in node '%s'", nodePath)
 		}
 		child := i.Body()
 		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(path)
+		return child.Resolve(path)
 	case fieldNameName:
-		return nil, fmt.Errorf("AbstractRuleWithBodyImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("AbstractRuleWithBodyImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("AbstractRuleWithBodyImpl.GetByPath: field '%s' does not exist in node '%s' of type 'AbstractRuleWithBody'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("AbstractRuleWithBodyImpl.Resolve: field '%s' does not exist in node '%s' of type 'AbstractRuleWithBody'", field.Value(), nodePath)
 	}
 }
 
@@ -1006,14 +1006,14 @@ func (i *AbstractTokenRuleImpl) ForEachReference(fn func(core.UntypedReference, 
 	i.AbstractTokenRuleData.ForEachReference(fn)
 }
 
-func (i *AbstractTokenRuleImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *AbstractTokenRuleImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameName:
-		return nil, fmt.Errorf("AbstractTokenRuleImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("AbstractTokenRuleImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("AbstractTokenRuleImpl.GetByPath: field '%s' does not exist in node '%s' of type 'AbstractTokenRule'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("AbstractTokenRuleImpl.Resolve: field '%s' does not exist in node '%s' of type 'AbstractTokenRule'", field.Value(), nodePath)
 	}
 }
 
@@ -1101,28 +1101,28 @@ func (i *ParserRuleImpl) ForEachReference(fn func(core.UntypedReference, unique.
 	i.ParserRuleData.ForEachReference(fn)
 }
 
-func (i *ParserRuleImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *ParserRuleImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameBody:
 		if i.Body() == nil {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("ParserRuleImpl.GetByPath: field 'body' is nil in node '%s'", nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("ParserRuleImpl.Resolve: field 'body' is nil in node '%s'", nodePath)
 		}
 		child := i.Body()
 		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(path)
+		return child.Resolve(path)
 	case fieldNameEntry:
-		return nil, fmt.Errorf("ParserRuleImpl.GetByPath: field 'entry' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("ParserRuleImpl.Resolve: field 'entry' holds a primitive value instead of an ast node")
 	case fieldNameName:
-		return nil, fmt.Errorf("ParserRuleImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("ParserRuleImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
 	case fieldNameReturnType:
-		return nil, fmt.Errorf("ParserRuleImpl.GetByPath: field 'returnType' is a cross-reference instead of a container field")
+		return nil, fmt.Errorf("ParserRuleImpl.Resolve: field 'returnType' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("ParserRuleImpl.GetByPath: field '%s' does not exist in node '%s' of type 'ParserRule'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("ParserRuleImpl.Resolve: field '%s' does not exist in node '%s' of type 'ParserRule'", field.Value(), nodePath)
 	}
 }
 
@@ -1216,18 +1216,18 @@ func (i *TokenImpl) ForEachReference(fn func(core.UntypedReference, unique.Handl
 	i.TokenData.ForEachReference(fn)
 }
 
-func (i *TokenImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *TokenImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameName:
-		return nil, fmt.Errorf("TokenImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("TokenImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
 	case fieldNameRegexp:
-		return nil, fmt.Errorf("TokenImpl.GetByPath: field 'regexp' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("TokenImpl.Resolve: field 'regexp' holds a primitive value instead of an ast node")
 	case fieldNameType:
-		return nil, fmt.Errorf("TokenImpl.GetByPath: field '_Type' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("TokenImpl.Resolve: field '_Type' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("TokenImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Token'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("TokenImpl.Resolve: field '%s' does not exist in node '%s' of type 'Token'", field.Value(), nodePath)
 	}
 }
 
@@ -1324,32 +1324,32 @@ func (i *TokenGroupImpl) ForEachReference(fn func(core.UntypedReference, unique.
 	i.TokenGroupData.ForEachReference(fn)
 }
 
-func (i *TokenGroupImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *TokenGroupImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, index := path.Shift()
 	switch field {
 	case fieldNameKeywords:
 		if index >= len(i.Keywords()) {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("TokenGroupImpl.GetByPath: index %d exceeds length of slice in 'keywords' (length=%d) in node '%s'", index, len(i.Keywords()), nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("TokenGroupImpl.Resolve: index %d exceeds length of slice in 'keywords' (length=%d) in node '%s'", index, len(i.Keywords()), nodePath)
 		}
 		child := i.Keywords()[index]
 		if child == nil {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("TokenGroupImpl.GetByPath: item %d of slice in field 'keywords' is nil in node '%s'", index, nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("TokenGroupImpl.Resolve: item %d of slice in field 'keywords' is nil in node '%s'", index, nodePath)
 		}
 		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(path)
+		return child.Resolve(path)
 	case fieldNameName:
-		return nil, fmt.Errorf("TokenGroupImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("TokenGroupImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
 	case fieldNameRegexps:
-		return nil, fmt.Errorf("TokenGroupImpl.GetByPath: field 'regexps' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("TokenGroupImpl.Resolve: field 'regexps' holds a primitive value instead of an ast node")
 	case fieldNameTokenRefs:
-		return nil, fmt.Errorf("TokenGroupImpl.GetByPath: field 'tokenRefs' is a cross-reference instead of a container field")
+		return nil, fmt.Errorf("TokenGroupImpl.Resolve: field 'tokenRefs' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("TokenGroupImpl.GetByPath: field '%s' does not exist in node '%s' of type 'TokenGroup'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("TokenGroupImpl.Resolve: field '%s' does not exist in node '%s' of type 'TokenGroup'", field.Value(), nodePath)
 	}
 }
 
@@ -1414,14 +1414,14 @@ func (i *ElementImpl) ForEachReference(fn func(core.UntypedReference, unique.Han
 	i.ElementData.ForEachReference(fn)
 }
 
-func (i *ElementImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *ElementImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameCardinality:
-		return nil, fmt.Errorf("ElementImpl.GetByPath: field 'cardinality' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("ElementImpl.Resolve: field 'cardinality' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("ElementImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Element'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("ElementImpl.Resolve: field '%s' does not exist in node '%s' of type 'Element'", field.Value(), nodePath)
 	}
 }
 
@@ -1491,28 +1491,28 @@ func (i *AlternativesImpl) ForEachReference(fn func(core.UntypedReference, uniqu
 	i.AlternativesData.ForEachReference(fn)
 }
 
-func (i *AlternativesImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *AlternativesImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, index := path.Shift()
 	switch field {
 	case fieldNameAlts:
 		if index >= len(i.Alts()) {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("AlternativesImpl.GetByPath: index %d exceeds length of slice in 'alts' (length=%d) in node '%s'", index, len(i.Alts()), nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("AlternativesImpl.Resolve: index %d exceeds length of slice in 'alts' (length=%d) in node '%s'", index, len(i.Alts()), nodePath)
 		}
 		child := i.Alts()[index]
 		if child == nil {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("AlternativesImpl.GetByPath: item %d of slice in field 'alts' is nil in node '%s'", index, nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("AlternativesImpl.Resolve: item %d of slice in field 'alts' is nil in node '%s'", index, nodePath)
 		}
 		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(path)
+		return child.Resolve(path)
 	case fieldNameCardinality:
-		return nil, fmt.Errorf("AlternativesImpl.GetByPath: field 'cardinality' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("AlternativesImpl.Resolve: field 'cardinality' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("AlternativesImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Alternatives'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("AlternativesImpl.Resolve: field '%s' does not exist in node '%s' of type 'Alternatives'", field.Value(), nodePath)
 	}
 }
 
@@ -1578,28 +1578,28 @@ func (i *GroupImpl) ForEachReference(fn func(core.UntypedReference, unique.Handl
 	i.GroupData.ForEachReference(fn)
 }
 
-func (i *GroupImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *GroupImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, index := path.Shift()
 	switch field {
 	case fieldNameElements:
 		if index >= len(i.Elements()) {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("GroupImpl.GetByPath: index %d exceeds length of slice in 'elements' (length=%d) in node '%s'", index, len(i.Elements()), nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("GroupImpl.Resolve: index %d exceeds length of slice in 'elements' (length=%d) in node '%s'", index, len(i.Elements()), nodePath)
 		}
 		child := i.Elements()[index]
 		if child == nil {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("GroupImpl.GetByPath: item %d of slice in field 'elements' is nil in node '%s'", index, nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("GroupImpl.Resolve: item %d of slice in field 'elements' is nil in node '%s'", index, nodePath)
 		}
 		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(path)
+		return child.Resolve(path)
 	case fieldNameCardinality:
-		return nil, fmt.Errorf("GroupImpl.GetByPath: field 'cardinality' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("GroupImpl.Resolve: field 'cardinality' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("GroupImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Group'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("GroupImpl.Resolve: field '%s' does not exist in node '%s' of type 'Group'", field.Value(), nodePath)
 	}
 }
 
@@ -1673,16 +1673,16 @@ func (i *KeywordImpl) ForEachReference(fn func(core.UntypedReference, unique.Han
 	i.KeywordData.ForEachReference(fn)
 }
 
-func (i *KeywordImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *KeywordImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameCardinality:
-		return nil, fmt.Errorf("KeywordImpl.GetByPath: field 'cardinality' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("KeywordImpl.Resolve: field 'cardinality' holds a primitive value instead of an ast node")
 	case fieldNameValue:
-		return nil, fmt.Errorf("KeywordImpl.GetByPath: field 'value' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("KeywordImpl.Resolve: field 'value' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("KeywordImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Keyword'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("KeywordImpl.Resolve: field '%s' does not exist in node '%s' of type 'Keyword'", field.Value(), nodePath)
 	}
 }
 
@@ -1788,28 +1788,28 @@ func (i *AssignmentImpl) ForEachReference(fn func(core.UntypedReference, unique.
 	i.AssignmentData.ForEachReference(fn)
 }
 
-func (i *AssignmentImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *AssignmentImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameValue:
 		if i.Value() == nil {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("AssignmentImpl.GetByPath: field 'value' is nil in node '%s'", nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("AssignmentImpl.Resolve: field 'value' is nil in node '%s'", nodePath)
 		}
 		child := i.Value()
 		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(path)
+		return child.Resolve(path)
 	case fieldNameCardinality:
-		return nil, fmt.Errorf("AssignmentImpl.GetByPath: field 'cardinality' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("AssignmentImpl.Resolve: field 'cardinality' holds a primitive value instead of an ast node")
 	case fieldNameOperator:
-		return nil, fmt.Errorf("AssignmentImpl.GetByPath: field 'operator' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("AssignmentImpl.Resolve: field 'operator' holds a primitive value instead of an ast node")
 	case fieldNameProperty:
-		return nil, fmt.Errorf("AssignmentImpl.GetByPath: field 'property' is a cross-reference instead of a container field")
+		return nil, fmt.Errorf("AssignmentImpl.Resolve: field 'property' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("AssignmentImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Assignment'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("AssignmentImpl.Resolve: field '%s' does not exist in node '%s' of type 'Assignment'", field.Value(), nodePath)
 	}
 }
 
@@ -1859,14 +1859,14 @@ func (i *AssignableImpl) ForEachReference(fn func(core.UntypedReference, unique.
 	i.AssignableData.ForEachReference(fn)
 }
 
-func (i *AssignableImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *AssignableImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameCardinality:
-		return nil, fmt.Errorf("AssignableImpl.GetByPath: field 'cardinality' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("AssignableImpl.Resolve: field 'cardinality' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("AssignableImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Assignable'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("AssignableImpl.Resolve: field '%s' does not exist in node '%s' of type 'Assignable'", field.Value(), nodePath)
 	}
 }
 
@@ -1956,26 +1956,26 @@ func (i *CrossRefImpl) ForEachReference(fn func(core.UntypedReference, unique.Ha
 	i.CrossRefData.ForEachReference(fn)
 }
 
-func (i *CrossRefImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *CrossRefImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameRule:
 		if i.Rule() == nil {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("CrossRefImpl.GetByPath: field 'rule' is nil in node '%s'", nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("CrossRefImpl.Resolve: field 'rule' is nil in node '%s'", nodePath)
 		}
 		child := i.Rule()
 		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(path)
+		return child.Resolve(path)
 	case fieldNameCardinality:
-		return nil, fmt.Errorf("CrossRefImpl.GetByPath: field 'cardinality' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("CrossRefImpl.Resolve: field 'cardinality' holds a primitive value instead of an ast node")
 	case fieldNameType:
-		return nil, fmt.Errorf("CrossRefImpl.GetByPath: field '_Type' is a cross-reference instead of a container field")
+		return nil, fmt.Errorf("CrossRefImpl.Resolve: field '_Type' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("CrossRefImpl.GetByPath: field '%s' does not exist in node '%s' of type 'CrossRef'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("CrossRefImpl.Resolve: field '%s' does not exist in node '%s' of type 'CrossRef'", field.Value(), nodePath)
 	}
 }
 
@@ -2047,16 +2047,16 @@ func (i *RuleCallImpl) ForEachReference(fn func(core.UntypedReference, unique.Ha
 	i.RuleCallData.ForEachReference(fn)
 }
 
-func (i *RuleCallImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *RuleCallImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameCardinality:
-		return nil, fmt.Errorf("RuleCallImpl.GetByPath: field 'cardinality' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("RuleCallImpl.Resolve: field 'cardinality' holds a primitive value instead of an ast node")
 	case fieldNameRule:
-		return nil, fmt.Errorf("RuleCallImpl.GetByPath: field 'rule' is a cross-reference instead of a container field")
+		return nil, fmt.Errorf("RuleCallImpl.Resolve: field 'rule' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("RuleCallImpl.GetByPath: field '%s' does not exist in node '%s' of type 'RuleCall'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("RuleCallImpl.Resolve: field '%s' does not exist in node '%s' of type 'RuleCall'", field.Value(), nodePath)
 	}
 }
 
@@ -2162,20 +2162,20 @@ func (i *ActionImpl) ForEachReference(fn func(core.UntypedReference, unique.Hand
 	i.ActionData.ForEachReference(fn)
 }
 
-func (i *ActionImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *ActionImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameCardinality:
-		return nil, fmt.Errorf("ActionImpl.GetByPath: field 'cardinality' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("ActionImpl.Resolve: field 'cardinality' holds a primitive value instead of an ast node")
 	case fieldNameOperator:
-		return nil, fmt.Errorf("ActionImpl.GetByPath: field 'operator' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("ActionImpl.Resolve: field 'operator' holds a primitive value instead of an ast node")
 	case fieldNameProperty:
-		return nil, fmt.Errorf("ActionImpl.GetByPath: field 'property' is a cross-reference instead of a container field")
+		return nil, fmt.Errorf("ActionImpl.Resolve: field 'property' is a cross-reference instead of a container field")
 	case fieldNameType:
-		return nil, fmt.Errorf("ActionImpl.GetByPath: field '_Type' is a cross-reference instead of a container field")
+		return nil, fmt.Errorf("ActionImpl.Resolve: field '_Type' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("ActionImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Action'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("ActionImpl.Resolve: field '%s' does not exist in node '%s' of type 'Action'", field.Value(), nodePath)
 	}
 }
 
@@ -2229,24 +2229,24 @@ func (i *CompositeRuleImpl) ForEachReference(fn func(core.UntypedReference, uniq
 	i.CompositeRuleData.ForEachReference(fn)
 }
 
-func (i *CompositeRuleImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *CompositeRuleImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameBody:
 		if i.Body() == nil {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("CompositeRuleImpl.GetByPath: field 'body' is nil in node '%s'", nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("CompositeRuleImpl.Resolve: field 'body' is nil in node '%s'", nodePath)
 		}
 		child := i.Body()
 		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(path)
+		return child.Resolve(path)
 	case fieldNameName:
-		return nil, fmt.Errorf("CompositeRuleImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("CompositeRuleImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("CompositeRuleImpl.GetByPath: field '%s' does not exist in node '%s' of type 'CompositeRule'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("CompositeRuleImpl.Resolve: field '%s' does not exist in node '%s' of type 'CompositeRule'", field.Value(), nodePath)
 	}
 }
 

--- a/internal/grammar/validator.go
+++ b/internal/grammar/validator.go
@@ -44,11 +44,13 @@ const (
 var reservedFieldNames = map[string]string{
 	"Document":         "AstNode.Document",
 	"Container":        "AstNode.Container",
+	"ContainmentData":  "AstNode.ContainmentData",
 	"Tokens":           "AstNode.Tokens",
 	"Segment":          "AstNode.Segment",
 	"Text":             "AstNode.Text",
 	"ForEachNode":      "AstNode.ForEachNode",
 	"ForEachReference": "AstNode.ForEachReference",
+	"Resolve":          "AstNode.Resolve",
 }
 
 // GrammarImpl.Validate checks grammar-level constraints:

--- a/internal/languages/completion/types_gen.go
+++ b/internal/languages/completion/types_gen.go
@@ -3,8 +3,12 @@
 package completion
 
 import (
-	core "typefox.dev/fastbelt"
+	"fmt"
+	"strconv"
+	"strings"
 	"unique"
+
+	core "typefox.dev/fastbelt"
 )
 
 type Obj interface {
@@ -50,6 +54,17 @@ func (i *ObjImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[
 
 func (i *ObjImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
 	return core.FieldInfos{}
+}
+
+func (i *ObjImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	nodePath, _ := i.AstNodeBase.NodePath()
+	return nil, fmt.Errorf("ObjImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Obj'", fieldAndIndex[0], nodePath)
 }
 
 type Root interface {
@@ -115,6 +130,34 @@ func (i *RootImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
 		return core.FieldInfos{Multi: true, Reference: false}
 	default:
 		return core.FieldInfos{}
+	}
+}
+
+func (i *RootImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameObjects:
+		index, err := strconv.Atoi(fieldAndIndex[1])
+		if err != nil {
+			return nil, err
+		} else if index >= len(i.Objects()) {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("RootImpl.GetByPath: index %d exceeds slice length of 'objects' (%d) at '%s'", index, len(i.Objects()), nodePath)
+		}
+		child := i.Objects()[index]
+		if len(parts) == 1 {
+			return child, nil
+		}
+		return child.GetByPath(parts[1])
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("RootImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Root'", fieldAndIndex[0], nodePath)
 	}
 }
 
@@ -214,6 +257,36 @@ func (i *DeclareImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
 	}
 }
 
+func (i *DeclareImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameChildren:
+		index, err := strconv.Atoi(fieldAndIndex[1])
+		if err != nil {
+			return nil, err
+		} else if index >= len(i.Children()) {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("DeclareImpl.GetByPath: index %d exceeds slice length of 'children' (%d) at '%s'", index, len(i.Children()), nodePath)
+		}
+		child := i.Children()[index]
+		if len(parts) == 1 {
+			return child, nil
+		}
+		return child.GetByPath(parts[1])
+	case fieldNameName:
+		return nil, fmt.Errorf("DeclareImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("DeclareImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Declare'", fieldAndIndex[0], nodePath)
+	}
+}
+
 type E interface {
 	core.AstNode
 	Obj
@@ -287,6 +360,17 @@ func (i *EImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
 	}
 }
 
+func (i *EImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	nodePath, _ := i.AstNodeBase.NodePath()
+	return nil, fmt.Errorf("EImpl.GetByPath: field '%s' does not exist in node '%s' of type 'E'", fieldAndIndex[0], nodePath)
+}
+
 type F interface {
 	core.AstNode
 	Obj
@@ -358,6 +442,34 @@ func (i *FImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
 	}
 }
 
+func (i *FImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameItems:
+		index, err := strconv.Atoi(fieldAndIndex[1])
+		if err != nil {
+			return nil, err
+		} else if index >= len(i.Items()) {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("FImpl.GetByPath: index %d exceeds slice length of 'items' (%d) at '%s'", index, len(i.Items()), nodePath)
+		}
+		child := i.Items()[index]
+		if len(parts) == 1 {
+			return child, nil
+		}
+		return child.GetByPath(parts[1])
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("FImpl.GetByPath: field '%s' does not exist in node '%s' of type 'F'", fieldAndIndex[0], nodePath)
+	}
+}
+
 type FItem interface {
 	core.AstNode
 
@@ -424,6 +536,17 @@ func (i *FItemImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
 	default:
 		return core.FieldInfos{}
 	}
+}
+
+func (i *FItemImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	nodePath, _ := i.AstNodeBase.NodePath()
+	return nil, fmt.Errorf("FItemImpl.GetByPath: field '%s' does not exist in node '%s' of type 'FItem'", fieldAndIndex[0], nodePath)
 }
 
 type G interface {
@@ -499,6 +622,17 @@ func (i *GImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
 	}
 }
 
+func (i *GImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	nodePath, _ := i.AstNodeBase.NodePath()
+	return nil, fmt.Errorf("GImpl.GetByPath: field '%s' does not exist in node '%s' of type 'G'", fieldAndIndex[0], nodePath)
+}
+
 type H interface {
 	core.AstNode
 	Obj
@@ -569,6 +703,31 @@ func (i *HImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
 		return core.FieldInfos{Multi: false, Reference: false}
 	default:
 		return core.FieldInfos{}
+	}
+}
+
+func (i *HImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameMember:
+		if i.Member() == nil {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("HImpl.GetByPath: field 'member' is nil at '%s'", nodePath)
+		}
+		child := i.Member()
+		if len(parts) == 1 {
+			return child, nil
+		}
+		return child.GetByPath(parts[1])
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("HImpl.GetByPath: field '%s' does not exist in node '%s' of type 'H'", fieldAndIndex[0], nodePath)
 	}
 }
 
@@ -660,6 +819,31 @@ func (i *MemberCallImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos
 	}
 }
 
+func (i *MemberCallImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNamePrevious:
+		if i.Previous() == nil {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("MemberCallImpl.GetByPath: field 'previous' is nil at '%s'", nodePath)
+		}
+		child := i.Previous()
+		if len(parts) == 1 {
+			return child, nil
+		}
+		return child.GetByPath(parts[1])
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("MemberCallImpl.GetByPath: field '%s' does not exist in node '%s' of type 'MemberCall'", fieldAndIndex[0], nodePath)
+	}
+}
+
 type J interface {
 	core.AstNode
 	Obj
@@ -731,6 +915,17 @@ func (i *JImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
 	default:
 		return core.FieldInfos{}
 	}
+}
+
+func (i *JImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	nodePath, _ := i.AstNodeBase.NodePath()
+	return nil, fmt.Errorf("JImpl.GetByPath: field '%s' does not exist in node '%s' of type 'J'", fieldAndIndex[0], nodePath)
 }
 
 type K interface {
@@ -826,6 +1021,17 @@ func (i *KImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
 	}
 }
 
+func (i *KImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	nodePath, _ := i.AstNodeBase.NodePath()
+	return nil, fmt.Errorf("KImpl.GetByPath: field '%s' does not exist in node '%s' of type 'K'", fieldAndIndex[0], nodePath)
+}
+
 type N interface {
 	core.AstNode
 	Obj
@@ -899,6 +1105,17 @@ func (i *NImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
 	}
 }
 
+func (i *NImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	nodePath, _ := i.AstNodeBase.NodePath()
+	return nil, fmt.Errorf("NImpl.GetByPath: field '%s' does not exist in node '%s' of type 'N'", fieldAndIndex[0], nodePath)
+}
+
 type O interface {
 	core.AstNode
 	Obj
@@ -970,6 +1187,17 @@ func (i *OImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
 	default:
 		return core.FieldInfos{}
 	}
+}
+
+func (i *OImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	nodePath, _ := i.AstNodeBase.NodePath()
+	return nil, fmt.Errorf("OImpl.GetByPath: field '%s' does not exist in node '%s' of type 'O'", fieldAndIndex[0], nodePath)
 }
 
 var (

--- a/internal/languages/completion/types_gen.go
+++ b/internal/languages/completion/types_gen.go
@@ -4,6 +4,7 @@ package completion
 
 import (
 	core "typefox.dev/fastbelt"
+	"unique"
 )
 
 type Obj interface {
@@ -28,10 +29,10 @@ func NewObjData() ObjData {
 
 func (i *ObjData) IsObj() {}
 
-func (i *ObjData) ForEachNode(fn func(core.AstNode)) {
+func (i *ObjData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 }
 
-func (i *ObjData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *ObjData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 type ObjImpl struct {
@@ -39,12 +40,16 @@ type ObjImpl struct {
 	ObjData
 }
 
-func (i *ObjImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *ObjImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.ObjData.ForEachNode(fn)
 }
 
-func (i *ObjImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *ObjImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.ObjData.ForEachReference(fn)
+}
+
+func (i *ObjImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return CompletionFieldInfos["Obj"][field.Value()]
 }
 
 type Root interface {
@@ -74,13 +79,13 @@ func NewRootData() RootData {
 
 func (i *RootData) IsRoot() {}
 
-func (i *RootData) ForEachNode(fn func(core.AstNode)) {
-	for _, item := range i.objects {
-		fn(item)
+func (i *RootData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+	for j, item := range i.objects {
+		fn(item, unique.Make("objects"), uint16(j))
 	}
 }
 
-func (i *RootData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *RootData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 func (i *RootData) Objects() []Obj {
@@ -96,12 +101,16 @@ type RootImpl struct {
 	RootData
 }
 
-func (i *RootImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *RootImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.RootData.ForEachNode(fn)
 }
 
-func (i *RootImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *RootImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.RootData.ForEachReference(fn)
+}
+
+func (i *RootImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return CompletionFieldInfos["Root"][field.Value()]
 }
 
 type Declare interface {
@@ -137,16 +146,16 @@ func NewDeclareData() DeclareData {
 
 func (i *DeclareData) IsDeclare() {}
 
-func (i *DeclareData) ForEachNode(fn func(core.AstNode)) {
+func (i *DeclareData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	if i.name != nil {
-		fn(i.name)
+		fn(i.name, unique.Make("name"), 0)
 	}
-	for _, item := range i.children {
-		fn(item)
+	for j, item := range i.children {
+		fn(item, unique.Make("children"), uint16(j))
 	}
 }
 
-func (i *DeclareData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *DeclareData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 func (i *DeclareData) Name() string {
@@ -179,14 +188,18 @@ type DeclareImpl struct {
 	DeclareData
 }
 
-func (i *DeclareImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *DeclareImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.ObjData.ForEachNode(fn)
 	i.DeclareData.ForEachNode(fn)
 }
 
-func (i *DeclareImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *DeclareImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.ObjData.ForEachReference(fn)
 	i.DeclareData.ForEachReference(fn)
+}
+
+func (i *DeclareImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return CompletionFieldInfos["Declare"][field.Value()]
 }
 
 type E interface {
@@ -216,12 +229,12 @@ func NewEData() EData {
 
 func (i *EData) IsE() {}
 
-func (i *EData) ForEachNode(fn func(core.AstNode)) {
+func (i *EData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 }
 
-func (i *EData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *EData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i.ref != nil {
-		fn(i.ref)
+		fn(i.ref, unique.Make("ref"), 0)
 	}
 }
 
@@ -243,14 +256,18 @@ type EImpl struct {
 	EData
 }
 
-func (i *EImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *EImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.ObjData.ForEachNode(fn)
 	i.EData.ForEachNode(fn)
 }
 
-func (i *EImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *EImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.ObjData.ForEachReference(fn)
 	i.EData.ForEachReference(fn)
+}
+
+func (i *EImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return CompletionFieldInfos["E"][field.Value()]
 }
 
 type F interface {
@@ -282,13 +299,13 @@ func NewFData() FData {
 
 func (i *FData) IsF() {}
 
-func (i *FData) ForEachNode(fn func(core.AstNode)) {
-	for _, item := range i.items {
-		fn(item)
+func (i *FData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+	for j, item := range i.items {
+		fn(item, unique.Make("items"), uint16(j))
 	}
 }
 
-func (i *FData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *FData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 func (i *FData) Items() []FItem {
@@ -305,14 +322,18 @@ type FImpl struct {
 	FData
 }
 
-func (i *FImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *FImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.ObjData.ForEachNode(fn)
 	i.FData.ForEachNode(fn)
 }
 
-func (i *FImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *FImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.ObjData.ForEachReference(fn)
 	i.FData.ForEachReference(fn)
+}
+
+func (i *FImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return CompletionFieldInfos["F"][field.Value()]
 }
 
 type FItem interface {
@@ -340,12 +361,12 @@ func NewFItemData() FItemData {
 
 func (i *FItemData) IsFItem() {}
 
-func (i *FItemData) ForEachNode(fn func(core.AstNode)) {
+func (i *FItemData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 }
 
-func (i *FItemData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *FItemData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i.ref != nil {
-		fn(i.ref)
+		fn(i.ref, unique.Make("ref"), 0)
 	}
 }
 
@@ -366,12 +387,16 @@ type FItemImpl struct {
 	FItemData
 }
 
-func (i *FItemImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *FItemImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.FItemData.ForEachNode(fn)
 }
 
-func (i *FItemImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *FItemImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.FItemData.ForEachReference(fn)
+}
+
+func (i *FItemImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return CompletionFieldInfos["FItem"][field.Value()]
 }
 
 type G interface {
@@ -401,12 +426,12 @@ func NewGData() GData {
 
 func (i *GData) IsG() {}
 
-func (i *GData) ForEachNode(fn func(core.AstNode)) {
+func (i *GData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 }
 
-func (i *GData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *GData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i.ref != nil {
-		fn(i.ref)
+		fn(i.ref, unique.Make("ref"), 0)
 	}
 }
 
@@ -428,14 +453,18 @@ type GImpl struct {
 	GData
 }
 
-func (i *GImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *GImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.ObjData.ForEachNode(fn)
 	i.GData.ForEachNode(fn)
 }
 
-func (i *GImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *GImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.ObjData.ForEachReference(fn)
 	i.GData.ForEachReference(fn)
+}
+
+func (i *GImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return CompletionFieldInfos["G"][field.Value()]
 }
 
 type H interface {
@@ -465,13 +494,13 @@ func NewHData() HData {
 
 func (i *HData) IsH() {}
 
-func (i *HData) ForEachNode(fn func(core.AstNode)) {
+func (i *HData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	if i.member != nil {
-		fn(i.member)
+		fn(i.member, unique.Make("member"), 0)
 	}
 }
 
-func (i *HData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *HData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 func (i *HData) Member() MemberCall {
@@ -492,14 +521,18 @@ type HImpl struct {
 	HData
 }
 
-func (i *HImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *HImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.ObjData.ForEachNode(fn)
 	i.HData.ForEachNode(fn)
 }
 
-func (i *HImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *HImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.ObjData.ForEachReference(fn)
 	i.HData.ForEachReference(fn)
+}
+
+func (i *HImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return CompletionFieldInfos["H"][field.Value()]
 }
 
 type MemberCall interface {
@@ -530,15 +563,15 @@ func NewMemberCallData() MemberCallData {
 
 func (i *MemberCallData) IsMemberCall() {}
 
-func (i *MemberCallData) ForEachNode(fn func(core.AstNode)) {
+func (i *MemberCallData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	if i.previous != nil {
-		fn(i.previous)
+		fn(i.previous, unique.Make("previous"), 0)
 	}
 }
 
-func (i *MemberCallData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *MemberCallData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i.ref != nil {
-		fn(i.ref)
+		fn(i.ref, unique.Make("ref"), 0)
 	}
 }
 
@@ -571,12 +604,16 @@ type MemberCallImpl struct {
 	MemberCallData
 }
 
-func (i *MemberCallImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *MemberCallImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.MemberCallData.ForEachNode(fn)
 }
 
-func (i *MemberCallImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *MemberCallImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.MemberCallData.ForEachReference(fn)
+}
+
+func (i *MemberCallImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return CompletionFieldInfos["MemberCall"][field.Value()]
 }
 
 type J interface {
@@ -606,12 +643,12 @@ func NewJData() JData {
 
 func (i *JData) IsJ() {}
 
-func (i *JData) ForEachNode(fn func(core.AstNode)) {
+func (i *JData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 }
 
-func (i *JData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *JData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i.ref != nil {
-		fn(i.ref)
+		fn(i.ref, unique.Make("ref"), 0)
 	}
 }
 
@@ -633,14 +670,18 @@ type JImpl struct {
 	JData
 }
 
-func (i *JImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *JImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.ObjData.ForEachNode(fn)
 	i.JData.ForEachNode(fn)
 }
 
-func (i *JImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *JImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.ObjData.ForEachReference(fn)
 	i.JData.ForEachReference(fn)
+}
+
+func (i *JImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return CompletionFieldInfos["J"][field.Value()]
 }
 
 type K interface {
@@ -673,15 +714,15 @@ func NewKData() KData {
 
 func (i *KData) IsK() {}
 
-func (i *KData) ForEachNode(fn func(core.AstNode)) {
+func (i *KData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 }
 
-func (i *KData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *KData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i.ref1 != nil {
-		fn(i.ref1)
+		fn(i.ref1, unique.Make("ref1"), 0)
 	}
 	if i.ref2 != nil {
-		fn(i.ref2)
+		fn(i.ref2, unique.Make("ref2"), 0)
 	}
 }
 
@@ -715,14 +756,18 @@ type KImpl struct {
 	KData
 }
 
-func (i *KImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *KImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.ObjData.ForEachNode(fn)
 	i.KData.ForEachNode(fn)
 }
 
-func (i *KImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *KImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.ObjData.ForEachReference(fn)
 	i.KData.ForEachReference(fn)
+}
+
+func (i *KImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return CompletionFieldInfos["K"][field.Value()]
 }
 
 type N interface {
@@ -752,12 +797,12 @@ func NewNData() NData {
 
 func (i *NData) IsN() {}
 
-func (i *NData) ForEachNode(fn func(core.AstNode)) {
+func (i *NData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 }
 
-func (i *NData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *NData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i.ref != nil {
-		fn(i.ref)
+		fn(i.ref, unique.Make("ref"), 0)
 	}
 }
 
@@ -779,14 +824,18 @@ type NImpl struct {
 	NData
 }
 
-func (i *NImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *NImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.ObjData.ForEachNode(fn)
 	i.NData.ForEachNode(fn)
 }
 
-func (i *NImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *NImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.ObjData.ForEachReference(fn)
 	i.NData.ForEachReference(fn)
+}
+
+func (i *NImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return CompletionFieldInfos["N"][field.Value()]
 }
 
 type O interface {
@@ -816,12 +865,12 @@ func NewOData() OData {
 
 func (i *OData) IsO() {}
 
-func (i *OData) ForEachNode(fn func(core.AstNode)) {
+func (i *OData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 }
 
-func (i *OData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *OData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i.ref != nil {
-		fn(i.ref)
+		fn(i.ref, unique.Make("ref"), 0)
 	}
 }
 
@@ -843,14 +892,18 @@ type OImpl struct {
 	OData
 }
 
-func (i *OImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *OImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.ObjData.ForEachNode(fn)
 	i.OData.ForEachNode(fn)
 }
 
-func (i *OImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *OImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.ObjData.ForEachReference(fn)
 	i.OData.ForEachReference(fn)
+}
+
+func (i *OImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return CompletionFieldInfos["O"][field.Value()]
 }
 
 var CompletionSyntheticFactories = map[string]func() core.AstNode{
@@ -867,4 +920,92 @@ var CompletionSyntheticFactories = map[string]func() core.AstNode{
 	"O":          func() core.AstNode { return NewO() },
 	"Obj":        func() core.AstNode { return NewObj() },
 	"Root":       func() core.AstNode { return NewRoot() },
+}
+
+var CompletionFieldInfos = map[string]map[string]core.FieldInfos{
+	"Declare": map[string]core.FieldInfos{
+		"children": {
+			Multi:     true,
+			Reference: false,
+		},
+		"name": {
+			Multi:     false,
+			Reference: false,
+		},
+	},
+	"E": map[string]core.FieldInfos{
+		"ref": {
+			Multi:     false,
+			Reference: true,
+		},
+	},
+	"F": map[string]core.FieldInfos{
+		"items": {
+			Multi:     true,
+			Reference: false,
+		},
+	},
+	"FItem": map[string]core.FieldInfos{
+		"ref": {
+			Multi:     false,
+			Reference: true,
+		},
+	},
+	"G": map[string]core.FieldInfos{
+		"ref": {
+			Multi:     false,
+			Reference: true,
+		},
+	},
+	"H": map[string]core.FieldInfos{
+		"member": {
+			Multi:     false,
+			Reference: false,
+		},
+	},
+	"J": map[string]core.FieldInfos{
+		"ref": {
+			Multi:     false,
+			Reference: true,
+		},
+	},
+	"K": map[string]core.FieldInfos{
+		"ref1": {
+			Multi:     false,
+			Reference: true,
+		},
+		"ref2": {
+			Multi:     false,
+			Reference: true,
+		},
+	},
+	"MemberCall": map[string]core.FieldInfos{
+		"previous": {
+			Multi:     false,
+			Reference: false,
+		},
+		"ref": {
+			Multi:     false,
+			Reference: true,
+		},
+	},
+	"N": map[string]core.FieldInfos{
+		"ref": {
+			Multi:     false,
+			Reference: true,
+		},
+	},
+	"O": map[string]core.FieldInfos{
+		"ref": {
+			Multi:     false,
+			Reference: true,
+		},
+	},
+	"Obj": map[string]core.FieldInfos{},
+	"Root": map[string]core.FieldInfos{
+		"objects": {
+			Multi:     true,
+			Reference: false,
+		},
+	},
 }

--- a/internal/languages/completion/types_gen.go
+++ b/internal/languages/completion/types_gen.go
@@ -280,7 +280,7 @@ func (i *DeclareImpl) GetByPath(path string) (core.AstNode, error) {
 		}
 		return child.GetByPath(parts[1])
 	case fieldNameName:
-		return nil, fmt.Errorf("DeclareImpl.GetByPath: field 'name' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("DeclareImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("DeclareImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Declare'", fieldAndIndex[0], nodePath)
@@ -367,8 +367,14 @@ func (i *EImpl) GetByPath(path string) (core.AstNode, error) {
 	}
 	parts := strings.SplitN(path, "/", 2)
 	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	nodePath, _ := i.AstNodeBase.NodePath()
-	return nil, fmt.Errorf("EImpl.GetByPath: field '%s' does not exist in node '%s' of type 'E'", fieldAndIndex[0], nodePath)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameRef:
+		return nil, fmt.Errorf("EImpl.GetByPath: field 'ref' is a cross-reference instead of a container field")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("EImpl.GetByPath: field '%s' does not exist in node '%s' of type 'E'", fieldAndIndex[0], nodePath)
+	}
 }
 
 type F interface {
@@ -545,8 +551,14 @@ func (i *FItemImpl) GetByPath(path string) (core.AstNode, error) {
 	}
 	parts := strings.SplitN(path, "/", 2)
 	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	nodePath, _ := i.AstNodeBase.NodePath()
-	return nil, fmt.Errorf("FItemImpl.GetByPath: field '%s' does not exist in node '%s' of type 'FItem'", fieldAndIndex[0], nodePath)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameRef:
+		return nil, fmt.Errorf("FItemImpl.GetByPath: field 'ref' is a cross-reference instead of a container field")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("FItemImpl.GetByPath: field '%s' does not exist in node '%s' of type 'FItem'", fieldAndIndex[0], nodePath)
+	}
 }
 
 type G interface {
@@ -629,8 +641,14 @@ func (i *GImpl) GetByPath(path string) (core.AstNode, error) {
 	}
 	parts := strings.SplitN(path, "/", 2)
 	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	nodePath, _ := i.AstNodeBase.NodePath()
-	return nil, fmt.Errorf("GImpl.GetByPath: field '%s' does not exist in node '%s' of type 'G'", fieldAndIndex[0], nodePath)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameRef:
+		return nil, fmt.Errorf("GImpl.GetByPath: field 'ref' is a cross-reference instead of a container field")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("GImpl.GetByPath: field '%s' does not exist in node '%s' of type 'G'", fieldAndIndex[0], nodePath)
+	}
 }
 
 type H interface {
@@ -838,6 +856,8 @@ func (i *MemberCallImpl) GetByPath(path string) (core.AstNode, error) {
 			return child, nil
 		}
 		return child.GetByPath(parts[1])
+	case fieldNameRef:
+		return nil, fmt.Errorf("MemberCallImpl.GetByPath: field 'ref' is a cross-reference instead of a container field")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("MemberCallImpl.GetByPath: field '%s' does not exist in node '%s' of type 'MemberCall'", fieldAndIndex[0], nodePath)
@@ -924,8 +944,14 @@ func (i *JImpl) GetByPath(path string) (core.AstNode, error) {
 	}
 	parts := strings.SplitN(path, "/", 2)
 	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	nodePath, _ := i.AstNodeBase.NodePath()
-	return nil, fmt.Errorf("JImpl.GetByPath: field '%s' does not exist in node '%s' of type 'J'", fieldAndIndex[0], nodePath)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameRef:
+		return nil, fmt.Errorf("JImpl.GetByPath: field 'ref' is a cross-reference instead of a container field")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("JImpl.GetByPath: field '%s' does not exist in node '%s' of type 'J'", fieldAndIndex[0], nodePath)
+	}
 }
 
 type K interface {
@@ -1028,8 +1054,16 @@ func (i *KImpl) GetByPath(path string) (core.AstNode, error) {
 	}
 	parts := strings.SplitN(path, "/", 2)
 	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	nodePath, _ := i.AstNodeBase.NodePath()
-	return nil, fmt.Errorf("KImpl.GetByPath: field '%s' does not exist in node '%s' of type 'K'", fieldAndIndex[0], nodePath)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameRef1:
+		return nil, fmt.Errorf("KImpl.GetByPath: field 'ref1' is a cross-reference instead of a container field")
+	case fieldNameRef2:
+		return nil, fmt.Errorf("KImpl.GetByPath: field 'ref2' is a cross-reference instead of a container field")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("KImpl.GetByPath: field '%s' does not exist in node '%s' of type 'K'", fieldAndIndex[0], nodePath)
+	}
 }
 
 type N interface {
@@ -1112,8 +1146,14 @@ func (i *NImpl) GetByPath(path string) (core.AstNode, error) {
 	}
 	parts := strings.SplitN(path, "/", 2)
 	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	nodePath, _ := i.AstNodeBase.NodePath()
-	return nil, fmt.Errorf("NImpl.GetByPath: field '%s' does not exist in node '%s' of type 'N'", fieldAndIndex[0], nodePath)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameRef:
+		return nil, fmt.Errorf("NImpl.GetByPath: field 'ref' is a cross-reference instead of a container field")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("NImpl.GetByPath: field '%s' does not exist in node '%s' of type 'N'", fieldAndIndex[0], nodePath)
+	}
 }
 
 type O interface {
@@ -1196,8 +1236,14 @@ func (i *OImpl) GetByPath(path string) (core.AstNode, error) {
 	}
 	parts := strings.SplitN(path, "/", 2)
 	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	nodePath, _ := i.AstNodeBase.NodePath()
-	return nil, fmt.Errorf("OImpl.GetByPath: field '%s' does not exist in node '%s' of type 'O'", fieldAndIndex[0], nodePath)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameRef:
+		return nil, fmt.Errorf("OImpl.GetByPath: field 'ref' is a cross-reference instead of a container field")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("OImpl.GetByPath: field '%s' does not exist in node '%s' of type 'O'", fieldAndIndex[0], nodePath)
+	}
 }
 
 var (

--- a/internal/languages/completion/types_gen.go
+++ b/internal/languages/completion/types_gen.go
@@ -145,12 +145,17 @@ func (i *RootImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameObjects:
 		index, err := strconv.Atoi(fieldAndIndex[1])
 		if err != nil {
-			return nil, err
-		} else if index >= len(i.Objects()) {
+			return nil, fmt.Errorf("RootImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
+		}
+		if index >= len(i.Objects()) {
 			nodePath, _ := i.AstNodeBase.NodePath()
-			return nil, fmt.Errorf("RootImpl.GetByPath: index %d exceeds slice length of 'objects' (%d) at '%s'", index, len(i.Objects()), nodePath)
+			return nil, fmt.Errorf("RootImpl.GetByPath: index %d exceeds length of slice in 'objects' (length=%d) in node '%s'", index, len(i.Objects()), nodePath)
 		}
 		child := i.Objects()[index]
+		if child == nil {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("RootImpl.GetByPath: item %d of slice in field 'objects' is nil in node '%s'", index, nodePath)
+		}
 		if len(parts) == 1 {
 			return child, nil
 		}
@@ -269,12 +274,17 @@ func (i *DeclareImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameChildren:
 		index, err := strconv.Atoi(fieldAndIndex[1])
 		if err != nil {
-			return nil, err
-		} else if index >= len(i.Children()) {
+			return nil, fmt.Errorf("DeclareImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
+		}
+		if index >= len(i.Children()) {
 			nodePath, _ := i.AstNodeBase.NodePath()
-			return nil, fmt.Errorf("DeclareImpl.GetByPath: index %d exceeds slice length of 'children' (%d) at '%s'", index, len(i.Children()), nodePath)
+			return nil, fmt.Errorf("DeclareImpl.GetByPath: index %d exceeds length of slice in 'children' (length=%d) in node '%s'", index, len(i.Children()), nodePath)
 		}
 		child := i.Children()[index]
+		if child == nil {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("DeclareImpl.GetByPath: item %d of slice in field 'children' is nil in node '%s'", index, nodePath)
+		}
 		if len(parts) == 1 {
 			return child, nil
 		}
@@ -460,12 +470,17 @@ func (i *FImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameItems:
 		index, err := strconv.Atoi(fieldAndIndex[1])
 		if err != nil {
-			return nil, err
-		} else if index >= len(i.Items()) {
+			return nil, fmt.Errorf("FImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
+		}
+		if index >= len(i.Items()) {
 			nodePath, _ := i.AstNodeBase.NodePath()
-			return nil, fmt.Errorf("FImpl.GetByPath: index %d exceeds slice length of 'items' (%d) at '%s'", index, len(i.Items()), nodePath)
+			return nil, fmt.Errorf("FImpl.GetByPath: index %d exceeds length of slice in 'items' (length=%d) in node '%s'", index, len(i.Items()), nodePath)
 		}
 		child := i.Items()[index]
+		if child == nil {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("FImpl.GetByPath: item %d of slice in field 'items' is nil in node '%s'", index, nodePath)
+		}
 		if len(parts) == 1 {
 			return child, nil
 		}
@@ -736,7 +751,7 @@ func (i *HImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameMember:
 		if i.Member() == nil {
 			nodePath, _ := i.AstNodeBase.NodePath()
-			return nil, fmt.Errorf("HImpl.GetByPath: field 'member' is nil at '%s'", nodePath)
+			return nil, fmt.Errorf("HImpl.GetByPath: field 'member' is nil in node '%s'", nodePath)
 		}
 		child := i.Member()
 		if len(parts) == 1 {
@@ -849,7 +864,7 @@ func (i *MemberCallImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNamePrevious:
 		if i.Previous() == nil {
 			nodePath, _ := i.AstNodeBase.NodePath()
-			return nil, fmt.Errorf("MemberCallImpl.GetByPath: field 'previous' is nil at '%s'", nodePath)
+			return nil, fmt.Errorf("MemberCallImpl.GetByPath: field 'previous' is nil in node '%s'", nodePath)
 		}
 		child := i.Previous()
 		if len(parts) == 1 {

--- a/internal/languages/completion/types_gen.go
+++ b/internal/languages/completion/types_gen.go
@@ -49,7 +49,7 @@ func (i *ObjImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[
 }
 
 func (i *ObjImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return CompletionFieldInfos["Obj"][field.Value()]
+	return core.FieldInfos{}
 }
 
 type Root interface {
@@ -81,7 +81,7 @@ func (i *RootData) IsRoot() {}
 
 func (i *RootData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	for j, item := range i.objects {
-		fn(item, unique.Make("objects"), uint16(j))
+		fn(item, fieldNameObjects, uint16(j))
 	}
 }
 
@@ -110,7 +110,12 @@ func (i *RootImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle
 }
 
 func (i *RootImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return CompletionFieldInfos["Root"][field.Value()]
+	switch field {
+	case fieldNameObjects:
+		return core.FieldInfos{Multi: true, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type Declare interface {
@@ -148,10 +153,10 @@ func (i *DeclareData) IsDeclare() {}
 
 func (i *DeclareData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	if i.name != nil {
-		fn(i.name, unique.Make("name"), 0)
+		fn(i.name, fieldNameName, 0)
 	}
 	for j, item := range i.children {
-		fn(item, unique.Make("children"), uint16(j))
+		fn(item, fieldNameChildren, uint16(j))
 	}
 }
 
@@ -199,7 +204,14 @@ func (i *DeclareImpl) ForEachReference(fn func(core.UntypedReference, unique.Han
 }
 
 func (i *DeclareImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return CompletionFieldInfos["Declare"][field.Value()]
+	switch field {
+	case fieldNameChildren:
+		return core.FieldInfos{Multi: true, Reference: false}
+	case fieldNameName:
+		return core.FieldInfos{Multi: false, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type E interface {
@@ -234,7 +246,7 @@ func (i *EData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)
 
 func (i *EData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i.ref != nil {
-		fn(i.ref, unique.Make("ref"), 0)
+		fn(i.ref, fieldNameRef, 0)
 	}
 }
 
@@ -267,7 +279,12 @@ func (i *EImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[st
 }
 
 func (i *EImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return CompletionFieldInfos["E"][field.Value()]
+	switch field {
+	case fieldNameRef:
+		return core.FieldInfos{Multi: false, Reference: true}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type F interface {
@@ -301,7 +318,7 @@ func (i *FData) IsF() {}
 
 func (i *FData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	for j, item := range i.items {
-		fn(item, unique.Make("items"), uint16(j))
+		fn(item, fieldNameItems, uint16(j))
 	}
 }
 
@@ -333,7 +350,12 @@ func (i *FImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[st
 }
 
 func (i *FImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return CompletionFieldInfos["F"][field.Value()]
+	switch field {
+	case fieldNameItems:
+		return core.FieldInfos{Multi: true, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type FItem interface {
@@ -366,7 +388,7 @@ func (i *FItemData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uin
 
 func (i *FItemData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i.ref != nil {
-		fn(i.ref, unique.Make("ref"), 0)
+		fn(i.ref, fieldNameRef, 0)
 	}
 }
 
@@ -396,7 +418,12 @@ func (i *FItemImpl) ForEachReference(fn func(core.UntypedReference, unique.Handl
 }
 
 func (i *FItemImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return CompletionFieldInfos["FItem"][field.Value()]
+	switch field {
+	case fieldNameRef:
+		return core.FieldInfos{Multi: false, Reference: true}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type G interface {
@@ -431,7 +458,7 @@ func (i *GData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)
 
 func (i *GData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i.ref != nil {
-		fn(i.ref, unique.Make("ref"), 0)
+		fn(i.ref, fieldNameRef, 0)
 	}
 }
 
@@ -464,7 +491,12 @@ func (i *GImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[st
 }
 
 func (i *GImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return CompletionFieldInfos["G"][field.Value()]
+	switch field {
+	case fieldNameRef:
+		return core.FieldInfos{Multi: false, Reference: true}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type H interface {
@@ -496,7 +528,7 @@ func (i *HData) IsH() {}
 
 func (i *HData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	if i.member != nil {
-		fn(i.member, unique.Make("member"), 0)
+		fn(i.member, fieldNameMember, 0)
 	}
 }
 
@@ -532,7 +564,12 @@ func (i *HImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[st
 }
 
 func (i *HImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return CompletionFieldInfos["H"][field.Value()]
+	switch field {
+	case fieldNameMember:
+		return core.FieldInfos{Multi: false, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type MemberCall interface {
@@ -565,13 +602,13 @@ func (i *MemberCallData) IsMemberCall() {}
 
 func (i *MemberCallData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	if i.previous != nil {
-		fn(i.previous, unique.Make("previous"), 0)
+		fn(i.previous, fieldNamePrevious, 0)
 	}
 }
 
 func (i *MemberCallData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i.ref != nil {
-		fn(i.ref, unique.Make("ref"), 0)
+		fn(i.ref, fieldNameRef, 0)
 	}
 }
 
@@ -613,7 +650,14 @@ func (i *MemberCallImpl) ForEachReference(fn func(core.UntypedReference, unique.
 }
 
 func (i *MemberCallImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return CompletionFieldInfos["MemberCall"][field.Value()]
+	switch field {
+	case fieldNamePrevious:
+		return core.FieldInfos{Multi: false, Reference: false}
+	case fieldNameRef:
+		return core.FieldInfos{Multi: false, Reference: true}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type J interface {
@@ -648,7 +692,7 @@ func (i *JData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)
 
 func (i *JData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i.ref != nil {
-		fn(i.ref, unique.Make("ref"), 0)
+		fn(i.ref, fieldNameRef, 0)
 	}
 }
 
@@ -681,7 +725,12 @@ func (i *JImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[st
 }
 
 func (i *JImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return CompletionFieldInfos["J"][field.Value()]
+	switch field {
+	case fieldNameRef:
+		return core.FieldInfos{Multi: false, Reference: true}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type K interface {
@@ -719,10 +768,10 @@ func (i *KData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)
 
 func (i *KData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i.ref1 != nil {
-		fn(i.ref1, unique.Make("ref1"), 0)
+		fn(i.ref1, fieldNameRef1, 0)
 	}
 	if i.ref2 != nil {
-		fn(i.ref2, unique.Make("ref2"), 0)
+		fn(i.ref2, fieldNameRef2, 0)
 	}
 }
 
@@ -767,7 +816,14 @@ func (i *KImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[st
 }
 
 func (i *KImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return CompletionFieldInfos["K"][field.Value()]
+	switch field {
+	case fieldNameRef1:
+		return core.FieldInfos{Multi: false, Reference: true}
+	case fieldNameRef2:
+		return core.FieldInfos{Multi: false, Reference: true}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type N interface {
@@ -802,7 +858,7 @@ func (i *NData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)
 
 func (i *NData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i.ref != nil {
-		fn(i.ref, unique.Make("ref"), 0)
+		fn(i.ref, fieldNameRef, 0)
 	}
 }
 
@@ -835,7 +891,12 @@ func (i *NImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[st
 }
 
 func (i *NImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return CompletionFieldInfos["N"][field.Value()]
+	switch field {
+	case fieldNameRef:
+		return core.FieldInfos{Multi: false, Reference: true}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type O interface {
@@ -870,7 +931,7 @@ func (i *OData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)
 
 func (i *OData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	if i.ref != nil {
-		fn(i.ref, unique.Make("ref"), 0)
+		fn(i.ref, fieldNameRef, 0)
 	}
 }
 
@@ -903,8 +964,25 @@ func (i *OImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[st
 }
 
 func (i *OImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return CompletionFieldInfos["O"][field.Value()]
+	switch field {
+	case fieldNameRef:
+		return core.FieldInfos{Multi: false, Reference: true}
+	default:
+		return core.FieldInfos{}
+	}
 }
+
+var (
+	fieldNameChildren = unique.Make("children")
+	fieldNameItems    = unique.Make("items")
+	fieldNameMember   = unique.Make("member")
+	fieldNameName     = unique.Make("name")
+	fieldNameObjects  = unique.Make("objects")
+	fieldNamePrevious = unique.Make("previous")
+	fieldNameRef      = unique.Make("ref")
+	fieldNameRef1     = unique.Make("ref1")
+	fieldNameRef2     = unique.Make("ref2")
+)
 
 var CompletionSyntheticFactories = map[string]func() core.AstNode{
 	"Declare":    func() core.AstNode { return NewDeclare() },
@@ -920,92 +998,4 @@ var CompletionSyntheticFactories = map[string]func() core.AstNode{
 	"O":          func() core.AstNode { return NewO() },
 	"Obj":        func() core.AstNode { return NewObj() },
 	"Root":       func() core.AstNode { return NewRoot() },
-}
-
-var CompletionFieldInfos = map[string]map[string]core.FieldInfos{
-	"Declare": map[string]core.FieldInfos{
-		"children": {
-			Multi:     true,
-			Reference: false,
-		},
-		"name": {
-			Multi:     false,
-			Reference: false,
-		},
-	},
-	"E": map[string]core.FieldInfos{
-		"ref": {
-			Multi:     false,
-			Reference: true,
-		},
-	},
-	"F": map[string]core.FieldInfos{
-		"items": {
-			Multi:     true,
-			Reference: false,
-		},
-	},
-	"FItem": map[string]core.FieldInfos{
-		"ref": {
-			Multi:     false,
-			Reference: true,
-		},
-	},
-	"G": map[string]core.FieldInfos{
-		"ref": {
-			Multi:     false,
-			Reference: true,
-		},
-	},
-	"H": map[string]core.FieldInfos{
-		"member": {
-			Multi:     false,
-			Reference: false,
-		},
-	},
-	"J": map[string]core.FieldInfos{
-		"ref": {
-			Multi:     false,
-			Reference: true,
-		},
-	},
-	"K": map[string]core.FieldInfos{
-		"ref1": {
-			Multi:     false,
-			Reference: true,
-		},
-		"ref2": {
-			Multi:     false,
-			Reference: true,
-		},
-	},
-	"MemberCall": map[string]core.FieldInfos{
-		"previous": {
-			Multi:     false,
-			Reference: false,
-		},
-		"ref": {
-			Multi:     false,
-			Reference: true,
-		},
-	},
-	"N": map[string]core.FieldInfos{
-		"ref": {
-			Multi:     false,
-			Reference: true,
-		},
-	},
-	"O": map[string]core.FieldInfos{
-		"ref": {
-			Multi:     false,
-			Reference: true,
-		},
-	},
-	"Obj": map[string]core.FieldInfos{},
-	"Root": map[string]core.FieldInfos{
-		"objects": {
-			Multi:     true,
-			Reference: false,
-		},
-	},
 }

--- a/internal/languages/completion/types_gen.go
+++ b/internal/languages/completion/types_gen.go
@@ -51,7 +51,10 @@ func (i *ObjImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[
 }
 
 func (i *ObjImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	nodePath, _ := core.PathOf(i)
 	return nil, fmt.Errorf("ObjImpl.Resolve: field '%s' does not exist in node '%s' of type 'Obj'", field.Value(), nodePath)
 }
@@ -114,7 +117,10 @@ func (i *RootImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle
 }
 
 func (i *RootImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, index := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, index := path.Head()
 	switch field {
 	case fieldNameObjects:
 		if index >= len(i.Objects()) {
@@ -126,10 +132,7 @@ func (i *RootImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 			nodePath, _ := core.PathOf(i)
 			return nil, fmt.Errorf("RootImpl.Resolve: item %d of slice in field 'objects' is nil in node '%s'", index, nodePath)
 		}
-		if path.Empty() {
-			return child, nil
-		}
-		return child.Resolve(path)
+		return child.Resolve(path.Tail())
 	default:
 		nodePath, _ := core.PathOf(i)
 		return nil, fmt.Errorf("RootImpl.Resolve: field '%s' does not exist in node '%s' of type 'Root'", field.Value(), nodePath)
@@ -222,7 +225,10 @@ func (i *DeclareImpl) ForEachReference(fn func(core.UntypedReference, unique.Han
 }
 
 func (i *DeclareImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, index := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, index := path.Head()
 	switch field {
 	case fieldNameChildren:
 		if index >= len(i.Children()) {
@@ -234,10 +240,7 @@ func (i *DeclareImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 			nodePath, _ := core.PathOf(i)
 			return nil, fmt.Errorf("DeclareImpl.Resolve: item %d of slice in field 'children' is nil in node '%s'", index, nodePath)
 		}
-		if path.Empty() {
-			return child, nil
-		}
-		return child.Resolve(path)
+		return child.Resolve(path.Tail())
 	case fieldNameName:
 		return nil, fmt.Errorf("DeclareImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
 	default:
@@ -311,7 +314,10 @@ func (i *EImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[st
 }
 
 func (i *EImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameRef:
 		return nil, fmt.Errorf("EImpl.Resolve: field 'ref' is a cross-reference instead of a container field")
@@ -384,7 +390,10 @@ func (i *FImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[st
 }
 
 func (i *FImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, index := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, index := path.Head()
 	switch field {
 	case fieldNameItems:
 		if index >= len(i.Items()) {
@@ -396,10 +405,7 @@ func (i *FImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 			nodePath, _ := core.PathOf(i)
 			return nil, fmt.Errorf("FImpl.Resolve: item %d of slice in field 'items' is nil in node '%s'", index, nodePath)
 		}
-		if path.Empty() {
-			return child, nil
-		}
-		return child.Resolve(path)
+		return child.Resolve(path.Tail())
 	default:
 		nodePath, _ := core.PathOf(i)
 		return nil, fmt.Errorf("FImpl.Resolve: field '%s' does not exist in node '%s' of type 'F'", field.Value(), nodePath)
@@ -466,7 +472,10 @@ func (i *FItemImpl) ForEachReference(fn func(core.UntypedReference, unique.Handl
 }
 
 func (i *FItemImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameRef:
 		return nil, fmt.Errorf("FItemImpl.Resolve: field 'ref' is a cross-reference instead of a container field")
@@ -541,7 +550,10 @@ func (i *GImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[st
 }
 
 func (i *GImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameRef:
 		return nil, fmt.Errorf("GImpl.Resolve: field 'ref' is a cross-reference instead of a container field")
@@ -616,7 +628,10 @@ func (i *HImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[st
 }
 
 func (i *HImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameMember:
 		if i.Member() == nil {
@@ -624,10 +639,7 @@ func (i *HImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 			return nil, fmt.Errorf("HImpl.Resolve: field 'member' is nil in node '%s'", nodePath)
 		}
 		child := i.Member()
-		if path.Empty() {
-			return child, nil
-		}
-		return child.Resolve(path)
+		return child.Resolve(path.Tail())
 	default:
 		nodePath, _ := core.PathOf(i)
 		return nil, fmt.Errorf("HImpl.Resolve: field '%s' does not exist in node '%s' of type 'H'", field.Value(), nodePath)
@@ -712,7 +724,10 @@ func (i *MemberCallImpl) ForEachReference(fn func(core.UntypedReference, unique.
 }
 
 func (i *MemberCallImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNamePrevious:
 		if i.Previous() == nil {
@@ -720,10 +735,7 @@ func (i *MemberCallImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 			return nil, fmt.Errorf("MemberCallImpl.Resolve: field 'previous' is nil in node '%s'", nodePath)
 		}
 		child := i.Previous()
-		if path.Empty() {
-			return child, nil
-		}
-		return child.Resolve(path)
+		return child.Resolve(path.Tail())
 	case fieldNameRef:
 		return nil, fmt.Errorf("MemberCallImpl.Resolve: field 'ref' is a cross-reference instead of a container field")
 	default:
@@ -797,7 +809,10 @@ func (i *JImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[st
 }
 
 func (i *JImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameRef:
 		return nil, fmt.Errorf("JImpl.Resolve: field 'ref' is a cross-reference instead of a container field")
@@ -890,7 +905,10 @@ func (i *KImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[st
 }
 
 func (i *KImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameRef1:
 		return nil, fmt.Errorf("KImpl.Resolve: field 'ref1' is a cross-reference instead of a container field")
@@ -967,7 +985,10 @@ func (i *NImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[st
 }
 
 func (i *NImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameRef:
 		return nil, fmt.Errorf("NImpl.Resolve: field 'ref' is a cross-reference instead of a container field")
@@ -1042,7 +1063,10 @@ func (i *OImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[st
 }
 
 func (i *OImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameRef:
 		return nil, fmt.Errorf("OImpl.Resolve: field 'ref' is a cross-reference instead of a container field")

--- a/internal/languages/completion/types_gen.go
+++ b/internal/languages/completion/types_gen.go
@@ -4,8 +4,6 @@ package completion
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
 	"unique"
 
 	core "typefox.dev/fastbelt"
@@ -33,10 +31,10 @@ func NewObjData() ObjData {
 
 func (i *ObjData) IsObj() {}
 
-func (i *ObjData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *ObjData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 }
 
-func (i *ObjData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *ObjData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 type ObjImpl struct {
@@ -44,27 +42,18 @@ type ObjImpl struct {
 	ObjData
 }
 
-func (i *ObjImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *ObjImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.ObjData.ForEachNode(fn)
 }
 
-func (i *ObjImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *ObjImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.ObjData.ForEachReference(fn)
 }
 
-func (i *ObjImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return core.FieldInfos{}
-}
-
-func (i *ObjImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	nodePath, _ := i.AstNodeBase.NodePath()
-	return nil, fmt.Errorf("ObjImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Obj'", fieldAndIndex[0], nodePath)
+func (i *ObjImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
+	nodePath, _ := core.NodePath(i)
+	return nil, fmt.Errorf("ObjImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Obj'", field.Value(), nodePath)
 }
 
 type Root interface {
@@ -94,13 +83,13 @@ func NewRootData() RootData {
 
 func (i *RootData) IsRoot() {}
 
-func (i *RootData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *RootData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	for j, item := range i.objects {
-		fn(item, fieldNameObjects, uint16(j))
+		fn(item, fieldNameObjects, j)
 	}
 }
 
-func (i *RootData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *RootData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 func (i *RootData) Objects() []Obj {
@@ -116,53 +105,34 @@ type RootImpl struct {
 	RootData
 }
 
-func (i *RootImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *RootImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.RootData.ForEachNode(fn)
 }
 
-func (i *RootImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *RootImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.RootData.ForEachReference(fn)
 }
 
-func (i *RootImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+func (i *RootImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, index := path.Shift()
 	switch field {
 	case fieldNameObjects:
-		return core.FieldInfos{Multi: true, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *RootImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
-	switch field {
-	case fieldNameObjects:
-		index, err := strconv.Atoi(fieldAndIndex[1])
-		if err != nil {
-			return nil, fmt.Errorf("RootImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
-		}
 		if index >= len(i.Objects()) {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("RootImpl.GetByPath: index %d exceeds length of slice in 'objects' (length=%d) in node '%s'", index, len(i.Objects()), nodePath)
 		}
 		child := i.Objects()[index]
 		if child == nil {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("RootImpl.GetByPath: item %d of slice in field 'objects' is nil in node '%s'", index, nodePath)
 		}
-		if len(parts) == 1 {
+		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(parts[1])
+		return child.GetByPath(path)
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("RootImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Root'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("RootImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Root'", field.Value(), nodePath)
 	}
 }
 
@@ -199,16 +169,16 @@ func NewDeclareData() DeclareData {
 
 func (i *DeclareData) IsDeclare() {}
 
-func (i *DeclareData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *DeclareData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	if i.name != nil {
-		fn(i.name, fieldNameName, 0)
+		fn(i.name, fieldNameName, -1)
 	}
 	for j, item := range i.children {
-		fn(item, fieldNameChildren, uint16(j))
+		fn(item, fieldNameChildren, j)
 	}
 }
 
-func (i *DeclareData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *DeclareData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 func (i *DeclareData) Name() string {
@@ -241,59 +211,38 @@ type DeclareImpl struct {
 	DeclareData
 }
 
-func (i *DeclareImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *DeclareImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.ObjData.ForEachNode(fn)
 	i.DeclareData.ForEachNode(fn)
 }
 
-func (i *DeclareImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *DeclareImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.ObjData.ForEachReference(fn)
 	i.DeclareData.ForEachReference(fn)
 }
 
-func (i *DeclareImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+func (i *DeclareImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, index := path.Shift()
 	switch field {
 	case fieldNameChildren:
-		return core.FieldInfos{Multi: true, Reference: false}
-	case fieldNameName:
-		return core.FieldInfos{Multi: false, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *DeclareImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
-	switch field {
-	case fieldNameChildren:
-		index, err := strconv.Atoi(fieldAndIndex[1])
-		if err != nil {
-			return nil, fmt.Errorf("DeclareImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
-		}
 		if index >= len(i.Children()) {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("DeclareImpl.GetByPath: index %d exceeds length of slice in 'children' (length=%d) in node '%s'", index, len(i.Children()), nodePath)
 		}
 		child := i.Children()[index]
 		if child == nil {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("DeclareImpl.GetByPath: item %d of slice in field 'children' is nil in node '%s'", index, nodePath)
 		}
-		if len(parts) == 1 {
+		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(parts[1])
+		return child.GetByPath(path)
 	case fieldNameName:
 		return nil, fmt.Errorf("DeclareImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("DeclareImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Declare'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("DeclareImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Declare'", field.Value(), nodePath)
 	}
 }
 
@@ -324,12 +273,12 @@ func NewEData() EData {
 
 func (i *EData) IsE() {}
 
-func (i *EData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *EData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 }
 
-func (i *EData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *EData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	if i.ref != nil {
-		fn(i.ref, fieldNameRef, 0)
+		fn(i.ref, fieldNameRef, -1)
 	}
 }
 
@@ -351,39 +300,24 @@ type EImpl struct {
 	EData
 }
 
-func (i *EImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *EImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.ObjData.ForEachNode(fn)
 	i.EData.ForEachNode(fn)
 }
 
-func (i *EImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *EImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.ObjData.ForEachReference(fn)
 	i.EData.ForEachReference(fn)
 }
 
-func (i *EImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameRef:
-		return core.FieldInfos{Multi: false, Reference: true}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *EImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *EImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameRef:
 		return nil, fmt.Errorf("EImpl.GetByPath: field 'ref' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("EImpl.GetByPath: field '%s' does not exist in node '%s' of type 'E'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("EImpl.GetByPath: field '%s' does not exist in node '%s' of type 'E'", field.Value(), nodePath)
 	}
 }
 
@@ -416,13 +350,13 @@ func NewFData() FData {
 
 func (i *FData) IsF() {}
 
-func (i *FData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *FData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	for j, item := range i.items {
-		fn(item, fieldNameItems, uint16(j))
+		fn(item, fieldNameItems, j)
 	}
 }
 
-func (i *FData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *FData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 func (i *FData) Items() []FItem {
@@ -439,55 +373,36 @@ type FImpl struct {
 	FData
 }
 
-func (i *FImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *FImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.ObjData.ForEachNode(fn)
 	i.FData.ForEachNode(fn)
 }
 
-func (i *FImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *FImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.ObjData.ForEachReference(fn)
 	i.FData.ForEachReference(fn)
 }
 
-func (i *FImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+func (i *FImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, index := path.Shift()
 	switch field {
 	case fieldNameItems:
-		return core.FieldInfos{Multi: true, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *FImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
-	switch field {
-	case fieldNameItems:
-		index, err := strconv.Atoi(fieldAndIndex[1])
-		if err != nil {
-			return nil, fmt.Errorf("FImpl.GetByPath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
-		}
 		if index >= len(i.Items()) {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("FImpl.GetByPath: index %d exceeds length of slice in 'items' (length=%d) in node '%s'", index, len(i.Items()), nodePath)
 		}
 		child := i.Items()[index]
 		if child == nil {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("FImpl.GetByPath: item %d of slice in field 'items' is nil in node '%s'", index, nodePath)
 		}
-		if len(parts) == 1 {
+		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(parts[1])
+		return child.GetByPath(path)
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("FImpl.GetByPath: field '%s' does not exist in node '%s' of type 'F'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("FImpl.GetByPath: field '%s' does not exist in node '%s' of type 'F'", field.Value(), nodePath)
 	}
 }
 
@@ -516,12 +431,12 @@ func NewFItemData() FItemData {
 
 func (i *FItemData) IsFItem() {}
 
-func (i *FItemData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *FItemData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 }
 
-func (i *FItemData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *FItemData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	if i.ref != nil {
-		fn(i.ref, fieldNameRef, 0)
+		fn(i.ref, fieldNameRef, -1)
 	}
 }
 
@@ -542,37 +457,22 @@ type FItemImpl struct {
 	FItemData
 }
 
-func (i *FItemImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *FItemImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.FItemData.ForEachNode(fn)
 }
 
-func (i *FItemImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *FItemImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.FItemData.ForEachReference(fn)
 }
 
-func (i *FItemImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameRef:
-		return core.FieldInfos{Multi: false, Reference: true}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *FItemImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *FItemImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameRef:
 		return nil, fmt.Errorf("FItemImpl.GetByPath: field 'ref' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("FItemImpl.GetByPath: field '%s' does not exist in node '%s' of type 'FItem'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("FItemImpl.GetByPath: field '%s' does not exist in node '%s' of type 'FItem'", field.Value(), nodePath)
 	}
 }
 
@@ -603,12 +503,12 @@ func NewGData() GData {
 
 func (i *GData) IsG() {}
 
-func (i *GData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *GData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 }
 
-func (i *GData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *GData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	if i.ref != nil {
-		fn(i.ref, fieldNameRef, 0)
+		fn(i.ref, fieldNameRef, -1)
 	}
 }
 
@@ -630,39 +530,24 @@ type GImpl struct {
 	GData
 }
 
-func (i *GImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *GImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.ObjData.ForEachNode(fn)
 	i.GData.ForEachNode(fn)
 }
 
-func (i *GImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *GImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.ObjData.ForEachReference(fn)
 	i.GData.ForEachReference(fn)
 }
 
-func (i *GImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameRef:
-		return core.FieldInfos{Multi: false, Reference: true}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *GImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *GImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameRef:
 		return nil, fmt.Errorf("GImpl.GetByPath: field 'ref' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("GImpl.GetByPath: field '%s' does not exist in node '%s' of type 'G'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("GImpl.GetByPath: field '%s' does not exist in node '%s' of type 'G'", field.Value(), nodePath)
 	}
 }
 
@@ -693,13 +578,13 @@ func NewHData() HData {
 
 func (i *HData) IsH() {}
 
-func (i *HData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *HData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	if i.member != nil {
-		fn(i.member, fieldNameMember, 0)
+		fn(i.member, fieldNameMember, -1)
 	}
 }
 
-func (i *HData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *HData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 func (i *HData) Member() MemberCall {
@@ -720,47 +605,32 @@ type HImpl struct {
 	HData
 }
 
-func (i *HImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *HImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.ObjData.ForEachNode(fn)
 	i.HData.ForEachNode(fn)
 }
 
-func (i *HImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *HImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.ObjData.ForEachReference(fn)
 	i.HData.ForEachReference(fn)
 }
 
-func (i *HImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameMember:
-		return core.FieldInfos{Multi: false, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *HImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *HImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameMember:
 		if i.Member() == nil {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("HImpl.GetByPath: field 'member' is nil in node '%s'", nodePath)
 		}
 		child := i.Member()
-		if len(parts) == 1 {
+		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(parts[1])
+		return child.GetByPath(path)
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("HImpl.GetByPath: field '%s' does not exist in node '%s' of type 'H'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("HImpl.GetByPath: field '%s' does not exist in node '%s' of type 'H'", field.Value(), nodePath)
 	}
 }
 
@@ -792,15 +662,15 @@ func NewMemberCallData() MemberCallData {
 
 func (i *MemberCallData) IsMemberCall() {}
 
-func (i *MemberCallData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *MemberCallData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	if i.previous != nil {
-		fn(i.previous, fieldNamePrevious, 0)
+		fn(i.previous, fieldNamePrevious, -1)
 	}
 }
 
-func (i *MemberCallData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *MemberCallData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	if i.ref != nil {
-		fn(i.ref, fieldNameRef, 0)
+		fn(i.ref, fieldNameRef, -1)
 	}
 }
 
@@ -833,49 +703,32 @@ type MemberCallImpl struct {
 	MemberCallData
 }
 
-func (i *MemberCallImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *MemberCallImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.MemberCallData.ForEachNode(fn)
 }
 
-func (i *MemberCallImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *MemberCallImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.MemberCallData.ForEachReference(fn)
 }
 
-func (i *MemberCallImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNamePrevious:
-		return core.FieldInfos{Multi: false, Reference: false}
-	case fieldNameRef:
-		return core.FieldInfos{Multi: false, Reference: true}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *MemberCallImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *MemberCallImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNamePrevious:
 		if i.Previous() == nil {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("MemberCallImpl.GetByPath: field 'previous' is nil in node '%s'", nodePath)
 		}
 		child := i.Previous()
-		if len(parts) == 1 {
+		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(parts[1])
+		return child.GetByPath(path)
 	case fieldNameRef:
 		return nil, fmt.Errorf("MemberCallImpl.GetByPath: field 'ref' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("MemberCallImpl.GetByPath: field '%s' does not exist in node '%s' of type 'MemberCall'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("MemberCallImpl.GetByPath: field '%s' does not exist in node '%s' of type 'MemberCall'", field.Value(), nodePath)
 	}
 }
 
@@ -906,12 +759,12 @@ func NewJData() JData {
 
 func (i *JData) IsJ() {}
 
-func (i *JData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *JData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 }
 
-func (i *JData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *JData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	if i.ref != nil {
-		fn(i.ref, fieldNameRef, 0)
+		fn(i.ref, fieldNameRef, -1)
 	}
 }
 
@@ -933,39 +786,24 @@ type JImpl struct {
 	JData
 }
 
-func (i *JImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *JImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.ObjData.ForEachNode(fn)
 	i.JData.ForEachNode(fn)
 }
 
-func (i *JImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *JImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.ObjData.ForEachReference(fn)
 	i.JData.ForEachReference(fn)
 }
 
-func (i *JImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameRef:
-		return core.FieldInfos{Multi: false, Reference: true}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *JImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *JImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameRef:
 		return nil, fmt.Errorf("JImpl.GetByPath: field 'ref' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("JImpl.GetByPath: field '%s' does not exist in node '%s' of type 'J'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("JImpl.GetByPath: field '%s' does not exist in node '%s' of type 'J'", field.Value(), nodePath)
 	}
 }
 
@@ -999,15 +837,15 @@ func NewKData() KData {
 
 func (i *KData) IsK() {}
 
-func (i *KData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *KData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 }
 
-func (i *KData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *KData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	if i.ref1 != nil {
-		fn(i.ref1, fieldNameRef1, 0)
+		fn(i.ref1, fieldNameRef1, -1)
 	}
 	if i.ref2 != nil {
-		fn(i.ref2, fieldNameRef2, 0)
+		fn(i.ref2, fieldNameRef2, -1)
 	}
 }
 
@@ -1041,43 +879,26 @@ type KImpl struct {
 	KData
 }
 
-func (i *KImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *KImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.ObjData.ForEachNode(fn)
 	i.KData.ForEachNode(fn)
 }
 
-func (i *KImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *KImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.ObjData.ForEachReference(fn)
 	i.KData.ForEachReference(fn)
 }
 
-func (i *KImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameRef1:
-		return core.FieldInfos{Multi: false, Reference: true}
-	case fieldNameRef2:
-		return core.FieldInfos{Multi: false, Reference: true}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *KImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *KImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameRef1:
 		return nil, fmt.Errorf("KImpl.GetByPath: field 'ref1' is a cross-reference instead of a container field")
 	case fieldNameRef2:
 		return nil, fmt.Errorf("KImpl.GetByPath: field 'ref2' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("KImpl.GetByPath: field '%s' does not exist in node '%s' of type 'K'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("KImpl.GetByPath: field '%s' does not exist in node '%s' of type 'K'", field.Value(), nodePath)
 	}
 }
 
@@ -1108,12 +929,12 @@ func NewNData() NData {
 
 func (i *NData) IsN() {}
 
-func (i *NData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *NData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 }
 
-func (i *NData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *NData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	if i.ref != nil {
-		fn(i.ref, fieldNameRef, 0)
+		fn(i.ref, fieldNameRef, -1)
 	}
 }
 
@@ -1135,39 +956,24 @@ type NImpl struct {
 	NData
 }
 
-func (i *NImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *NImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.ObjData.ForEachNode(fn)
 	i.NData.ForEachNode(fn)
 }
 
-func (i *NImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *NImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.ObjData.ForEachReference(fn)
 	i.NData.ForEachReference(fn)
 }
 
-func (i *NImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameRef:
-		return core.FieldInfos{Multi: false, Reference: true}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *NImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *NImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameRef:
 		return nil, fmt.Errorf("NImpl.GetByPath: field 'ref' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("NImpl.GetByPath: field '%s' does not exist in node '%s' of type 'N'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("NImpl.GetByPath: field '%s' does not exist in node '%s' of type 'N'", field.Value(), nodePath)
 	}
 }
 
@@ -1198,12 +1004,12 @@ func NewOData() OData {
 
 func (i *OData) IsO() {}
 
-func (i *OData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *OData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 }
 
-func (i *OData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *OData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	if i.ref != nil {
-		fn(i.ref, fieldNameRef, 0)
+		fn(i.ref, fieldNameRef, -1)
 	}
 }
 
@@ -1225,39 +1031,24 @@ type OImpl struct {
 	OData
 }
 
-func (i *OImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *OImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.ObjData.ForEachNode(fn)
 	i.OData.ForEachNode(fn)
 }
 
-func (i *OImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *OImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.ObjData.ForEachReference(fn)
 	i.OData.ForEachReference(fn)
 }
 
-func (i *OImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameRef:
-		return core.FieldInfos{Multi: false, Reference: true}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *OImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *OImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameRef:
 		return nil, fmt.Errorf("OImpl.GetByPath: field 'ref' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("OImpl.GetByPath: field '%s' does not exist in node '%s' of type 'O'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("OImpl.GetByPath: field '%s' does not exist in node '%s' of type 'O'", field.Value(), nodePath)
 	}
 }
 

--- a/internal/languages/completion/types_gen.go
+++ b/internal/languages/completion/types_gen.go
@@ -50,10 +50,10 @@ func (i *ObjImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[
 	i.ObjData.ForEachReference(fn)
 }
 
-func (i *ObjImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *ObjImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
-	nodePath, _ := core.NodePath(i)
-	return nil, fmt.Errorf("ObjImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Obj'", field.Value(), nodePath)
+	nodePath, _ := core.PathOf(i)
+	return nil, fmt.Errorf("ObjImpl.Resolve: field '%s' does not exist in node '%s' of type 'Obj'", field.Value(), nodePath)
 }
 
 type Root interface {
@@ -113,26 +113,26 @@ func (i *RootImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle
 	i.RootData.ForEachReference(fn)
 }
 
-func (i *RootImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *RootImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, index := path.Shift()
 	switch field {
 	case fieldNameObjects:
 		if index >= len(i.Objects()) {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("RootImpl.GetByPath: index %d exceeds length of slice in 'objects' (length=%d) in node '%s'", index, len(i.Objects()), nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("RootImpl.Resolve: index %d exceeds length of slice in 'objects' (length=%d) in node '%s'", index, len(i.Objects()), nodePath)
 		}
 		child := i.Objects()[index]
 		if child == nil {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("RootImpl.GetByPath: item %d of slice in field 'objects' is nil in node '%s'", index, nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("RootImpl.Resolve: item %d of slice in field 'objects' is nil in node '%s'", index, nodePath)
 		}
 		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(path)
+		return child.Resolve(path)
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("RootImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Root'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("RootImpl.Resolve: field '%s' does not exist in node '%s' of type 'Root'", field.Value(), nodePath)
 	}
 }
 
@@ -221,28 +221,28 @@ func (i *DeclareImpl) ForEachReference(fn func(core.UntypedReference, unique.Han
 	i.DeclareData.ForEachReference(fn)
 }
 
-func (i *DeclareImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *DeclareImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, index := path.Shift()
 	switch field {
 	case fieldNameChildren:
 		if index >= len(i.Children()) {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("DeclareImpl.GetByPath: index %d exceeds length of slice in 'children' (length=%d) in node '%s'", index, len(i.Children()), nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("DeclareImpl.Resolve: index %d exceeds length of slice in 'children' (length=%d) in node '%s'", index, len(i.Children()), nodePath)
 		}
 		child := i.Children()[index]
 		if child == nil {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("DeclareImpl.GetByPath: item %d of slice in field 'children' is nil in node '%s'", index, nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("DeclareImpl.Resolve: item %d of slice in field 'children' is nil in node '%s'", index, nodePath)
 		}
 		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(path)
+		return child.Resolve(path)
 	case fieldNameName:
-		return nil, fmt.Errorf("DeclareImpl.GetByPath: field 'name' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("DeclareImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("DeclareImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Declare'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("DeclareImpl.Resolve: field '%s' does not exist in node '%s' of type 'Declare'", field.Value(), nodePath)
 	}
 }
 
@@ -310,14 +310,14 @@ func (i *EImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[st
 	i.EData.ForEachReference(fn)
 }
 
-func (i *EImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *EImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameRef:
-		return nil, fmt.Errorf("EImpl.GetByPath: field 'ref' is a cross-reference instead of a container field")
+		return nil, fmt.Errorf("EImpl.Resolve: field 'ref' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("EImpl.GetByPath: field '%s' does not exist in node '%s' of type 'E'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("EImpl.Resolve: field '%s' does not exist in node '%s' of type 'E'", field.Value(), nodePath)
 	}
 }
 
@@ -383,26 +383,26 @@ func (i *FImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[st
 	i.FData.ForEachReference(fn)
 }
 
-func (i *FImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *FImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, index := path.Shift()
 	switch field {
 	case fieldNameItems:
 		if index >= len(i.Items()) {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("FImpl.GetByPath: index %d exceeds length of slice in 'items' (length=%d) in node '%s'", index, len(i.Items()), nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("FImpl.Resolve: index %d exceeds length of slice in 'items' (length=%d) in node '%s'", index, len(i.Items()), nodePath)
 		}
 		child := i.Items()[index]
 		if child == nil {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("FImpl.GetByPath: item %d of slice in field 'items' is nil in node '%s'", index, nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("FImpl.Resolve: item %d of slice in field 'items' is nil in node '%s'", index, nodePath)
 		}
 		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(path)
+		return child.Resolve(path)
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("FImpl.GetByPath: field '%s' does not exist in node '%s' of type 'F'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("FImpl.Resolve: field '%s' does not exist in node '%s' of type 'F'", field.Value(), nodePath)
 	}
 }
 
@@ -465,14 +465,14 @@ func (i *FItemImpl) ForEachReference(fn func(core.UntypedReference, unique.Handl
 	i.FItemData.ForEachReference(fn)
 }
 
-func (i *FItemImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *FItemImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameRef:
-		return nil, fmt.Errorf("FItemImpl.GetByPath: field 'ref' is a cross-reference instead of a container field")
+		return nil, fmt.Errorf("FItemImpl.Resolve: field 'ref' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("FItemImpl.GetByPath: field '%s' does not exist in node '%s' of type 'FItem'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("FItemImpl.Resolve: field '%s' does not exist in node '%s' of type 'FItem'", field.Value(), nodePath)
 	}
 }
 
@@ -540,14 +540,14 @@ func (i *GImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[st
 	i.GData.ForEachReference(fn)
 }
 
-func (i *GImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *GImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameRef:
-		return nil, fmt.Errorf("GImpl.GetByPath: field 'ref' is a cross-reference instead of a container field")
+		return nil, fmt.Errorf("GImpl.Resolve: field 'ref' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("GImpl.GetByPath: field '%s' does not exist in node '%s' of type 'G'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("GImpl.Resolve: field '%s' does not exist in node '%s' of type 'G'", field.Value(), nodePath)
 	}
 }
 
@@ -615,22 +615,22 @@ func (i *HImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[st
 	i.HData.ForEachReference(fn)
 }
 
-func (i *HImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *HImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameMember:
 		if i.Member() == nil {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("HImpl.GetByPath: field 'member' is nil in node '%s'", nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("HImpl.Resolve: field 'member' is nil in node '%s'", nodePath)
 		}
 		child := i.Member()
 		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(path)
+		return child.Resolve(path)
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("HImpl.GetByPath: field '%s' does not exist in node '%s' of type 'H'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("HImpl.Resolve: field '%s' does not exist in node '%s' of type 'H'", field.Value(), nodePath)
 	}
 }
 
@@ -711,24 +711,24 @@ func (i *MemberCallImpl) ForEachReference(fn func(core.UntypedReference, unique.
 	i.MemberCallData.ForEachReference(fn)
 }
 
-func (i *MemberCallImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *MemberCallImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNamePrevious:
 		if i.Previous() == nil {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("MemberCallImpl.GetByPath: field 'previous' is nil in node '%s'", nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("MemberCallImpl.Resolve: field 'previous' is nil in node '%s'", nodePath)
 		}
 		child := i.Previous()
 		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(path)
+		return child.Resolve(path)
 	case fieldNameRef:
-		return nil, fmt.Errorf("MemberCallImpl.GetByPath: field 'ref' is a cross-reference instead of a container field")
+		return nil, fmt.Errorf("MemberCallImpl.Resolve: field 'ref' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("MemberCallImpl.GetByPath: field '%s' does not exist in node '%s' of type 'MemberCall'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("MemberCallImpl.Resolve: field '%s' does not exist in node '%s' of type 'MemberCall'", field.Value(), nodePath)
 	}
 }
 
@@ -796,14 +796,14 @@ func (i *JImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[st
 	i.JData.ForEachReference(fn)
 }
 
-func (i *JImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *JImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameRef:
-		return nil, fmt.Errorf("JImpl.GetByPath: field 'ref' is a cross-reference instead of a container field")
+		return nil, fmt.Errorf("JImpl.Resolve: field 'ref' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("JImpl.GetByPath: field '%s' does not exist in node '%s' of type 'J'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("JImpl.Resolve: field '%s' does not exist in node '%s' of type 'J'", field.Value(), nodePath)
 	}
 }
 
@@ -889,16 +889,16 @@ func (i *KImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[st
 	i.KData.ForEachReference(fn)
 }
 
-func (i *KImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *KImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameRef1:
-		return nil, fmt.Errorf("KImpl.GetByPath: field 'ref1' is a cross-reference instead of a container field")
+		return nil, fmt.Errorf("KImpl.Resolve: field 'ref1' is a cross-reference instead of a container field")
 	case fieldNameRef2:
-		return nil, fmt.Errorf("KImpl.GetByPath: field 'ref2' is a cross-reference instead of a container field")
+		return nil, fmt.Errorf("KImpl.Resolve: field 'ref2' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("KImpl.GetByPath: field '%s' does not exist in node '%s' of type 'K'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("KImpl.Resolve: field '%s' does not exist in node '%s' of type 'K'", field.Value(), nodePath)
 	}
 }
 
@@ -966,14 +966,14 @@ func (i *NImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[st
 	i.NData.ForEachReference(fn)
 }
 
-func (i *NImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *NImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameRef:
-		return nil, fmt.Errorf("NImpl.GetByPath: field 'ref' is a cross-reference instead of a container field")
+		return nil, fmt.Errorf("NImpl.Resolve: field 'ref' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("NImpl.GetByPath: field '%s' does not exist in node '%s' of type 'N'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("NImpl.Resolve: field '%s' does not exist in node '%s' of type 'N'", field.Value(), nodePath)
 	}
 }
 
@@ -1041,14 +1041,14 @@ func (i *OImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[st
 	i.OData.ForEachReference(fn)
 }
 
-func (i *OImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *OImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameRef:
-		return nil, fmt.Errorf("OImpl.GetByPath: field 'ref' is a cross-reference instead of a container field")
+		return nil, fmt.Errorf("OImpl.Resolve: field 'ref' is a cross-reference instead of a container field")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("OImpl.GetByPath: field '%s' does not exist in node '%s' of type 'O'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("OImpl.Resolve: field '%s' does not exist in node '%s' of type 'O'", field.Value(), nodePath)
 	}
 }
 

--- a/internal/languages/lookahead/types_gen.go
+++ b/internal/languages/lookahead/types_gen.go
@@ -115,9 +115,9 @@ func (i *ObjImpl) GetByPath(path string) (core.AstNode, error) {
 	field := unique.Make(fieldAndIndex[0])
 	switch field {
 	case fieldNameNode:
-		return nil, fmt.Errorf("ObjImpl.GetByPath: field 'node' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("ObjImpl.GetByPath: field 'node' holds a primitive value instead of an ast node")
 	case fieldNameValue:
-		return nil, fmt.Errorf("ObjImpl.GetByPath: field 'value' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("ObjImpl.GetByPath: field 'value' holds a primitive value instead of an ast node")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("ObjImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Obj'", fieldAndIndex[0], nodePath)
@@ -306,11 +306,11 @@ func (i *BImpl) GetByPath(path string) (core.AstNode, error) {
 	field := unique.Make(fieldAndIndex[0])
 	switch field {
 	case fieldNameNode:
-		return nil, fmt.Errorf("BImpl.GetByPath: field 'node' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("BImpl.GetByPath: field 'node' holds a primitive value instead of an ast node")
 	case fieldNamePost:
-		return nil, fmt.Errorf("BImpl.GetByPath: field 'post' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("BImpl.GetByPath: field 'post' holds a primitive value instead of an ast node")
 	case fieldNameValue:
-		return nil, fmt.Errorf("BImpl.GetByPath: field 'value' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("BImpl.GetByPath: field 'value' holds a primitive value instead of an ast node")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("BImpl.GetByPath: field '%s' does not exist in node '%s' of type 'B'", fieldAndIndex[0], nodePath)

--- a/internal/languages/lookahead/types_gen.go
+++ b/internal/languages/lookahead/types_gen.go
@@ -4,6 +4,7 @@ package lookahead
 
 import (
 	core "typefox.dev/fastbelt"
+	"unique"
 )
 
 type Obj interface {
@@ -36,13 +37,13 @@ func NewObjData() ObjData {
 
 func (i *ObjData) IsObj() {}
 
-func (i *ObjData) ForEachNode(fn func(core.AstNode)) {
+func (i *ObjData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	if i.node != nil {
-		fn(i.node)
+		fn(i.node, unique.Make("node"), 0)
 	}
 }
 
-func (i *ObjData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *ObjData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 func (i *ObjData) Value() string {
@@ -82,12 +83,16 @@ type ObjImpl struct {
 	ObjData
 }
 
-func (i *ObjImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *ObjImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.ObjData.ForEachNode(fn)
 }
 
-func (i *ObjImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *ObjImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.ObjData.ForEachReference(fn)
+}
+
+func (i *ObjImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return LookaheadFieldInfos["Obj"][field.Value()]
 }
 
 type Root interface {
@@ -115,13 +120,13 @@ func NewRootData() RootData {
 
 func (i *RootData) IsRoot() {}
 
-func (i *RootData) ForEachNode(fn func(core.AstNode)) {
+func (i *RootData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	if i.item != nil {
-		fn(i.item)
+		fn(i.item, unique.Make("item"), 0)
 	}
 }
 
-func (i *RootData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *RootData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 func (i *RootData) Item() Obj {
@@ -141,12 +146,16 @@ type RootImpl struct {
 	RootData
 }
 
-func (i *RootImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *RootImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.RootData.ForEachNode(fn)
 }
 
-func (i *RootImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *RootImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.RootData.ForEachReference(fn)
+}
+
+func (i *RootImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return LookaheadFieldInfos["Root"][field.Value()]
 }
 
 type B interface {
@@ -177,10 +186,10 @@ func NewBData() BData {
 
 func (i *BData) IsB() {}
 
-func (i *BData) ForEachNode(fn func(core.AstNode)) {
+func (i *BData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 }
 
-func (i *BData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *BData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 func (i *BData) Post() string {
@@ -205,18 +214,55 @@ type BImpl struct {
 	BData
 }
 
-func (i *BImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *BImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.ObjData.ForEachNode(fn)
 	i.BData.ForEachNode(fn)
 }
 
-func (i *BImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *BImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.ObjData.ForEachReference(fn)
 	i.BData.ForEachReference(fn)
+}
+
+func (i *BImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return LookaheadFieldInfos["B"][field.Value()]
 }
 
 var LookaheadSyntheticFactories = map[string]func() core.AstNode{
 	"B":    func() core.AstNode { return NewB() },
 	"Obj":  func() core.AstNode { return NewObj() },
 	"Root": func() core.AstNode { return NewRoot() },
+}
+
+var LookaheadFieldInfos = map[string]map[string]core.FieldInfos{
+	"B": map[string]core.FieldInfos{
+		"node": {
+			Multi:     false,
+			Reference: false,
+		},
+		"post": {
+			Multi:     false,
+			Reference: false,
+		},
+		"value": {
+			Multi:     false,
+			Reference: false,
+		},
+	},
+	"Obj": map[string]core.FieldInfos{
+		"node": {
+			Multi:     false,
+			Reference: false,
+		},
+		"value": {
+			Multi:     false,
+			Reference: false,
+		},
+	},
+	"Root": map[string]core.FieldInfos{
+		"item": {
+			Multi:     false,
+			Reference: false,
+		},
+	},
 }

--- a/internal/languages/lookahead/types_gen.go
+++ b/internal/languages/lookahead/types_gen.go
@@ -204,7 +204,7 @@ func (i *RootImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameItem:
 		if i.Item() == nil {
 			nodePath, _ := i.AstNodeBase.NodePath()
-			return nil, fmt.Errorf("RootImpl.GetByPath: field 'item' is nil at '%s'", nodePath)
+			return nil, fmt.Errorf("RootImpl.GetByPath: field 'item' is nil in node '%s'", nodePath)
 		}
 		child := i.Item()
 		if len(parts) == 1 {

--- a/internal/languages/lookahead/types_gen.go
+++ b/internal/languages/lookahead/types_gen.go
@@ -3,8 +3,11 @@
 package lookahead
 
 import (
-	core "typefox.dev/fastbelt"
+	"fmt"
+	"strings"
 	"unique"
+
+	core "typefox.dev/fastbelt"
 )
 
 type Obj interface {
@@ -102,6 +105,25 @@ func (i *ObjImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
 	}
 }
 
+func (i *ObjImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameNode:
+		return nil, fmt.Errorf("ObjImpl.GetByPath: field 'node' holds a primitive value and cannot be navigated")
+	case fieldNameValue:
+		return nil, fmt.Errorf("ObjImpl.GetByPath: field 'value' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("ObjImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Obj'", fieldAndIndex[0], nodePath)
+	}
+}
+
 type Root interface {
 	core.AstNode
 
@@ -167,6 +189,31 @@ func (i *RootImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
 		return core.FieldInfos{Multi: false, Reference: false}
 	default:
 		return core.FieldInfos{}
+	}
+}
+
+func (i *RootImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameItem:
+		if i.Item() == nil {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("RootImpl.GetByPath: field 'item' is nil at '%s'", nodePath)
+		}
+		child := i.Item()
+		if len(parts) == 1 {
+			return child, nil
+		}
+		return child.GetByPath(parts[1])
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("RootImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Root'", fieldAndIndex[0], nodePath)
 	}
 }
 
@@ -246,6 +293,27 @@ func (i *BImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
 		return core.FieldInfos{Multi: false, Reference: false}
 	default:
 		return core.FieldInfos{}
+	}
+}
+
+func (i *BImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameNode:
+		return nil, fmt.Errorf("BImpl.GetByPath: field 'node' holds a primitive value and cannot be navigated")
+	case fieldNamePost:
+		return nil, fmt.Errorf("BImpl.GetByPath: field 'post' holds a primitive value and cannot be navigated")
+	case fieldNameValue:
+		return nil, fmt.Errorf("BImpl.GetByPath: field 'value' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("BImpl.GetByPath: field '%s' does not exist in node '%s' of type 'B'", fieldAndIndex[0], nodePath)
 	}
 }
 

--- a/internal/languages/lookahead/types_gen.go
+++ b/internal/languages/lookahead/types_gen.go
@@ -39,7 +39,7 @@ func (i *ObjData) IsObj() {}
 
 func (i *ObjData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	if i.node != nil {
-		fn(i.node, unique.Make("node"), 0)
+		fn(i.node, fieldNameNode, 0)
 	}
 }
 
@@ -92,7 +92,14 @@ func (i *ObjImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[
 }
 
 func (i *ObjImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return LookaheadFieldInfos["Obj"][field.Value()]
+	switch field {
+	case fieldNameNode:
+		return core.FieldInfos{Multi: false, Reference: false}
+	case fieldNameValue:
+		return core.FieldInfos{Multi: false, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type Root interface {
@@ -122,7 +129,7 @@ func (i *RootData) IsRoot() {}
 
 func (i *RootData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	if i.item != nil {
-		fn(i.item, unique.Make("item"), 0)
+		fn(i.item, fieldNameItem, 0)
 	}
 }
 
@@ -155,7 +162,12 @@ func (i *RootImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle
 }
 
 func (i *RootImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return LookaheadFieldInfos["Root"][field.Value()]
+	switch field {
+	case fieldNameItem:
+		return core.FieldInfos{Multi: false, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type B interface {
@@ -225,44 +237,27 @@ func (i *BImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[st
 }
 
 func (i *BImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return LookaheadFieldInfos["B"][field.Value()]
+	switch field {
+	case fieldNameNode:
+		return core.FieldInfos{Multi: false, Reference: false}
+	case fieldNamePost:
+		return core.FieldInfos{Multi: false, Reference: false}
+	case fieldNameValue:
+		return core.FieldInfos{Multi: false, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
+
+var (
+	fieldNameItem  = unique.Make("item")
+	fieldNameNode  = unique.Make("node")
+	fieldNamePost  = unique.Make("post")
+	fieldNameValue = unique.Make("value")
+)
 
 var LookaheadSyntheticFactories = map[string]func() core.AstNode{
 	"B":    func() core.AstNode { return NewB() },
 	"Obj":  func() core.AstNode { return NewObj() },
 	"Root": func() core.AstNode { return NewRoot() },
-}
-
-var LookaheadFieldInfos = map[string]map[string]core.FieldInfos{
-	"B": map[string]core.FieldInfos{
-		"node": {
-			Multi:     false,
-			Reference: false,
-		},
-		"post": {
-			Multi:     false,
-			Reference: false,
-		},
-		"value": {
-			Multi:     false,
-			Reference: false,
-		},
-	},
-	"Obj": map[string]core.FieldInfos{
-		"node": {
-			Multi:     false,
-			Reference: false,
-		},
-		"value": {
-			Multi:     false,
-			Reference: false,
-		},
-	},
-	"Root": map[string]core.FieldInfos{
-		"item": {
-			Multi:     false,
-			Reference: false,
-		},
-	},
 }

--- a/internal/languages/lookahead/types_gen.go
+++ b/internal/languages/lookahead/types_gen.go
@@ -4,7 +4,6 @@ package lookahead
 
 import (
 	"fmt"
-	"strings"
 	"unique"
 
 	core "typefox.dev/fastbelt"
@@ -40,13 +39,13 @@ func NewObjData() ObjData {
 
 func (i *ObjData) IsObj() {}
 
-func (i *ObjData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *ObjData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	if i.node != nil {
-		fn(i.node, fieldNameNode, 0)
+		fn(i.node, fieldNameNode, -1)
 	}
 }
 
-func (i *ObjData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *ObjData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 func (i *ObjData) Value() string {
@@ -86,41 +85,24 @@ type ObjImpl struct {
 	ObjData
 }
 
-func (i *ObjImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *ObjImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.ObjData.ForEachNode(fn)
 }
 
-func (i *ObjImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *ObjImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.ObjData.ForEachReference(fn)
 }
 
-func (i *ObjImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameNode:
-		return core.FieldInfos{Multi: false, Reference: false}
-	case fieldNameValue:
-		return core.FieldInfos{Multi: false, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *ObjImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *ObjImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameNode:
 		return nil, fmt.Errorf("ObjImpl.GetByPath: field 'node' holds a primitive value instead of an ast node")
 	case fieldNameValue:
 		return nil, fmt.Errorf("ObjImpl.GetByPath: field 'value' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("ObjImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Obj'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("ObjImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Obj'", field.Value(), nodePath)
 	}
 }
 
@@ -149,13 +131,13 @@ func NewRootData() RootData {
 
 func (i *RootData) IsRoot() {}
 
-func (i *RootData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *RootData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	if i.item != nil {
-		fn(i.item, fieldNameItem, 0)
+		fn(i.item, fieldNameItem, -1)
 	}
 }
 
-func (i *RootData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *RootData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 func (i *RootData) Item() Obj {
@@ -175,45 +157,30 @@ type RootImpl struct {
 	RootData
 }
 
-func (i *RootImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *RootImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.RootData.ForEachNode(fn)
 }
 
-func (i *RootImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *RootImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.RootData.ForEachReference(fn)
 }
 
-func (i *RootImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameItem:
-		return core.FieldInfos{Multi: false, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *RootImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *RootImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameItem:
 		if i.Item() == nil {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("RootImpl.GetByPath: field 'item' is nil in node '%s'", nodePath)
 		}
 		child := i.Item()
-		if len(parts) == 1 {
+		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(parts[1])
+		return child.GetByPath(path)
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("RootImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Root'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("RootImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Root'", field.Value(), nodePath)
 	}
 }
 
@@ -245,10 +212,10 @@ func NewBData() BData {
 
 func (i *BData) IsB() {}
 
-func (i *BData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *BData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 }
 
-func (i *BData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *BData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 func (i *BData) Post() string {
@@ -273,37 +240,18 @@ type BImpl struct {
 	BData
 }
 
-func (i *BImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *BImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.ObjData.ForEachNode(fn)
 	i.BData.ForEachNode(fn)
 }
 
-func (i *BImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *BImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.ObjData.ForEachReference(fn)
 	i.BData.ForEachReference(fn)
 }
 
-func (i *BImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameNode:
-		return core.FieldInfos{Multi: false, Reference: false}
-	case fieldNamePost:
-		return core.FieldInfos{Multi: false, Reference: false}
-	case fieldNameValue:
-		return core.FieldInfos{Multi: false, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *BImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *BImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameNode:
 		return nil, fmt.Errorf("BImpl.GetByPath: field 'node' holds a primitive value instead of an ast node")
@@ -312,8 +260,8 @@ func (i *BImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameValue:
 		return nil, fmt.Errorf("BImpl.GetByPath: field 'value' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("BImpl.GetByPath: field '%s' does not exist in node '%s' of type 'B'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("BImpl.GetByPath: field '%s' does not exist in node '%s' of type 'B'", field.Value(), nodePath)
 	}
 }
 

--- a/internal/languages/lookahead/types_gen.go
+++ b/internal/languages/lookahead/types_gen.go
@@ -94,7 +94,10 @@ func (i *ObjImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[
 }
 
 func (i *ObjImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameNode:
 		return nil, fmt.Errorf("ObjImpl.Resolve: field 'node' holds a primitive value instead of an ast node")
@@ -166,7 +169,10 @@ func (i *RootImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle
 }
 
 func (i *RootImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameItem:
 		if i.Item() == nil {
@@ -174,10 +180,7 @@ func (i *RootImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 			return nil, fmt.Errorf("RootImpl.Resolve: field 'item' is nil in node '%s'", nodePath)
 		}
 		child := i.Item()
-		if path.Empty() {
-			return child, nil
-		}
-		return child.Resolve(path)
+		return child.Resolve(path.Tail())
 	default:
 		nodePath, _ := core.PathOf(i)
 		return nil, fmt.Errorf("RootImpl.Resolve: field '%s' does not exist in node '%s' of type 'Root'", field.Value(), nodePath)
@@ -251,7 +254,10 @@ func (i *BImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[st
 }
 
 func (i *BImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameNode:
 		return nil, fmt.Errorf("BImpl.Resolve: field 'node' holds a primitive value instead of an ast node")

--- a/internal/languages/lookahead/types_gen.go
+++ b/internal/languages/lookahead/types_gen.go
@@ -93,16 +93,16 @@ func (i *ObjImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[
 	i.ObjData.ForEachReference(fn)
 }
 
-func (i *ObjImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *ObjImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameNode:
-		return nil, fmt.Errorf("ObjImpl.GetByPath: field 'node' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("ObjImpl.Resolve: field 'node' holds a primitive value instead of an ast node")
 	case fieldNameValue:
-		return nil, fmt.Errorf("ObjImpl.GetByPath: field 'value' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("ObjImpl.Resolve: field 'value' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("ObjImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Obj'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("ObjImpl.Resolve: field '%s' does not exist in node '%s' of type 'Obj'", field.Value(), nodePath)
 	}
 }
 
@@ -165,22 +165,22 @@ func (i *RootImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle
 	i.RootData.ForEachReference(fn)
 }
 
-func (i *RootImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *RootImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameItem:
 		if i.Item() == nil {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("RootImpl.GetByPath: field 'item' is nil in node '%s'", nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("RootImpl.Resolve: field 'item' is nil in node '%s'", nodePath)
 		}
 		child := i.Item()
 		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(path)
+		return child.Resolve(path)
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("RootImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Root'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("RootImpl.Resolve: field '%s' does not exist in node '%s' of type 'Root'", field.Value(), nodePath)
 	}
 }
 
@@ -250,18 +250,18 @@ func (i *BImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[st
 	i.BData.ForEachReference(fn)
 }
 
-func (i *BImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *BImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameNode:
-		return nil, fmt.Errorf("BImpl.GetByPath: field 'node' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("BImpl.Resolve: field 'node' holds a primitive value instead of an ast node")
 	case fieldNamePost:
-		return nil, fmt.Errorf("BImpl.GetByPath: field 'post' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("BImpl.Resolve: field 'post' holds a primitive value instead of an ast node")
 	case fieldNameValue:
-		return nil, fmt.Errorf("BImpl.GetByPath: field 'value' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("BImpl.Resolve: field 'value' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("BImpl.GetByPath: field '%s' does not exist in node '%s' of type 'B'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("BImpl.Resolve: field '%s' does not exist in node '%s' of type 'B'", field.Value(), nodePath)
 	}
 }
 

--- a/internal/languages/token_groups/types_gen.go
+++ b/internal/languages/token_groups/types_gen.go
@@ -90,7 +90,7 @@ func (i *ModelImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameItem:
 		if i.Item() == nil {
 			nodePath, _ := i.AstNodeBase.NodePath()
-			return nil, fmt.Errorf("ModelImpl.GetByPath: field 'item' is nil at '%s'", nodePath)
+			return nil, fmt.Errorf("ModelImpl.GetByPath: field 'item' is nil in node '%s'", nodePath)
 		}
 		child := i.Item()
 		if len(parts) == 1 {

--- a/internal/languages/token_groups/types_gen.go
+++ b/internal/languages/token_groups/types_gen.go
@@ -3,8 +3,11 @@
 package token_groups
 
 import (
-	core "typefox.dev/fastbelt"
+	"fmt"
+	"strings"
 	"unique"
+
+	core "typefox.dev/fastbelt"
 )
 
 type Model interface {
@@ -75,6 +78,31 @@ func (i *ModelImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
 	}
 }
 
+func (i *ModelImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameItem:
+		if i.Item() == nil {
+			nodePath, _ := i.AstNodeBase.NodePath()
+			return nil, fmt.Errorf("ModelImpl.GetByPath: field 'item' is nil at '%s'", nodePath)
+		}
+		child := i.Item()
+		if len(parts) == 1 {
+			return child, nil
+		}
+		return child.GetByPath(parts[1])
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("ModelImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Model'", fieldAndIndex[0], nodePath)
+	}
+}
+
 type Item interface {
 	core.AstNode
 
@@ -142,6 +170,23 @@ func (i *ItemImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
 		return core.FieldInfos{Multi: false, Reference: false}
 	default:
 		return core.FieldInfos{}
+	}
+}
+
+func (i *ItemImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameValue:
+		return nil, fmt.Errorf("ItemImpl.GetByPath: field 'value' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("ItemImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Item'", fieldAndIndex[0], nodePath)
 	}
 }
 
@@ -241,6 +286,27 @@ func (i *RecoveryImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
 		return core.FieldInfos{Multi: false, Reference: false}
 	default:
 		return core.FieldInfos{}
+	}
+}
+
+func (i *RecoveryImpl) GetByPath(path string) (core.AstNode, error) {
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return i, nil
+	}
+	parts := strings.SplitN(path, "/", 2)
+	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
+	field := unique.Make(fieldAndIndex[0])
+	switch field {
+	case fieldNameFirst:
+		return nil, fmt.Errorf("RecoveryImpl.GetByPath: field 'first' holds a primitive value and cannot be navigated")
+	case fieldNameSecond:
+		return nil, fmt.Errorf("RecoveryImpl.GetByPath: field 'second' holds a primitive value and cannot be navigated")
+	case fieldNameValue:
+		return nil, fmt.Errorf("RecoveryImpl.GetByPath: field 'value' holds a primitive value and cannot be navigated")
+	default:
+		nodePath, _ := i.AstNodeBase.NodePath()
+		return nil, fmt.Errorf("RecoveryImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Recovery'", fieldAndIndex[0], nodePath)
 	}
 }
 

--- a/internal/languages/token_groups/types_gen.go
+++ b/internal/languages/token_groups/types_gen.go
@@ -183,7 +183,7 @@ func (i *ItemImpl) GetByPath(path string) (core.AstNode, error) {
 	field := unique.Make(fieldAndIndex[0])
 	switch field {
 	case fieldNameValue:
-		return nil, fmt.Errorf("ItemImpl.GetByPath: field 'value' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("ItemImpl.GetByPath: field 'value' holds a primitive value instead of an ast node")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("ItemImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Item'", fieldAndIndex[0], nodePath)
@@ -299,11 +299,11 @@ func (i *RecoveryImpl) GetByPath(path string) (core.AstNode, error) {
 	field := unique.Make(fieldAndIndex[0])
 	switch field {
 	case fieldNameFirst:
-		return nil, fmt.Errorf("RecoveryImpl.GetByPath: field 'first' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("RecoveryImpl.GetByPath: field 'first' holds a primitive value instead of an ast node")
 	case fieldNameSecond:
-		return nil, fmt.Errorf("RecoveryImpl.GetByPath: field 'second' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("RecoveryImpl.GetByPath: field 'second' holds a primitive value instead of an ast node")
 	case fieldNameValue:
-		return nil, fmt.Errorf("RecoveryImpl.GetByPath: field 'value' holds a primitive value and cannot be navigated")
+		return nil, fmt.Errorf("RecoveryImpl.GetByPath: field 'value' holds a primitive value instead of an ast node")
 	default:
 		nodePath, _ := i.AstNodeBase.NodePath()
 		return nil, fmt.Errorf("RecoveryImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Recovery'", fieldAndIndex[0], nodePath)

--- a/internal/languages/token_groups/types_gen.go
+++ b/internal/languages/token_groups/types_gen.go
@@ -34,7 +34,7 @@ func (i *ModelData) IsModel() {}
 
 func (i *ModelData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	if i.item != nil {
-		fn(i.item, unique.Make("item"), 0)
+		fn(i.item, fieldNameItem, 0)
 	}
 }
 
@@ -67,7 +67,12 @@ func (i *ModelImpl) ForEachReference(fn func(core.UntypedReference, unique.Handl
 }
 
 func (i *ModelImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return TokenGroupsFieldInfos["Model"][field.Value()]
+	switch field {
+	case fieldNameItem:
+		return core.FieldInfos{Multi: false, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type Item interface {
@@ -132,7 +137,12 @@ func (i *ItemImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle
 }
 
 func (i *ItemImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return TokenGroupsFieldInfos["Item"][field.Value()]
+	switch field {
+	case fieldNameValue:
+		return core.FieldInfos{Multi: false, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
 
 type Recovery interface {
@@ -222,40 +232,27 @@ func (i *RecoveryImpl) ForEachReference(fn func(core.UntypedReference, unique.Ha
 }
 
 func (i *RecoveryImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	return TokenGroupsFieldInfos["Recovery"][field.Value()]
+	switch field {
+	case fieldNameFirst:
+		return core.FieldInfos{Multi: false, Reference: false}
+	case fieldNameSecond:
+		return core.FieldInfos{Multi: false, Reference: false}
+	case fieldNameValue:
+		return core.FieldInfos{Multi: false, Reference: false}
+	default:
+		return core.FieldInfos{}
+	}
 }
+
+var (
+	fieldNameFirst  = unique.Make("first")
+	fieldNameItem   = unique.Make("item")
+	fieldNameSecond = unique.Make("second")
+	fieldNameValue  = unique.Make("value")
+)
 
 var TokenGroupsSyntheticFactories = map[string]func() core.AstNode{
 	"Item":     func() core.AstNode { return NewItem() },
 	"Model":    func() core.AstNode { return NewModel() },
 	"Recovery": func() core.AstNode { return NewRecovery() },
-}
-
-var TokenGroupsFieldInfos = map[string]map[string]core.FieldInfos{
-	"Item": map[string]core.FieldInfos{
-		"value": {
-			Multi:     false,
-			Reference: false,
-		},
-	},
-	"Model": map[string]core.FieldInfos{
-		"item": {
-			Multi:     false,
-			Reference: false,
-		},
-	},
-	"Recovery": map[string]core.FieldInfos{
-		"first": {
-			Multi:     false,
-			Reference: false,
-		},
-		"second": {
-			Multi:     false,
-			Reference: false,
-		},
-		"value": {
-			Multi:     false,
-			Reference: false,
-		},
-	},
 }

--- a/internal/languages/token_groups/types_gen.go
+++ b/internal/languages/token_groups/types_gen.go
@@ -4,6 +4,7 @@ package token_groups
 
 import (
 	core "typefox.dev/fastbelt"
+	"unique"
 )
 
 type Model interface {
@@ -31,13 +32,13 @@ func NewModelData() ModelData {
 
 func (i *ModelData) IsModel() {}
 
-func (i *ModelData) ForEachNode(fn func(core.AstNode)) {
+func (i *ModelData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	if i.item != nil {
-		fn(i.item)
+		fn(i.item, unique.Make("item"), 0)
 	}
 }
 
-func (i *ModelData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *ModelData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 func (i *ModelData) Item() Item {
@@ -57,12 +58,16 @@ type ModelImpl struct {
 	ModelData
 }
 
-func (i *ModelImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *ModelImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.ModelData.ForEachNode(fn)
 }
 
-func (i *ModelImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *ModelImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.ModelData.ForEachReference(fn)
+}
+
+func (i *ModelImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return TokenGroupsFieldInfos["Model"][field.Value()]
 }
 
 type Item interface {
@@ -91,10 +96,10 @@ func NewItemData() ItemData {
 
 func (i *ItemData) IsItem() {}
 
-func (i *ItemData) ForEachNode(fn func(core.AstNode)) {
+func (i *ItemData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 }
 
-func (i *ItemData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *ItemData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 func (i *ItemData) Value() string {
@@ -118,12 +123,16 @@ type ItemImpl struct {
 	ItemData
 }
 
-func (i *ItemImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *ItemImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.ItemData.ForEachNode(fn)
 }
 
-func (i *ItemImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *ItemImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.ItemData.ForEachReference(fn)
+}
+
+func (i *ItemImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return TokenGroupsFieldInfos["Item"][field.Value()]
 }
 
 type Recovery interface {
@@ -158,10 +167,10 @@ func NewRecoveryData() RecoveryData {
 
 func (i *RecoveryData) IsRecovery() {}
 
-func (i *RecoveryData) ForEachNode(fn func(core.AstNode)) {
+func (i *RecoveryData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 }
 
-func (i *RecoveryData) ForEachReference(fn func(core.UntypedReference)) {
+func (i *RecoveryData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 }
 
 func (i *RecoveryData) First() string {
@@ -202,18 +211,51 @@ type RecoveryImpl struct {
 	RecoveryData
 }
 
-func (i *RecoveryImpl) ForEachNode(fn func(core.AstNode)) {
+func (i *RecoveryImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
 	i.ItemData.ForEachNode(fn)
 	i.RecoveryData.ForEachNode(fn)
 }
 
-func (i *RecoveryImpl) ForEachReference(fn func(core.UntypedReference)) {
+func (i *RecoveryImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
 	i.ItemData.ForEachReference(fn)
 	i.RecoveryData.ForEachReference(fn)
+}
+
+func (i *RecoveryImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
+	return TokenGroupsFieldInfos["Recovery"][field.Value()]
 }
 
 var TokenGroupsSyntheticFactories = map[string]func() core.AstNode{
 	"Item":     func() core.AstNode { return NewItem() },
 	"Model":    func() core.AstNode { return NewModel() },
 	"Recovery": func() core.AstNode { return NewRecovery() },
+}
+
+var TokenGroupsFieldInfos = map[string]map[string]core.FieldInfos{
+	"Item": map[string]core.FieldInfos{
+		"value": {
+			Multi:     false,
+			Reference: false,
+		},
+	},
+	"Model": map[string]core.FieldInfos{
+		"item": {
+			Multi:     false,
+			Reference: false,
+		},
+	},
+	"Recovery": map[string]core.FieldInfos{
+		"first": {
+			Multi:     false,
+			Reference: false,
+		},
+		"second": {
+			Multi:     false,
+			Reference: false,
+		},
+		"value": {
+			Multi:     false,
+			Reference: false,
+		},
+	},
 }

--- a/internal/languages/token_groups/types_gen.go
+++ b/internal/languages/token_groups/types_gen.go
@@ -69,7 +69,10 @@ func (i *ModelImpl) ForEachReference(fn func(core.UntypedReference, unique.Handl
 }
 
 func (i *ModelImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameItem:
 		if i.Item() == nil {
@@ -77,10 +80,7 @@ func (i *ModelImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 			return nil, fmt.Errorf("ModelImpl.Resolve: field 'item' is nil in node '%s'", nodePath)
 		}
 		child := i.Item()
-		if path.Empty() {
-			return child, nil
-		}
-		return child.Resolve(path)
+		return child.Resolve(path.Tail())
 	default:
 		nodePath, _ := core.PathOf(i)
 		return nil, fmt.Errorf("ModelImpl.Resolve: field '%s' does not exist in node '%s' of type 'Model'", field.Value(), nodePath)
@@ -149,7 +149,10 @@ func (i *ItemImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle
 }
 
 func (i *ItemImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameValue:
 		return nil, fmt.Errorf("ItemImpl.Resolve: field 'value' holds a primitive value instead of an ast node")
@@ -246,7 +249,10 @@ func (i *RecoveryImpl) ForEachReference(fn func(core.UntypedReference, unique.Ha
 }
 
 func (i *RecoveryImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
-	field, _ := path.Shift()
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
 	switch field {
 	case fieldNameFirst:
 		return nil, fmt.Errorf("RecoveryImpl.Resolve: field 'first' holds a primitive value instead of an ast node")

--- a/internal/languages/token_groups/types_gen.go
+++ b/internal/languages/token_groups/types_gen.go
@@ -4,7 +4,6 @@ package token_groups
 
 import (
 	"fmt"
-	"strings"
 	"unique"
 
 	core "typefox.dev/fastbelt"
@@ -35,13 +34,13 @@ func NewModelData() ModelData {
 
 func (i *ModelData) IsModel() {}
 
-func (i *ModelData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *ModelData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	if i.item != nil {
-		fn(i.item, fieldNameItem, 0)
+		fn(i.item, fieldNameItem, -1)
 	}
 }
 
-func (i *ModelData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *ModelData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 func (i *ModelData) Item() Item {
@@ -61,45 +60,30 @@ type ModelImpl struct {
 	ModelData
 }
 
-func (i *ModelImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *ModelImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.ModelData.ForEachNode(fn)
 }
 
-func (i *ModelImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *ModelImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.ModelData.ForEachReference(fn)
 }
 
-func (i *ModelImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameItem:
-		return core.FieldInfos{Multi: false, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *ModelImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *ModelImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameItem:
 		if i.Item() == nil {
-			nodePath, _ := i.AstNodeBase.NodePath()
+			nodePath, _ := core.NodePath(i)
 			return nil, fmt.Errorf("ModelImpl.GetByPath: field 'item' is nil in node '%s'", nodePath)
 		}
 		child := i.Item()
-		if len(parts) == 1 {
+		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(parts[1])
+		return child.GetByPath(path)
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("ModelImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Model'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("ModelImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Model'", field.Value(), nodePath)
 	}
 }
 
@@ -129,10 +113,10 @@ func NewItemData() ItemData {
 
 func (i *ItemData) IsItem() {}
 
-func (i *ItemData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *ItemData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 }
 
-func (i *ItemData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *ItemData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 func (i *ItemData) Value() string {
@@ -156,37 +140,22 @@ type ItemImpl struct {
 	ItemData
 }
 
-func (i *ItemImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *ItemImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.ItemData.ForEachNode(fn)
 }
 
-func (i *ItemImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *ItemImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.ItemData.ForEachReference(fn)
 }
 
-func (i *ItemImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameValue:
-		return core.FieldInfos{Multi: false, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *ItemImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *ItemImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameValue:
 		return nil, fmt.Errorf("ItemImpl.GetByPath: field 'value' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("ItemImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Item'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("ItemImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Item'", field.Value(), nodePath)
 	}
 }
 
@@ -222,10 +191,10 @@ func NewRecoveryData() RecoveryData {
 
 func (i *RecoveryData) IsRecovery() {}
 
-func (i *RecoveryData) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *RecoveryData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 }
 
-func (i *RecoveryData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *RecoveryData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 }
 
 func (i *RecoveryData) First() string {
@@ -266,37 +235,18 @@ type RecoveryImpl struct {
 	RecoveryData
 }
 
-func (i *RecoveryImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], uint16)) {
+func (i *RecoveryImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
 	i.ItemData.ForEachNode(fn)
 	i.RecoveryData.ForEachNode(fn)
 }
 
-func (i *RecoveryImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], uint16)) {
+func (i *RecoveryImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
 	i.ItemData.ForEachReference(fn)
 	i.RecoveryData.ForEachReference(fn)
 }
 
-func (i *RecoveryImpl) FieldInfos(field unique.Handle[string]) core.FieldInfos {
-	switch field {
-	case fieldNameFirst:
-		return core.FieldInfos{Multi: false, Reference: false}
-	case fieldNameSecond:
-		return core.FieldInfos{Multi: false, Reference: false}
-	case fieldNameValue:
-		return core.FieldInfos{Multi: false, Reference: false}
-	default:
-		return core.FieldInfos{}
-	}
-}
-
-func (i *RecoveryImpl) GetByPath(path string) (core.AstNode, error) {
-	path = strings.TrimLeft(path, "/")
-	if path == "" {
-		return i, nil
-	}
-	parts := strings.SplitN(path, "/", 2)
-	fieldAndIndex := strings.SplitN(parts[0], "@", 2)
-	field := unique.Make(fieldAndIndex[0])
+func (i *RecoveryImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+	field, _ := path.Shift()
 	switch field {
 	case fieldNameFirst:
 		return nil, fmt.Errorf("RecoveryImpl.GetByPath: field 'first' holds a primitive value instead of an ast node")
@@ -305,8 +255,8 @@ func (i *RecoveryImpl) GetByPath(path string) (core.AstNode, error) {
 	case fieldNameValue:
 		return nil, fmt.Errorf("RecoveryImpl.GetByPath: field 'value' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := i.AstNodeBase.NodePath()
-		return nil, fmt.Errorf("RecoveryImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Recovery'", fieldAndIndex[0], nodePath)
+		nodePath, _ := core.NodePath(i)
+		return nil, fmt.Errorf("RecoveryImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Recovery'", field.Value(), nodePath)
 	}
 }
 

--- a/internal/languages/token_groups/types_gen.go
+++ b/internal/languages/token_groups/types_gen.go
@@ -68,22 +68,22 @@ func (i *ModelImpl) ForEachReference(fn func(core.UntypedReference, unique.Handl
 	i.ModelData.ForEachReference(fn)
 }
 
-func (i *ModelImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *ModelImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameItem:
 		if i.Item() == nil {
-			nodePath, _ := core.NodePath(i)
-			return nil, fmt.Errorf("ModelImpl.GetByPath: field 'item' is nil in node '%s'", nodePath)
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("ModelImpl.Resolve: field 'item' is nil in node '%s'", nodePath)
 		}
 		child := i.Item()
 		if path.Empty() {
 			return child, nil
 		}
-		return child.GetByPath(path)
+		return child.Resolve(path)
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("ModelImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Model'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("ModelImpl.Resolve: field '%s' does not exist in node '%s' of type 'Model'", field.Value(), nodePath)
 	}
 }
 
@@ -148,14 +148,14 @@ func (i *ItemImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle
 	i.ItemData.ForEachReference(fn)
 }
 
-func (i *ItemImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *ItemImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameValue:
-		return nil, fmt.Errorf("ItemImpl.GetByPath: field 'value' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("ItemImpl.Resolve: field 'value' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("ItemImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Item'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("ItemImpl.Resolve: field '%s' does not exist in node '%s' of type 'Item'", field.Value(), nodePath)
 	}
 }
 
@@ -245,18 +245,18 @@ func (i *RecoveryImpl) ForEachReference(fn func(core.UntypedReference, unique.Ha
 	i.RecoveryData.ForEachReference(fn)
 }
 
-func (i *RecoveryImpl) GetByPath(path *core.PathSegments) (core.AstNode, error) {
+func (i *RecoveryImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 	field, _ := path.Shift()
 	switch field {
 	case fieldNameFirst:
-		return nil, fmt.Errorf("RecoveryImpl.GetByPath: field 'first' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("RecoveryImpl.Resolve: field 'first' holds a primitive value instead of an ast node")
 	case fieldNameSecond:
-		return nil, fmt.Errorf("RecoveryImpl.GetByPath: field 'second' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("RecoveryImpl.Resolve: field 'second' holds a primitive value instead of an ast node")
 	case fieldNameValue:
-		return nil, fmt.Errorf("RecoveryImpl.GetByPath: field 'value' holds a primitive value instead of an ast node")
+		return nil, fmt.Errorf("RecoveryImpl.Resolve: field 'value' holds a primitive value instead of an ast node")
 	default:
-		nodePath, _ := core.NodePath(i)
-		return nil, fmt.Errorf("RecoveryImpl.GetByPath: field '%s' does not exist in node '%s' of type 'Recovery'", field.Value(), nodePath)
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("RecoveryImpl.Resolve: field '%s' does not exist in node '%s' of type 'Recovery'", field.Value(), nodePath)
 	}
 }
 

--- a/path.go
+++ b/path.go
@@ -12,9 +12,9 @@ import (
 	"unique"
 )
 
-// FragmentPath describes instance of node path descriptors pointing to a child AST node within a parent.
+// FragmentPath describes node path descriptors pointing to a child AST node within a parent.
 type FragmentPath interface {
-	// Empty returns [true] if this descriptor is empty and equal to the empty path string, returns [false] otherwise.
+	// Empty returns true if this descriptor is empty and equal to the empty path string, returns false otherwise.
 	Empty() bool
 	// Head returns field name (unique.Handle) and index of the head segment of the segment list.
 	// index is expected to be negative (-1) for non-list fields.
@@ -82,7 +82,8 @@ func PathOf(node AstNode) (fragmentPath, error) {
 	containerField, index := node.ContainmentData()
 
 	if container == nil {
-		return fragmentPath{}, nil
+		// initialize the result fragment path with an initial capacity of 5 items (assumed common upper bound)
+		return make(fragmentPath, 0, 5), nil
 	} else if containerField == fieldZero || containerField == fieldEmpty {
 		return nil, errors.New("cannot determine node path, 'containerField' is empty")
 	}
@@ -114,8 +115,8 @@ func Resolve(path string, node AstNode) (AstNode, error) {
 }
 
 func parsePath(path string) (fragmentPath, error) {
-	result := fragmentPath{}
-	path = strings.TrimLeft(path, "/")
+	// initialize the result fragment path with an initial capacity of 5 items (assumed common upper bound)
+	result := make(fragmentPath, 0, 5)
 
 	for curSegment := range strings.SplitSeq(path, "/") {
 		if curSegment == "" {

--- a/path.go
+++ b/path.go
@@ -102,8 +102,8 @@ func PathOf(node AstNode) (fragmentPath, error) {
 }
 
 // Resolve returns the (deeply) contained child of node denoted by path.
-// Leading slashes of path are ignored, the field names are evaluated child by child starting with node.
-func Resolve(path string, node AstNode) (AstNode, error) {
+// Leading slashes in path are ignored, the field names are evaluated child by child starting with node.
+func Resolve(node AstNode, path string) (AstNode, error) {
 	if path == "" {
 		return node, nil
 	}

--- a/path.go
+++ b/path.go
@@ -80,11 +80,11 @@ var fieldZero = unique.Handle[string]{}
 
 // PathOf composes a [FragmentPath] denoting node's path within its root container.
 // It does so in a recursive manner based on node's [AstNode.ContainmentData].
-// Calling [FragmentPath.String] on the result yields a slash-separated
+// Calling [FragmentPath.String]() on the result yields a slash-separated
 // path string that uniquely identifies this node within its containment hierarchy.
 // e.g. "/rules@2/alternatives@0".
 // Returns an empty descriptor for root nodes/nodes without a configured container,
-// whose [FragmentPath.String] yields an empty string.
+// its [FragmentPath.String]() yields an empty string.
 func PathOf(node AstNode) (*fragmentPathImpl, error) {
 	container := node.Container()
 	containerField, index := node.ContainmentData()

--- a/path.go
+++ b/path.go
@@ -1,3 +1,7 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
 package fastbelt
 
 import (
@@ -8,25 +12,30 @@ import (
 	"unique"
 )
 
+// FragmentPath describes instance of node path descriptors pointing to a child AST node within a parent.
 type FragmentPath interface {
+	// Empty returns [true] if this descriptor is empty and equal to the empty path string, returns [false] otherwise.
 	Empty() bool
-	Push(name unique.Handle[string], index int) FragmentPath
-	Shift() (unique.Handle[string], int)
+	// Head returns field name (unique.Handle) and index of the head segment of the segment list.
+	// index is expected to be negative (-1) for non-list fields.
+	Head() (unique.Handle[string], int)
+	// Tail returns a copy of this path descriptor with the first element dropped from the segments list.
+	Tail() FragmentPath
+	// String returns the corresponding fragment path string
 	String() string
 }
 
-type FragmentPathImpl struct {
+// Base implementation of [FragmentPath]
+type fragmentPathImpl struct {
 	segments []struct {
 		name  unique.Handle[string]
 		index int
 	}
 }
 
-func (p *FragmentPathImpl) Empty() bool {
-	return len(p.segments) == 0
-}
+var _ FragmentPath = (*fragmentPathImpl)(nil)
 
-func (p *FragmentPathImpl) Push(name unique.Handle[string], index int) FragmentPath {
+func (p *fragmentPathImpl) push(name unique.Handle[string], index int) *fragmentPathImpl {
 	p.segments = append(p.segments, struct {
 		name  unique.Handle[string]
 		index int
@@ -34,20 +43,29 @@ func (p *FragmentPathImpl) Push(name unique.Handle[string], index int) FragmentP
 	return p
 }
 
-func (p *FragmentPathImpl) Shift() (name unique.Handle[string], index int) {
-	len := len(p.segments)
-	if len == 0 {
+func (p *fragmentPathImpl) Empty() bool {
+	return len(p.segments) == 0
+}
+
+func (p *fragmentPathImpl) Head() (name unique.Handle[string], index int) {
+	count := len(p.segments)
+	if count == 0 {
 		return fieldZero, -1
 	} else {
 		head := p.segments[0]
-		p.segments = p.segments[1:]
 		return head.name, head.index
 	}
 }
 
-func (ps *FragmentPathImpl) String() string {
+func (p *fragmentPathImpl) Tail() FragmentPath {
+	clone := *p
+	clone.segments = clone.segments[1:]
+	return &clone
+}
+
+func (p *fragmentPathImpl) String() string {
 	var sb strings.Builder
-	for _, s := range ps.segments {
+	for _, s := range p.segments {
 		sb.WriteString("/")
 		sb.WriteString(s.name.Value())
 		if s.index >= 0 {
@@ -60,35 +78,36 @@ func (ps *FragmentPathImpl) String() string {
 
 var fieldZero = unique.Handle[string]{}
 
-// NodePath determines node's path within its root container in a recursive manner,
+// PathOf determines node's path within its root container in a recursive manner
 // based on node's [AstNode.ContainmentData]. It returns a slash-separated
 // path string that uniquely identifies this node within its document tree,
 // e.g. "/rules@2/alternatives@0".
 // Returns "" for the root node (no container).
-func PathOf(node AstNode) (FragmentPath, error) {
+func PathOf(node AstNode) (*fragmentPathImpl, error) {
 	container := node.Container()
 	containerField, index := node.ContainmentData()
 
-	b := &FragmentPathImpl{}
 	if container == nil {
-		return b, nil
+		return &fragmentPathImpl{}, nil
 	} else if containerField == fieldZero || containerField.Value() == "" {
-		return b, errors.New("cannot determine node path, 'containerField' is empty")
+		return nil, errors.New("cannot determine node path, 'containerField' is empty")
 	}
 
 	parentPath, err := PathOf(container)
 	if err != nil {
 		if errors.Unwrap(err) == nil {
-			return b, fmt.Errorf(
-				"AstNodeBase.NodePath: error within node of type %T: %w", container, err)
+			return nil, fmt.Errorf(
+				"PathOf: error within node of type %T: %w", container, err)
 		} else {
-			return b, fmt.Errorf(
-				"AstNodeBase.NodePath: error within container of type %T:\n %w", container, err)
+			return nil, fmt.Errorf(
+				"PathOf: error within container of type %T:\n %w", container, err)
 		}
 	}
-	return parentPath.Push(containerField, index), nil
+	return parentPath.push(containerField, index), nil
 }
 
+// Resolve returns the (deeply) contained child of node denoted by path.
+// Leading slashes of path are ignored, the field names are evaluated child by child starting with node.
 func Resolve(path string, node AstNode) (AstNode, error) {
 	if path == "" {
 		return node, nil
@@ -100,8 +119,8 @@ func Resolve(path string, node AstNode) (AstNode, error) {
 	return node.Resolve(segments)
 }
 
-func parsePath(path string) (FragmentPath, error) {
-	result := &FragmentPathImpl{}
+func parsePath(path string) (*fragmentPathImpl, error) {
+	result := &fragmentPathImpl{}
 	path = strings.TrimLeft(path, "/")
 
 	for segment := range strings.SplitSeq(path, "/") {
@@ -111,13 +130,13 @@ func parsePath(path string) (FragmentPath, error) {
 		fieldAndIndex := strings.SplitN(segment, "@", 2)
 		field := unique.Make(fieldAndIndex[0])
 		if len(fieldAndIndex) == 1 {
-			result.Push(field, -1)
+			result.push(field, -1)
 		} else {
 			index, err := strconv.Atoi(fieldAndIndex[1])
 			if err != nil {
-				return nil, fmt.Errorf("ParsePath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
+				return nil, fmt.Errorf("parsePath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
 			}
-			result.Push(field, index)
+			result.push(field, index)
 		}
 	}
 	return result, nil

--- a/path.go
+++ b/path.go
@@ -1,0 +1,124 @@
+package fastbelt
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"unique"
+)
+
+type FragmentPath interface {
+	Empty() bool
+	Push(name unique.Handle[string], index int) FragmentPath
+	Shift() (unique.Handle[string], int)
+	String() string
+}
+
+type FragmentPathImpl struct {
+	segments []struct {
+		name  unique.Handle[string]
+		index int
+	}
+}
+
+func (p *FragmentPathImpl) Empty() bool {
+	return len(p.segments) == 0
+}
+
+func (p *FragmentPathImpl) Push(name unique.Handle[string], index int) FragmentPath {
+	p.segments = append(p.segments, struct {
+		name  unique.Handle[string]
+		index int
+	}{name, index})
+	return p
+}
+
+func (p *FragmentPathImpl) Shift() (name unique.Handle[string], index int) {
+	len := len(p.segments)
+	if len == 0 {
+		return fieldZero, -1
+	} else {
+		head := p.segments[0]
+		p.segments = p.segments[1:]
+		return head.name, head.index
+	}
+}
+
+func (ps *FragmentPathImpl) String() string {
+	var sb strings.Builder
+	for _, s := range ps.segments {
+		sb.WriteString("/")
+		sb.WriteString(s.name.Value())
+		if s.index >= 0 {
+			sb.WriteString("@")
+			sb.WriteString(strconv.Itoa(int(s.index)))
+		}
+	}
+	return sb.String()
+}
+
+var fieldZero = unique.Handle[string]{}
+
+// NodePath determines node's path within its root container in a recursive manner,
+// based on node's [AstNode.ContainmentData]. It returns a slash-separated
+// path string that uniquely identifies this node within its document tree,
+// e.g. "/rules@2/alternatives@0".
+// Returns "" for the root node (no container).
+func PathOf(node AstNode) (FragmentPath, error) {
+	container := node.Container()
+	containerField, index := node.ContainmentData()
+
+	b := &FragmentPathImpl{}
+	if container == nil {
+		return b, nil
+	} else if containerField == fieldZero || containerField.Value() == "" {
+		return b, errors.New("cannot determine node path, 'containerField' is empty")
+	}
+
+	parentPath, err := PathOf(container)
+	if err != nil {
+		if errors.Unwrap(err) == nil {
+			return b, fmt.Errorf(
+				"AstNodeBase.NodePath: error within node of type %T: %w", container, err)
+		} else {
+			return b, fmt.Errorf(
+				"AstNodeBase.NodePath: error within container of type %T:\n %w", container, err)
+		}
+	}
+	return parentPath.Push(containerField, index), nil
+}
+
+func Resolve(path string, node AstNode) (AstNode, error) {
+	if path == "" {
+		return node, nil
+	}
+	segments, err := parsePath(path)
+	if err != nil {
+		return nil, err
+	}
+	return node.Resolve(segments)
+}
+
+func parsePath(path string) (FragmentPath, error) {
+	result := &FragmentPathImpl{}
+	path = strings.TrimLeft(path, "/")
+
+	for segment := range strings.SplitSeq(path, "/") {
+		if segment == "" {
+			continue
+		}
+		fieldAndIndex := strings.SplitN(segment, "@", 2)
+		field := unique.Make(fieldAndIndex[0])
+		if len(fieldAndIndex) == 1 {
+			result.Push(field, -1)
+		} else {
+			index, err := strconv.Atoi(fieldAndIndex[1])
+			if err != nil {
+				return nil, fmt.Errorf("ParsePath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
+			}
+			result.Push(field, index)
+		}
+	}
+	return result, nil
+}

--- a/path.go
+++ b/path.go
@@ -25,73 +25,65 @@ type FragmentPath interface {
 	String() string
 }
 
-// Base implementation of [FragmentPath]
-type fragmentPathImpl struct {
-	segments []struct {
-		name  unique.Handle[string]
-		index int
-	}
+type fragmentPath []segment
+type segment struct {
+	name  unique.Handle[string]
+	index int
 }
 
-var _ FragmentPath = (*fragmentPathImpl)(nil)
+var _ FragmentPath = (fragmentPath)(nil)
 
-func (p *fragmentPathImpl) push(name unique.Handle[string], index int) *fragmentPathImpl {
-	p.segments = append(p.segments, struct {
-		name  unique.Handle[string]
-		index int
-	}{name, index})
-	return p
+func (p fragmentPath) Empty() bool {
+	return len(p) == 0
 }
 
-func (p *fragmentPathImpl) Empty() bool {
-	return len(p.segments) == 0
-}
-
-func (p *fragmentPathImpl) Head() (name unique.Handle[string], index int) {
-	count := len(p.segments)
-	if count == 0 {
+func (p fragmentPath) Head() (name unique.Handle[string], index int) {
+	if len(p) == 0 {
 		return fieldZero, -1
 	} else {
-		head := p.segments[0]
+		head := p[0]
 		return head.name, head.index
 	}
 }
 
-func (p *fragmentPathImpl) Tail() FragmentPath {
-	clone := *p
-	clone.segments = clone.segments[1:]
-	return &clone
+func (p fragmentPath) Tail() FragmentPath {
+	if len(p) == 0 {
+		return p
+	} else {
+		return p[1:]
+	}
 }
 
-func (p *fragmentPathImpl) String() string {
+func (p fragmentPath) String() string {
 	var sb strings.Builder
-	for _, s := range p.segments {
+	for _, s := range p {
 		sb.WriteString("/")
 		sb.WriteString(s.name.Value())
 		if s.index >= 0 {
 			sb.WriteString("@")
-			sb.WriteString(strconv.Itoa(int(s.index)))
+			sb.WriteString(strconv.Itoa(s.index))
 		}
 	}
 	return sb.String()
 }
 
 var fieldZero = unique.Handle[string]{}
+var fieldEmpty = unique.Make("")
 
 // PathOf composes a [FragmentPath] denoting node's path within its root container.
 // It does so in a recursive manner based on node's [AstNode.ContainmentData].
 // Calling [FragmentPath.String]() on the result yields a slash-separated
 // path string that uniquely identifies this node within its containment hierarchy.
 // e.g. "/rules@2/alternatives@0".
-// Returns an empty descriptor for root nodes/nodes without a configured container,
+// Returns an empty descriptor for root nodes & nodes with no configured container,
 // its [FragmentPath.String]() yields an empty string.
-func PathOf(node AstNode) (*fragmentPathImpl, error) {
+func PathOf(node AstNode) (fragmentPath, error) {
 	container := node.Container()
 	containerField, index := node.ContainmentData()
 
 	if container == nil {
-		return &fragmentPathImpl{}, nil
-	} else if containerField == fieldZero || containerField.Value() == "" {
+		return fragmentPath{}, nil
+	} else if containerField == fieldZero || containerField == fieldEmpty {
 		return nil, errors.New("cannot determine node path, 'containerField' is empty")
 	}
 
@@ -105,7 +97,7 @@ func PathOf(node AstNode) (*fragmentPathImpl, error) {
 				"PathOf: error within container of type %T:\n %w", container, err)
 		}
 	}
-	return parentPath.push(containerField, index), nil
+	return append(parentPath, segment{containerField, index}), nil
 }
 
 // Resolve returns the (deeply) contained child of node denoted by path.
@@ -121,25 +113,25 @@ func Resolve(path string, node AstNode) (AstNode, error) {
 	return node.Resolve(segments)
 }
 
-func parsePath(path string) (*fragmentPathImpl, error) {
-	result := &fragmentPathImpl{}
+func parsePath(path string) (fragmentPath, error) {
+	result := fragmentPath{}
 	path = strings.TrimLeft(path, "/")
 
-	for segment := range strings.SplitSeq(path, "/") {
-		if segment == "" {
+	for curSegment := range strings.SplitSeq(path, "/") {
+		if curSegment == "" {
 			continue
 		}
-		fieldAndIndex := strings.SplitN(segment, "@", 2)
+		fieldAndIndex := strings.SplitN(curSegment, "@", 2)
 		field := unique.Make(fieldAndIndex[0])
-		if len(fieldAndIndex) == 1 {
-			result.push(field, -1)
-		} else {
-			index, err := strconv.Atoi(fieldAndIndex[1])
+		index := -1
+		if len(fieldAndIndex) == 2 {
+			err := error(nil)
+			index, err = strconv.Atoi(fieldAndIndex[1])
 			if err != nil {
 				return nil, fmt.Errorf("parsePath: index '%s' is not a valid uint: %w", fieldAndIndex[1], err)
 			}
-			result.push(field, index)
 		}
+		result = append(result, segment{field, index})
 	}
 	return result, nil
 }

--- a/path.go
+++ b/path.go
@@ -78,11 +78,13 @@ func (p *fragmentPathImpl) String() string {
 
 var fieldZero = unique.Handle[string]{}
 
-// PathOf determines node's path within its root container in a recursive manner
-// based on node's [AstNode.ContainmentData]. It returns a slash-separated
-// path string that uniquely identifies this node within its document tree,
+// PathOf composes a [FragmentPath] denoting node's path within its root container.
+// It does so in a recursive manner based on node's [AstNode.ContainmentData].
+// Calling [FragmentPath.String] on the result yields a slash-separated
+// path string that uniquely identifies this node within its containment hierarchy.
 // e.g. "/rules@2/alternatives@0".
-// Returns "" for the root node (no container).
+// Returns an empty descriptor for root nodes/nodes without a configured container,
+// whose [FragmentPath.String] yields an empty string.
 func PathOf(node AstNode) (*fragmentPathImpl, error) {
 	container := node.Container()
 	containerField, index := node.ContainmentData()

--- a/server/completion_provider.go
+++ b/server/completion_provider.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"unique"
 
 	core "typefox.dev/fastbelt"
 	"typefox.dev/fastbelt/parser"
@@ -454,7 +455,7 @@ func buildSyntheticOwnerChain(adapter parser.LanguageCompletionAdapter, doc *cor
 			continue
 		}
 		if parent != nil {
-			node.SetContainer(parent)
+			node.SetContainer(parent, unique.Make(""), 0)
 		}
 		node.SetDocument(doc)
 		parent = node
@@ -538,7 +539,7 @@ func applyPrecedingAction(adapter parser.LanguageCompletionAdapter, owner core.A
 	}
 	wrapper.SetDocument(owner.Document())
 	if container := owner.Container(); container != nil {
-		wrapper.SetContainer(container)
+		wrapper.SetContainer(container, unique.Make(""), 0)
 	}
 	return wrapper
 }


### PR DESCRIPTION
Contributes
* AstNode path fragment computation and
* AstNode identification based on a given path and a parent/root node.

Most significant changes:
* addition of fields `containerField` and `containerIndex` to `AstNodeBase`
  * `containerField` takes `unique.Handle[string]` representing pointers of interned string constants representing the field names
  * `containerIndex` takes an `int`
* addition of func `ContainmentData()` to `AstNode` and `AstNodeBase` providing the former fields' values
* extension of `SetContainer()` to also expect arguments for the former fields and assigns those ones
* extension of `ForEachNode()` and `ForEachReference()`, precisely extension of the expected lambdas providing the former values, too; required for recursive application of `SetContainer(...)` within `AssignContainers(...)`
* addition of (static) funcs `PathOf(AstNode) (string, error)` and `Resolve(AstNode, string) (AstNode, error)`
  * computes the path fragment of an AstNode within its parents,
* addition of path string abstraction interface named `FragmentPath` + implementation `fragmentPath`
* addition of func `Resolve(...)` to `AstNode` and `AstNodeBase` (base impl) + generation for each impl type
  * reveals a nested ast node within some parent node according to the given (relative) path
* generation of interned string handles for each occurring field name
* generation of type specific impls of `Resolve(FragmentPath)`
* error handling/reporting
* unit tests in `ast_locating_test.go` within the `Arithmetics` example language
* benchmarks in `ast_locating_benchmark_test.go` within the `Arithmetics` example language