### PR TITLE
Reduce AST memory allocations

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -39,9 +39,9 @@ type AstNode interface {
 	SetContainer(container AstNode, containerField unique.Handle[string], index int)
 	// Tokens returns the tokens associated with the node.
 	Tokens() []*Token
-	// SetToken appends token to the node's token list.
-	SetToken(token *Token)
-	// SetTokens replaces the node's token list with tokens.
+	// AppendToken appends token to the node's token list.
+	AppendToken(token *Token)
+	// SetTokens replaces the node's token list with another list of tokens.
 	SetTokens(tokens []*Token)
 	// TextRange returns the text range of the node.
 	TextRange() TextRange
@@ -178,10 +178,17 @@ func (node *AstNodeBase) TextRange() TextRange {
 	}
 }
 
-// SetToken appends token to the node's token list.
-func (node *AstNodeBase) SetToken(token *Token) {
+// AppendToken appends token to the node's token list.
+func (node *AstNodeBase) AppendToken(token *Token) {
 	if node != nil && token != nil {
-		node.tokens = append(node.tokens, token)
+		if node.tokens == nil {
+			// Most nodes end up with a handful of tokens; start with capacity 4
+			// to avoid the cap 1->2->4 growth reallocations of a bare append.
+			node.tokens = make([]*Token, 1, 4)
+			node.tokens[0] = token
+		} else {
+			node.tokens = append(node.tokens, token)
+		}
 	}
 }
 
@@ -307,23 +314,12 @@ func References(node AstNode) iter.Seq[UntypedReference] {
 	}
 }
 
-// NewAstNode creates an [AstNodeBase] with initialized token storage.
-//
-// It is intended for generated node implementations that embed AstNodeBase.
-// AstNodeBase carries framework metadata only and has no language-specific
-// semantic fields on its own.
-func NewAstNode() AstNodeBase {
-	return AstNodeBase{
-		tokens: []*Token{},
-	}
-}
-
 // AssignToken appends token to node and records node and kind on the token.
 //
 // It is primarily used by generated parsers while constructing nodes incrementally.
 func AssignToken(node AstNode, token *Token, kind int) {
 	if node != nil && token != nil {
-		node.SetToken(token)
+		node.AppendToken(token)
 		token.Element = node
 		token.Kind = kind
 	}
@@ -346,8 +342,9 @@ func AssignTokens(node AstNode, tokens []*Token) {
 // It is used when parser actions replace the current node while preserving already consumed text.
 func MergeTokens(newNode AstNode, oldTokens []*Token) {
 	if newNode != nil && len(oldTokens) > 0 {
-		// Prepend old tokens to the new node's tokens
-		AssignTokens(newNode, append(oldTokens, newNode.Tokens()...))
+		// Prepend old tokens to the new node's tokens. The full slice expression
+		// forces append to copy, so the caller's backing array is never mutated.
+		AssignTokens(newNode, append(oldTokens[:len(oldTokens):len(oldTokens)], newNode.Tokens()...))
 	}
 }
 
@@ -449,31 +446,28 @@ type CompositeNode interface {
 	IsCompositeNode()
 }
 
-// NewCompositeNode creates a [CompositeNode] backed by [CompositeNodeBase].
+// NewCompositeNode creates a [CompositeNode] backed by [compositeNode].
 func NewCompositeNode() CompositeNode {
-	return &CompositeNodeBase{
-		AstNodeBase: NewAstNode(),
-	}
+	return &compositeNode{}
 }
 
-// CompositeNodeBase provides the default [CompositeNode] implementation for generated composite rules.
-type CompositeNodeBase struct {
+// compositeNode is the default implementation of [CompositeNode].
+// It is private, no adopter code should use it directly.
+type compositeNode struct {
 	AstNodeBase
 	// We could use a sync.Once here, but that would add some overhead
 	// In benchmarks, using an atomic pointer here is much faster (roughly 2x)
 	cache atomic.Pointer[string]
 }
 
-// IsCompositeNode marks CompositeNodeBase as implementing [CompositeNode].
-func (node *CompositeNodeBase) IsCompositeNode() {}
+func (node *compositeNode) IsCompositeNode() {}
 
 // Owner returns the AST node that owns this string unit.
-func (node *CompositeNodeBase) Owner() AstNode {
+func (node *compositeNode) Owner() AstNode {
 	return node.container
 }
 
-// String returns the concatenated token images of node, caching the computed value.
-func (node *CompositeNodeBase) String() string {
+func (node *compositeNode) String() string {
 	// Cache the string value, as it is accessed frequently
 	// Since this operation can be done in parallel, we need an atomic pointer here
 	if p := node.cache.Load(); p != nil {
@@ -485,7 +479,7 @@ func (node *CompositeNodeBase) String() string {
 	}
 }
 
-func (node *CompositeNodeBase) stringSlow() string {
+func (node *compositeNode) stringSlow() string {
 	// Construct the string value by concatenating the text of all tokens of the node
 	// Only need to do this once, as the tokens are usually not modified after parsing
 	var sb strings.Builder

--- a/ast_test.go
+++ b/ast_test.go
@@ -29,7 +29,7 @@ func BenchmarkCompositeNodeSequential(b *testing.B) {
 }
 
 // BenchmarkCompositeNodeConcurrent benchmarks concurrent access to the
-// atomic-pointer string cache on CompositeNodeBase.
+// atomic-pointer string cache on compositeNode.
 //
 // The setup creates a large pool of nodes whose tokens have nil TokenType
 // (only Image is used by stringSlow). Each goroutine picks nodes pseudo-randomly
@@ -86,7 +86,7 @@ func generateRandomNodes(nodeCount, minTokensPerNode, maxTokensPerNode int) []Co
 		tokenCount := src.IntN(maxTokensPerNode-minTokensPerNode+1) + minTokensPerNode
 		for range tokenCount {
 			// String only reads Token.Image.
-			node.SetToken(&Token{Image: words[src.IntN(len(words))]})
+			node.AppendToken(&Token{Image: words[src.IntN(len(words))]})
 		}
 		nodes[i] = node
 	}

--- a/examples/arithmetics/ast_locating_test.go
+++ b/examples/arithmetics/ast_locating_test.go
@@ -208,10 +208,10 @@ func TestPathOf(t *testing.T) {
 		// in order to test the error logging across some levels of nesting an additional root object is created,
 		// which serves a container for the copied module,
 		// while module's 'containerField' is set to the interned value of "" --> error!
-		root := core.NewAstNode()
+		root := NewModule()
 
 		module := *module.(*ModuleImpl)
-		module.SetContainer(&root, unique.Make(""), 0)
+		module.SetContainer(root, unique.Make(""), 0)
 
 		def := *stmts[0].(*DefinitionImpl)
 		var field, index = def.ContainmentData()

--- a/examples/arithmetics/benchmark_test.go
+++ b/examples/arithmetics/benchmark_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+package arithmetics
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"typefox.dev/fastbelt"
+	"typefox.dev/fastbelt/lexer"
+	"typefox.dev/fastbelt/parser"
+	"typefox.dev/fastbelt/util/service"
+)
+
+// generateArithmeticsContent produces an expression-heavy module
+func generateArithmeticsContent(statements int) string {
+	var sb strings.Builder
+	sb.WriteString("module benchmark\n")
+	sb.WriteString("def base: 42;\n")
+	sb.WriteString("def calc(x, y): x * y + base % 2 - (x / y) ^ 2;\n")
+	for i := range statements {
+		fmt.Fprintf(&sb, "def val%d: %d + %d * 3 - base / (%d + 1);\n", i, i, i+1, i+2)
+		fmt.Fprintf(&sb, "calc(val%d, %d) + val%d * (base - %d);\n", i, i, i, i)
+	}
+	return sb.String()
+}
+
+// BenchmarkParser benchmarks parsing a single expression-heavy arithmetics
+// document, reusing the pre-lexed token slice every iteration.
+func BenchmarkParser(b *testing.B) {
+	content := generateArithmeticsContent(50)
+	srv := CreateServices()
+	lexerService := service.MustGet[lexer.Lexer](srv)
+	parserService := service.MustGet[parser.Parser](srv)
+	lexed := lexerService.Lex(content)
+	if len(lexed.Errors) > 0 {
+		b.Fatalf("lexer errors: %v", lexed.Errors)
+	}
+	doc, err := fastbelt.NewDocumentFromString("file:///workspace/benchmark.arithmetics", "arithmetics", content)
+	if err != nil {
+		b.Fatal(err)
+	}
+	doc.Tokens = lexed.Tokens
+	if result := parserService.Parse(doc); len(result.Errors) > 0 {
+		b.Fatalf("parser errors: %v", result.Errors)
+	}
+	b.SetBytes(int64(len(content)))
+	b.ResetTimer()
+	for b.Loop() {
+		result := parserService.Parse(doc)
+		doc.Root = result.Node
+	}
+}

--- a/examples/arithmetics/types_gen.go
+++ b/examples/arithmetics/types_gen.go
@@ -21,21 +21,12 @@ type Module interface {
 }
 
 func NewModule() Module {
-	return &ModuleImpl{
-		AstNodeBase: core.NewAstNode(),
-		ModuleData:  NewModuleData(),
-	}
+	return &ModuleImpl{}
 }
 
 type ModuleData struct {
 	name       *core.Token
 	statements []Statement
-}
-
-func NewModuleData() ModuleData {
-	return ModuleData{
-		statements: []Statement{},
-	}
 }
 
 func (i *ModuleData) IsModule() {}
@@ -118,17 +109,10 @@ type Statement interface {
 }
 
 func NewStatement() Statement {
-	return &StatementImpl{
-		AstNodeBase:   core.NewAstNode(),
-		StatementData: NewStatementData(),
-	}
+	return &StatementImpl{}
 }
 
 type StatementData struct {
-}
-
-func NewStatementData() StatementData {
-	return StatementData{}
 }
 
 func (i *StatementData) IsStatement() {}
@@ -171,18 +155,11 @@ type AbstractDefinition interface {
 }
 
 func NewAbstractDefinition() AbstractDefinition {
-	return &AbstractDefinitionImpl{
-		AstNodeBase:            core.NewAstNode(),
-		AbstractDefinitionData: NewAbstractDefinitionData(),
-	}
+	return &AbstractDefinitionImpl{}
 }
 
 type AbstractDefinitionData struct {
 	name *core.Token
-}
-
-func NewAbstractDefinitionData() AbstractDefinitionData {
-	return AbstractDefinitionData{}
 }
 
 func (i *AbstractDefinitionData) IsAbstractDefinition() {}
@@ -249,23 +226,12 @@ type Definition interface {
 }
 
 func NewDefinition() Definition {
-	return &DefinitionImpl{
-		AstNodeBase:            core.NewAstNode(),
-		AbstractDefinitionData: NewAbstractDefinitionData(),
-		StatementData:          NewStatementData(),
-		DefinitionData:         NewDefinitionData(),
-	}
+	return &DefinitionImpl{}
 }
 
 type DefinitionData struct {
 	args       []DeclaredParameter
 	expression Expression
-}
-
-func NewDefinitionData() DefinitionData {
-	return DefinitionData{
-		args: []DeclaredParameter{},
-	}
 }
 
 func (i *DefinitionData) IsDefinition() {}
@@ -361,18 +327,10 @@ type DeclaredParameter interface {
 }
 
 func NewDeclaredParameter() DeclaredParameter {
-	return &DeclaredParameterImpl{
-		AstNodeBase:            core.NewAstNode(),
-		AbstractDefinitionData: NewAbstractDefinitionData(),
-		DeclaredParameterData:  NewDeclaredParameterData(),
-	}
+	return &DeclaredParameterImpl{}
 }
 
 type DeclaredParameterData struct {
-}
-
-func NewDeclaredParameterData() DeclaredParameterData {
-	return DeclaredParameterData{}
 }
 
 func (i *DeclaredParameterData) IsDeclaredParameter() {}
@@ -423,19 +381,11 @@ type Evaluation interface {
 }
 
 func NewEvaluation() Evaluation {
-	return &EvaluationImpl{
-		AstNodeBase:    core.NewAstNode(),
-		StatementData:  NewStatementData(),
-		EvaluationData: NewEvaluationData(),
-	}
+	return &EvaluationImpl{}
 }
 
 type EvaluationData struct {
 	expression Expression
-}
-
-func NewEvaluationData() EvaluationData {
-	return EvaluationData{}
 }
 
 func (i *EvaluationData) IsEvaluation() {}
@@ -503,17 +453,10 @@ type Expression interface {
 }
 
 func NewExpression() Expression {
-	return &ExpressionImpl{
-		AstNodeBase:    core.NewAstNode(),
-		ExpressionData: NewExpressionData(),
-	}
+	return &ExpressionImpl{}
 }
 
 type ExpressionData struct {
-}
-
-func NewExpressionData() ExpressionData {
-	return ExpressionData{}
 }
 
 func (i *ExpressionData) IsExpression() {}
@@ -561,21 +504,13 @@ type BinaryExpression interface {
 }
 
 func NewBinaryExpression() BinaryExpression {
-	return &BinaryExpressionImpl{
-		AstNodeBase:          core.NewAstNode(),
-		ExpressionData:       NewExpressionData(),
-		BinaryExpressionData: NewBinaryExpressionData(),
-	}
+	return &BinaryExpressionImpl{}
 }
 
 type BinaryExpressionData struct {
 	left     Expression
 	operator *core.Token
 	right    Expression
-}
-
-func NewBinaryExpressionData() BinaryExpressionData {
-	return BinaryExpressionData{}
 }
 
 func (i *BinaryExpressionData) IsBinaryExpression() {}
@@ -688,22 +623,12 @@ type FunctionCall interface {
 }
 
 func NewFunctionCall() FunctionCall {
-	return &FunctionCallImpl{
-		AstNodeBase:      core.NewAstNode(),
-		ExpressionData:   NewExpressionData(),
-		FunctionCallData: NewFunctionCallData(),
-	}
+	return &FunctionCallImpl{}
 }
 
 type FunctionCallData struct {
 	args     []Expression
 	callable *core.Reference[AbstractDefinition]
-}
-
-func NewFunctionCallData() FunctionCallData {
-	return FunctionCallData{
-		args: []Expression{},
-	}
 }
 
 func (i *FunctionCallData) IsFunctionCall() {}
@@ -792,19 +717,11 @@ type NumberLiteral interface {
 }
 
 func NewNumberLiteral() NumberLiteral {
-	return &NumberLiteralImpl{
-		AstNodeBase:       core.NewAstNode(),
-		ExpressionData:    NewExpressionData(),
-		NumberLiteralData: NewNumberLiteralData(),
-	}
+	return &NumberLiteralImpl{}
 }
 
 type NumberLiteralData struct {
 	value *core.Token
-}
-
-func NewNumberLiteralData() NumberLiteralData {
-	return NumberLiteralData{}
 }
 
 func (i *NumberLiteralData) IsNumberLiteral() {}

--- a/examples/statemachine/types_gen.go
+++ b/examples/statemachine/types_gen.go
@@ -27,10 +27,7 @@ type Statemachine interface {
 }
 
 func NewStatemachine() Statemachine {
-	return &StatemachineImpl{
-		AstNodeBase:      core.NewAstNode(),
-		StatemachineData: NewStatemachineData(),
-	}
+	return &StatemachineImpl{}
 }
 
 type StatemachineData struct {
@@ -39,14 +36,6 @@ type StatemachineData struct {
 	commands []Command
 	init     *core.Reference[State]
 	states   []State
-}
-
-func NewStatemachineData() StatemachineData {
-	return StatemachineData{
-		events:   []Event{},
-		commands: []Command{},
-		states:   []State{},
-	}
 }
 
 func (i *StatemachineData) IsStatemachine() {}
@@ -193,18 +182,11 @@ type Event interface {
 }
 
 func NewEvent() Event {
-	return &EventImpl{
-		AstNodeBase: core.NewAstNode(),
-		EventData:   NewEventData(),
-	}
+	return &EventImpl{}
 }
 
 type EventData struct {
 	name *core.Token
-}
-
-func NewEventData() EventData {
-	return EventData{}
 }
 
 func (i *EventData) IsEvent() {}
@@ -268,18 +250,11 @@ type Command interface {
 }
 
 func NewCommand() Command {
-	return &CommandImpl{
-		AstNodeBase: core.NewAstNode(),
-		CommandData: NewCommandData(),
-	}
+	return &CommandImpl{}
 }
 
 type CommandData struct {
 	name *core.Token
-}
-
-func NewCommandData() CommandData {
-	return CommandData{}
 }
 
 func (i *CommandData) IsCommand() {}
@@ -347,23 +322,13 @@ type State interface {
 }
 
 func NewState() State {
-	return &StateImpl{
-		AstNodeBase: core.NewAstNode(),
-		StateData:   NewStateData(),
-	}
+	return &StateImpl{}
 }
 
 type StateData struct {
 	name        *core.Token
 	actions     []*core.Reference[Command]
 	transitions []Transition
-}
-
-func NewStateData() StateData {
-	return StateData{
-		actions:     []*core.Reference[Command]{},
-		transitions: []Transition{},
-	}
 }
 
 func (i *StateData) IsState() {}
@@ -463,19 +428,12 @@ type Transition interface {
 }
 
 func NewTransition() Transition {
-	return &TransitionImpl{
-		AstNodeBase:    core.NewAstNode(),
-		TransitionData: NewTransitionData(),
-	}
+	return &TransitionImpl{}
 }
 
 type TransitionData struct {
 	event *core.Reference[Event]
 	state *core.Reference[State]
-}
-
-func NewTransitionData() TransitionData {
-	return TransitionData{}
 }
 
 func (i *TransitionData) IsTransition() {}

--- a/internal/generator/type_generator.go
+++ b/internal/generator/type_generator.go
@@ -211,15 +211,7 @@ func generateInterface(node codegen.Node, grammr grammar.Grammar, iface grammar.
 	node.AppendLine()
 	node.AppendLine("func New", iface.Name(), "() ", iface.Name(), " {")
 	node.Indent(func(n codegen.Node) {
-		n.AppendLine("return &", iface.Name(), "Impl{")
-		n.Indent(func(n2 codegen.Node) {
-			n2.AppendLine("AstNodeBase: core.NewAstNode(),")
-			for _, extend := range getAllExtends(grammr, iface) {
-				n2.AppendLine(extend, "Data: New", extend, "Data(),")
-			}
-			n2.AppendLine(iface.Name(), "Data: New", iface.Name(), "Data(),")
-		})
-		n.AppendLine("}")
+		n.AppendLine("return &", iface.Name(), "Impl{}")
 	})
 	node.AppendLine("}")
 	node.AppendLine()
@@ -272,20 +264,6 @@ func generateDataStruct(node codegen.Node, iface grammar.Interface, fields []Fie
 			}
 			n.AppendLine(field.PName + " " + typeStr)
 		}
-	})
-	node.AppendLine("}")
-	node.AppendLine()
-	node.AppendLine("func New", iface.Name(), "Data() ", iface.Name(), "Data {")
-	node.Indent(func(n codegen.Node) {
-		n.AppendLine("return ", iface.Name(), "Data{")
-		n.Indent(func(n2 codegen.Node) {
-			for _, field := range fields {
-				if field.Array {
-					n2.AppendLine(field.PName, ": []", field.GType, "{},")
-				}
-			}
-		})
-		n.AppendLine("}")
 	})
 	node.AppendLine("}")
 	node.AppendLine()

--- a/internal/grammar/types_gen.go
+++ b/internal/grammar/types_gen.go
@@ -29,10 +29,7 @@ type Grammar interface {
 }
 
 func NewGrammar() Grammar {
-	return &GrammarImpl{
-		AstNodeBase: core.NewAstNode(),
-		GrammarData: NewGrammarData(),
-	}
+	return &GrammarImpl{}
 }
 
 type GrammarData struct {
@@ -42,16 +39,6 @@ type GrammarData struct {
 	terminals   []Token
 	tokenGroups []TokenGroup
 	interfaces  []Interface
-}
-
-func NewGrammarData() GrammarData {
-	return GrammarData{
-		rules:       []ParserRule{},
-		composites:  []CompositeRule{},
-		terminals:   []Token{},
-		tokenGroups: []TokenGroup{},
-		interfaces:  []Interface{},
-	}
 }
 
 func (i *GrammarData) IsGrammar() {}
@@ -229,23 +216,13 @@ type Interface interface {
 }
 
 func NewInterface() Interface {
-	return &InterfaceImpl{
-		AstNodeBase:   core.NewAstNode(),
-		InterfaceData: NewInterfaceData(),
-	}
+	return &InterfaceImpl{}
 }
 
 type InterfaceData struct {
 	name    *core.Token
 	extends []*core.Reference[Interface]
 	fields  []Field
-}
-
-func NewInterfaceData() InterfaceData {
-	return InterfaceData{
-		extends: []*core.Reference[Interface]{},
-		fields:  []Field{},
-	}
 }
 
 func (i *InterfaceData) IsInterface() {}
@@ -346,19 +323,12 @@ type Field interface {
 }
 
 func NewField() Field {
-	return &FieldImpl{
-		AstNodeBase: core.NewAstNode(),
-		FieldData:   NewFieldData(),
-	}
+	return &FieldImpl{}
 }
 
 type FieldData struct {
 	name  *core.Token
 	_Type FieldType
-}
-
-func NewFieldData() FieldData {
-	return FieldData{}
 }
 
 func (i *FieldData) IsField() {}
@@ -441,17 +411,10 @@ type FieldType interface {
 }
 
 func NewFieldType() FieldType {
-	return &FieldTypeImpl{
-		AstNodeBase:   core.NewAstNode(),
-		FieldTypeData: NewFieldTypeData(),
-	}
+	return &FieldTypeImpl{}
 }
 
 type FieldTypeData struct {
-}
-
-func NewFieldTypeData() FieldTypeData {
-	return FieldTypeData{}
 }
 
 func (i *FieldTypeData) IsFieldType() {}
@@ -494,19 +457,11 @@ type ArrayType interface {
 }
 
 func NewArrayType() ArrayType {
-	return &ArrayTypeImpl{
-		AstNodeBase:   core.NewAstNode(),
-		FieldTypeData: NewFieldTypeData(),
-		ArrayTypeData: NewArrayTypeData(),
-	}
+	return &ArrayTypeImpl{}
 }
 
 type ArrayTypeData struct {
 	internalType FieldType
-}
-
-func NewArrayTypeData() ArrayTypeData {
-	return ArrayTypeData{}
 }
 
 func (i *ArrayTypeData) IsArrayType() {}
@@ -577,19 +532,11 @@ type ReferenceType interface {
 }
 
 func NewReferenceType() ReferenceType {
-	return &ReferenceTypeImpl{
-		AstNodeBase:       core.NewAstNode(),
-		FieldTypeData:     NewFieldTypeData(),
-		ReferenceTypeData: NewReferenceTypeData(),
-	}
+	return &ReferenceTypeImpl{}
 }
 
 type ReferenceTypeData struct {
 	_Type *core.Reference[Interface]
-}
-
-func NewReferenceTypeData() ReferenceTypeData {
-	return ReferenceTypeData{}
 }
 
 func (i *ReferenceTypeData) IsReferenceType() {}
@@ -655,19 +602,11 @@ type SimpleType interface {
 }
 
 func NewSimpleType() SimpleType {
-	return &SimpleTypeImpl{
-		AstNodeBase:    core.NewAstNode(),
-		FieldTypeData:  NewFieldTypeData(),
-		SimpleTypeData: NewSimpleTypeData(),
-	}
+	return &SimpleTypeImpl{}
 }
 
 type SimpleTypeData struct {
 	_Type *core.Reference[Interface]
-}
-
-func NewSimpleTypeData() SimpleTypeData {
-	return SimpleTypeData{}
 }
 
 func (i *SimpleTypeData) IsSimpleType() {}
@@ -734,19 +673,11 @@ type PrimitiveType interface {
 }
 
 func NewPrimitiveType() PrimitiveType {
-	return &PrimitiveTypeImpl{
-		AstNodeBase:       core.NewAstNode(),
-		FieldTypeData:     NewFieldTypeData(),
-		PrimitiveTypeData: NewPrimitiveTypeData(),
-	}
+	return &PrimitiveTypeImpl{}
 }
 
 type PrimitiveTypeData struct {
 	_Type *core.Token
-}
-
-func NewPrimitiveTypeData() PrimitiveTypeData {
-	return PrimitiveTypeData{}
 }
 
 func (i *PrimitiveTypeData) IsPrimitiveType() {}
@@ -813,18 +744,11 @@ type AbstractRule interface {
 }
 
 func NewAbstractRule() AbstractRule {
-	return &AbstractRuleImpl{
-		AstNodeBase:      core.NewAstNode(),
-		AbstractRuleData: NewAbstractRuleData(),
-	}
+	return &AbstractRuleImpl{}
 }
 
 type AbstractRuleData struct {
 	name *core.Token
-}
-
-func NewAbstractRuleData() AbstractRuleData {
-	return AbstractRuleData{}
 }
 
 func (i *AbstractRuleData) IsAbstractRule() {}
@@ -888,19 +812,11 @@ type AbstractRuleWithBody interface {
 }
 
 func NewAbstractRuleWithBody() AbstractRuleWithBody {
-	return &AbstractRuleWithBodyImpl{
-		AstNodeBase:              core.NewAstNode(),
-		AbstractRuleData:         NewAbstractRuleData(),
-		AbstractRuleWithBodyData: NewAbstractRuleWithBodyData(),
-	}
+	return &AbstractRuleWithBodyImpl{}
 }
 
 type AbstractRuleWithBodyData struct {
 	body Element
-}
-
-func NewAbstractRuleWithBodyData() AbstractRuleWithBodyData {
-	return AbstractRuleWithBodyData{}
 }
 
 func (i *AbstractRuleWithBodyData) IsAbstractRuleWithBody() {}
@@ -971,18 +887,10 @@ type AbstractTokenRule interface {
 }
 
 func NewAbstractTokenRule() AbstractTokenRule {
-	return &AbstractTokenRuleImpl{
-		AstNodeBase:           core.NewAstNode(),
-		AbstractRuleData:      NewAbstractRuleData(),
-		AbstractTokenRuleData: NewAbstractTokenRuleData(),
-	}
+	return &AbstractTokenRuleImpl{}
 }
 
 type AbstractTokenRuleData struct {
-}
-
-func NewAbstractTokenRuleData() AbstractTokenRuleData {
-	return AbstractTokenRuleData{}
 }
 
 func (i *AbstractTokenRuleData) IsAbstractTokenRule() {}
@@ -1036,21 +944,12 @@ type ParserRule interface {
 }
 
 func NewParserRule() ParserRule {
-	return &ParserRuleImpl{
-		AstNodeBase:              core.NewAstNode(),
-		AbstractRuleWithBodyData: NewAbstractRuleWithBodyData(),
-		AbstractRuleData:         NewAbstractRuleData(),
-		ParserRuleData:           NewParserRuleData(),
-	}
+	return &ParserRuleImpl{}
 }
 
 type ParserRuleData struct {
 	entry      *core.Token
 	returnType *core.Reference[Interface]
-}
-
-func NewParserRuleData() ParserRuleData {
-	return ParserRuleData{}
 }
 
 func (i *ParserRuleData) IsParserRule() {}
@@ -1146,21 +1045,12 @@ type Token interface {
 }
 
 func NewToken() Token {
-	return &TokenImpl{
-		AstNodeBase:           core.NewAstNode(),
-		AbstractTokenRuleData: NewAbstractTokenRuleData(),
-		AbstractRuleData:      NewAbstractRuleData(),
-		TokenData:             NewTokenData(),
-	}
+	return &TokenImpl{}
 }
 
 type TokenData struct {
 	_Type  *core.Token
 	regexp *core.Token
-}
-
-func NewTokenData() TokenData {
-	return TokenData{}
 }
 
 func (i *TokenData) IsToken() {}
@@ -1254,26 +1144,13 @@ type TokenGroup interface {
 }
 
 func NewTokenGroup() TokenGroup {
-	return &TokenGroupImpl{
-		AstNodeBase:           core.NewAstNode(),
-		AbstractTokenRuleData: NewAbstractTokenRuleData(),
-		AbstractRuleData:      NewAbstractRuleData(),
-		TokenGroupData:        NewTokenGroupData(),
-	}
+	return &TokenGroupImpl{}
 }
 
 type TokenGroupData struct {
 	tokenRefs []*core.Reference[AbstractTokenRule]
 	regexps   []*core.Token
 	keywords  []Keyword
-}
-
-func NewTokenGroupData() TokenGroupData {
-	return TokenGroupData{
-		tokenRefs: []*core.Reference[AbstractTokenRule]{},
-		regexps:   []*core.Token{},
-		keywords:  []Keyword{},
-	}
 }
 
 func (i *TokenGroupData) IsTokenGroup() {}
@@ -1372,18 +1249,11 @@ type Element interface {
 }
 
 func NewElement() Element {
-	return &ElementImpl{
-		AstNodeBase: core.NewAstNode(),
-		ElementData: NewElementData(),
-	}
+	return &ElementImpl{}
 }
 
 type ElementData struct {
 	cardinality *core.Token
-}
-
-func NewElementData() ElementData {
-	return ElementData{}
 }
 
 func (i *ElementData) IsElement() {}
@@ -1447,22 +1317,11 @@ type Alternatives interface {
 }
 
 func NewAlternatives() Alternatives {
-	return &AlternativesImpl{
-		AstNodeBase:      core.NewAstNode(),
-		AssignableData:   NewAssignableData(),
-		ElementData:      NewElementData(),
-		AlternativesData: NewAlternativesData(),
-	}
+	return &AlternativesImpl{}
 }
 
 type AlternativesData struct {
 	alts []Element
-}
-
-func NewAlternativesData() AlternativesData {
-	return AlternativesData{
-		alts: []Element{},
-	}
 }
 
 func (i *AlternativesData) IsAlternatives() {}
@@ -1538,21 +1397,11 @@ type Group interface {
 }
 
 func NewGroup() Group {
-	return &GroupImpl{
-		AstNodeBase: core.NewAstNode(),
-		ElementData: NewElementData(),
-		GroupData:   NewGroupData(),
-	}
+	return &GroupImpl{}
 }
 
 type GroupData struct {
 	elements []Element
-}
-
-func NewGroupData() GroupData {
-	return GroupData{
-		elements: []Element{},
-	}
 }
 
 func (i *GroupData) IsGroup() {}
@@ -1626,20 +1475,11 @@ type Keyword interface {
 }
 
 func NewKeyword() Keyword {
-	return &KeywordImpl{
-		AstNodeBase:    core.NewAstNode(),
-		AssignableData: NewAssignableData(),
-		ElementData:    NewElementData(),
-		KeywordData:    NewKeywordData(),
-	}
+	return &KeywordImpl{}
 }
 
 type KeywordData struct {
 	value *core.Token
-}
-
-func NewKeywordData() KeywordData {
-	return KeywordData{}
 }
 
 func (i *KeywordData) IsKeyword() {}
@@ -1716,21 +1556,13 @@ type Assignment interface {
 }
 
 func NewAssignment() Assignment {
-	return &AssignmentImpl{
-		AstNodeBase:    core.NewAstNode(),
-		ElementData:    NewElementData(),
-		AssignmentData: NewAssignmentData(),
-	}
+	return &AssignmentImpl{}
 }
 
 type AssignmentData struct {
 	property *core.Reference[Field]
 	operator *core.Token
 	value    Assignable
-}
-
-func NewAssignmentData() AssignmentData {
-	return AssignmentData{}
 }
 
 func (i *AssignmentData) IsAssignment() {}
@@ -1836,18 +1668,10 @@ type Assignable interface {
 }
 
 func NewAssignable() Assignable {
-	return &AssignableImpl{
-		AstNodeBase:    core.NewAstNode(),
-		ElementData:    NewElementData(),
-		AssignableData: NewAssignableData(),
-	}
+	return &AssignableImpl{}
 }
 
 type AssignableData struct {
-}
-
-func NewAssignableData() AssignableData {
-	return AssignableData{}
 }
 
 func (i *AssignableData) IsAssignable() {}
@@ -1900,21 +1724,12 @@ type CrossRef interface {
 }
 
 func NewCrossRef() CrossRef {
-	return &CrossRefImpl{
-		AstNodeBase:    core.NewAstNode(),
-		AssignableData: NewAssignableData(),
-		ElementData:    NewElementData(),
-		CrossRefData:   NewCrossRefData(),
-	}
+	return &CrossRefImpl{}
 }
 
 type CrossRefData struct {
 	_Type *core.Reference[Interface]
 	rule  RuleCall
-}
-
-func NewCrossRefData() CrossRefData {
-	return CrossRefData{}
 }
 
 func (i *CrossRefData) IsCrossRef() {}
@@ -2007,20 +1822,11 @@ type RuleCall interface {
 }
 
 func NewRuleCall() RuleCall {
-	return &RuleCallImpl{
-		AstNodeBase:    core.NewAstNode(),
-		AssignableData: NewAssignableData(),
-		ElementData:    NewElementData(),
-		RuleCallData:   NewRuleCallData(),
-	}
+	return &RuleCallImpl{}
 }
 
 type RuleCallData struct {
 	rule *core.Reference[AbstractRule]
-}
-
-func NewRuleCallData() RuleCallData {
-	return RuleCallData{}
 }
 
 func (i *RuleCallData) IsRuleCall() {}
@@ -2096,21 +1902,13 @@ type Action interface {
 }
 
 func NewAction() Action {
-	return &ActionImpl{
-		AstNodeBase: core.NewAstNode(),
-		ElementData: NewElementData(),
-		ActionData:  NewActionData(),
-	}
+	return &ActionImpl{}
 }
 
 type ActionData struct {
 	_Type    *core.Reference[Interface]
 	operator *core.Token
 	property *core.Reference[Field]
-}
-
-func NewActionData() ActionData {
-	return ActionData{}
 }
 
 func (i *ActionData) IsAction() {}
@@ -2211,19 +2009,10 @@ type CompositeRule interface {
 }
 
 func NewCompositeRule() CompositeRule {
-	return &CompositeRuleImpl{
-		AstNodeBase:              core.NewAstNode(),
-		AbstractRuleWithBodyData: NewAbstractRuleWithBodyData(),
-		AbstractRuleData:         NewAbstractRuleData(),
-		CompositeRuleData:        NewCompositeRuleData(),
-	}
+	return &CompositeRuleImpl{}
 }
 
 type CompositeRuleData struct {
-}
-
-func NewCompositeRuleData() CompositeRuleData {
-	return CompositeRuleData{}
 }
 
 func (i *CompositeRuleData) IsCompositeRule() {}

--- a/internal/languages/completion/types_gen.go
+++ b/internal/languages/completion/types_gen.go
@@ -16,17 +16,10 @@ type Obj interface {
 }
 
 func NewObj() Obj {
-	return &ObjImpl{
-		AstNodeBase: core.NewAstNode(),
-		ObjData:     NewObjData(),
-	}
+	return &ObjImpl{}
 }
 
 type ObjData struct {
-}
-
-func NewObjData() ObjData {
-	return ObjData{}
 }
 
 func (i *ObjData) IsObj() {}
@@ -68,20 +61,11 @@ type Root interface {
 }
 
 func NewRoot() Root {
-	return &RootImpl{
-		AstNodeBase: core.NewAstNode(),
-		RootData:    NewRootData(),
-	}
+	return &RootImpl{}
 }
 
 type RootData struct {
 	objects []Obj
-}
-
-func NewRootData() RootData {
-	return RootData{
-		objects: []Obj{},
-	}
 }
 
 func (i *RootData) IsRoot() {}
@@ -152,22 +136,12 @@ type Declare interface {
 }
 
 func NewDeclare() Declare {
-	return &DeclareImpl{
-		AstNodeBase: core.NewAstNode(),
-		ObjData:     NewObjData(),
-		DeclareData: NewDeclareData(),
-	}
+	return &DeclareImpl{}
 }
 
 type DeclareData struct {
 	name     core.CompositeNode
 	children []Declare
-}
-
-func NewDeclareData() DeclareData {
-	return DeclareData{
-		children: []Declare{},
-	}
 }
 
 func (i *DeclareData) IsDeclare() {}
@@ -259,19 +233,11 @@ type E interface {
 }
 
 func NewE() E {
-	return &EImpl{
-		AstNodeBase: core.NewAstNode(),
-		ObjData:     NewObjData(),
-		EData:       NewEData(),
-	}
+	return &EImpl{}
 }
 
 type EData struct {
 	ref *core.Reference[Declare]
-}
-
-func NewEData() EData {
-	return EData{}
 }
 
 func (i *EData) IsE() {}
@@ -337,21 +303,11 @@ type F interface {
 }
 
 func NewF() F {
-	return &FImpl{
-		AstNodeBase: core.NewAstNode(),
-		ObjData:     NewObjData(),
-		FData:       NewFData(),
-	}
+	return &FImpl{}
 }
 
 type FData struct {
 	items []FItem
-}
-
-func NewFData() FData {
-	return FData{
-		items: []FItem{},
-	}
 }
 
 func (i *FData) IsF() {}
@@ -421,18 +377,11 @@ type FItem interface {
 }
 
 func NewFItem() FItem {
-	return &FItemImpl{
-		AstNodeBase: core.NewAstNode(),
-		FItemData:   NewFItemData(),
-	}
+	return &FItemImpl{}
 }
 
 type FItemData struct {
 	ref *core.Reference[Declare]
-}
-
-func NewFItemData() FItemData {
-	return FItemData{}
 }
 
 func (i *FItemData) IsFItem() {}
@@ -495,19 +444,11 @@ type G interface {
 }
 
 func NewG() G {
-	return &GImpl{
-		AstNodeBase: core.NewAstNode(),
-		ObjData:     NewObjData(),
-		GData:       NewGData(),
-	}
+	return &GImpl{}
 }
 
 type GData struct {
 	ref *core.Reference[Declare]
-}
-
-func NewGData() GData {
-	return GData{}
 }
 
 func (i *GData) IsG() {}
@@ -573,19 +514,11 @@ type H interface {
 }
 
 func NewH() H {
-	return &HImpl{
-		AstNodeBase: core.NewAstNode(),
-		ObjData:     NewObjData(),
-		HData:       NewHData(),
-	}
+	return &HImpl{}
 }
 
 type HData struct {
 	member MemberCall
-}
-
-func NewHData() HData {
-	return HData{}
 }
 
 func (i *HData) IsH() {}
@@ -657,19 +590,12 @@ type MemberCall interface {
 }
 
 func NewMemberCall() MemberCall {
-	return &MemberCallImpl{
-		AstNodeBase:    core.NewAstNode(),
-		MemberCallData: NewMemberCallData(),
-	}
+	return &MemberCallImpl{}
 }
 
 type MemberCallData struct {
 	ref      *core.Reference[Declare]
 	previous MemberCall
-}
-
-func NewMemberCallData() MemberCallData {
-	return MemberCallData{}
 }
 
 func (i *MemberCallData) IsMemberCall() {}
@@ -754,19 +680,11 @@ type J interface {
 }
 
 func NewJ() J {
-	return &JImpl{
-		AstNodeBase: core.NewAstNode(),
-		ObjData:     NewObjData(),
-		JData:       NewJData(),
-	}
+	return &JImpl{}
 }
 
 type JData struct {
 	ref *core.Reference[Declare]
-}
-
-func NewJData() JData {
-	return JData{}
 }
 
 func (i *JData) IsJ() {}
@@ -834,20 +752,12 @@ type K interface {
 }
 
 func NewK() K {
-	return &KImpl{
-		AstNodeBase: core.NewAstNode(),
-		ObjData:     NewObjData(),
-		KData:       NewKData(),
-	}
+	return &KImpl{}
 }
 
 type KData struct {
 	ref1 *core.Reference[Declare]
 	ref2 *core.Reference[Declare]
-}
-
-func NewKData() KData {
-	return KData{}
 }
 
 func (i *KData) IsK() {}
@@ -930,19 +840,11 @@ type N interface {
 }
 
 func NewN() N {
-	return &NImpl{
-		AstNodeBase: core.NewAstNode(),
-		ObjData:     NewObjData(),
-		NData:       NewNData(),
-	}
+	return &NImpl{}
 }
 
 type NData struct {
 	ref *core.Reference[Declare]
-}
-
-func NewNData() NData {
-	return NData{}
 }
 
 func (i *NData) IsN() {}
@@ -1008,19 +910,11 @@ type O interface {
 }
 
 func NewO() O {
-	return &OImpl{
-		AstNodeBase: core.NewAstNode(),
-		ObjData:     NewObjData(),
-		OData:       NewOData(),
-	}
+	return &OImpl{}
 }
 
 type OData struct {
 	ref *core.Reference[Declare]
-}
-
-func NewOData() OData {
-	return OData{}
 }
 
 func (i *OData) IsO() {}

--- a/internal/languages/lookahead/types_gen.go
+++ b/internal/languages/lookahead/types_gen.go
@@ -22,19 +22,12 @@ type Obj interface {
 }
 
 func NewObj() Obj {
-	return &ObjImpl{
-		AstNodeBase: core.NewAstNode(),
-		ObjData:     NewObjData(),
-	}
+	return &ObjImpl{}
 }
 
 type ObjData struct {
 	value *core.Token
 	node  core.CompositeNode
-}
-
-func NewObjData() ObjData {
-	return ObjData{}
 }
 
 func (i *ObjData) IsObj() {}
@@ -118,18 +111,11 @@ type Root interface {
 }
 
 func NewRoot() Root {
-	return &RootImpl{
-		AstNodeBase: core.NewAstNode(),
-		RootData:    NewRootData(),
-	}
+	return &RootImpl{}
 }
 
 type RootData struct {
 	item Obj
-}
-
-func NewRootData() RootData {
-	return RootData{}
 }
 
 func (i *RootData) IsRoot() {}
@@ -198,19 +184,11 @@ type B interface {
 }
 
 func NewB() B {
-	return &BImpl{
-		AstNodeBase: core.NewAstNode(),
-		ObjData:     NewObjData(),
-		BData:       NewBData(),
-	}
+	return &BImpl{}
 }
 
 type BData struct {
 	post *core.Token
-}
-
-func NewBData() BData {
-	return BData{}
 }
 
 func (i *BData) IsB() {}

--- a/internal/languages/token_groups/types_gen.go
+++ b/internal/languages/token_groups/types_gen.go
@@ -18,18 +18,11 @@ type Model interface {
 }
 
 func NewModel() Model {
-	return &ModelImpl{
-		AstNodeBase: core.NewAstNode(),
-		ModelData:   NewModelData(),
-	}
+	return &ModelImpl{}
 }
 
 type ModelData struct {
 	item Item
-}
-
-func NewModelData() ModelData {
-	return ModelData{}
 }
 
 func (i *ModelData) IsModel() {}
@@ -97,18 +90,11 @@ type Item interface {
 }
 
 func NewItem() Item {
-	return &ItemImpl{
-		AstNodeBase: core.NewAstNode(),
-		ItemData:    NewItemData(),
-	}
+	return &ItemImpl{}
 }
 
 type ItemData struct {
 	value *core.Token
-}
-
-func NewItemData() ItemData {
-	return ItemData{}
 }
 
 func (i *ItemData) IsItem() {}
@@ -176,20 +162,12 @@ type Recovery interface {
 }
 
 func NewRecovery() Recovery {
-	return &RecoveryImpl{
-		AstNodeBase:  core.NewAstNode(),
-		ItemData:     NewItemData(),
-		RecoveryData: NewRecoveryData(),
-	}
+	return &RecoveryImpl{}
 }
 
 type RecoveryData struct {
 	first  *core.Token
 	second *core.Token
-}
-
-func NewRecoveryData() RecoveryData {
-	return RecoveryData{}
 }
 
 func (i *RecoveryData) IsRecovery() {}

--- a/token.go
+++ b/token.go
@@ -95,7 +95,7 @@ func NewTokenType(id int, name, label string, group int, kind TokenKind, pushMod
 
 // NewTokenGroup creates a token type that represents a named group of other token types.
 func NewTokenGroup(id int, name, label string, matchingTypes []*TokenType) *TokenType {
-	bitsets := make([]*collections.BitSet, len(matchingTypes))
+	bitsets := make([]*collections.BitSet, 0, len(matchingTypes))
 	for _, mt := range matchingTypes {
 		bitsets = append(bitsets, mt.bitset)
 	}


### PR DESCRIPTION
The parser currently allocates a lot of empty arrays that aren't really necessary. For most purposes, `nil` and `[]` (empty) slices are essentially the same. This change removes all of the array initialization code, which reduces retained memory, reduces the amount of intermediate allocated memory, and improves parsing performance.

Adds a benchmark for the arithmetics language, which is affected by this change more than the statemachine language.