### PR TITLE
Support infix rules

### DIFF
--- a/cmd/fastbelt/generate.go
+++ b/cmd/fastbelt/generate.go
@@ -14,7 +14,7 @@ import (
 
 	core "typefox.dev/fastbelt"
 	"typefox.dev/fastbelt/internal/generator"
-	grammarPkg "typefox.dev/fastbelt/internal/grammar"
+	"typefox.dev/fastbelt/internal/grammar"
 	"typefox.dev/fastbelt/textdoc"
 	"typefox.dev/fastbelt/util/service"
 	"typefox.dev/fastbelt/workspace"
@@ -54,7 +54,7 @@ func runGenerateCLI(opts generateOptions) error {
 		return err
 	}
 
-	sc := grammarPkg.CreateServices()
+	sc := grammar.CreateServices()
 	file, _ := textdoc.NewFile(lsp.URIFromPath(grammarPath), "fb", 0, string(grammarText))
 
 	document := core.NewDocument(file)
@@ -97,17 +97,17 @@ func runGenerateCLI(opts generateOptions) error {
 		return fmt.Errorf("aborting code generation due to %d errors", errCount)
 	}
 
-	grammar, ok := document.Root.(grammarPkg.Grammar)
+	gram, ok := document.Root.(grammar.Grammar)
 	if !ok {
 		return fmt.Errorf("parser result is not a Grammar")
 	}
-	entryRule, err := validateEntryRule(grammar)
+	entryRule, err := validateEntryRule(gram)
 	if err != nil {
 		return err
 	}
 	// Desugar infix rules once, so every generator below sees the synthesized
 	// operator token groups and flat rule bodies.
-	if err := grammarPkg.ExpandInfixRules(grammar); err != nil {
+	if err := grammar.ExpandInfixRules(gram); err != nil {
 		return err
 	}
 
@@ -122,46 +122,46 @@ func runGenerateCLI(opts generateOptions) error {
 	}
 
 	if err := writeFile("linker", filepath.Join(outputPath, "linker_gen.go"),
-		generator.GenerateLinker(grammar, packageName)); err != nil {
+		generator.GenerateLinker(gram, packageName)); err != nil {
 		return err
 	}
 	if err := writeFile("types", filepath.Join(outputPath, "types_gen.go"),
-		generator.GenerateTypes(grammar, packageName)); err != nil {
+		generator.GenerateTypes(gram, packageName)); err != nil {
 		return err
 	}
-	tokenTypes := generator.GenerateTokenTypes(grammar)
-	atnData := generator.BuildParserATNData(grammar, tokenTypes)
+	tokenTypes := generator.GenerateTokenTypes(gram)
+	atnData := generator.BuildParserATNData(gram, tokenTypes)
 	if err := writeFile("parser", filepath.Join(outputPath, "parser_gen.go"),
-		generator.GenerateParser(grammar, entryRule, packageName, tokenTypes, atnData)); err != nil {
+		generator.GenerateParser(gram, entryRule, packageName, tokenTypes, atnData)); err != nil {
 		return err
 	}
 	if err := writeFile("completion-parser", filepath.Join(outputPath, "completion_parser_gen.go"),
-		generator.GenerateCompletionParser(grammar, entryRule, packageName, tokenTypes, atnData)); err != nil {
+		generator.GenerateCompletionParser(gram, entryRule, packageName, tokenTypes, atnData)); err != nil {
 		return err
 	}
 	if err := writeFile("parser-lookahead", filepath.Join(outputPath, "parser_lookahead_gen.go"),
-		generator.GenerateParserLookahead(grammar, packageName, tokenTypes, atnData)); err != nil {
+		generator.GenerateParserLookahead(gram, packageName, tokenTypes, atnData)); err != nil {
 		return err
 	}
 	if err := writeFile("completion", filepath.Join(outputPath, "completion_gen.go"),
-		generator.GenerateCompletion(grammar, packageName)); err != nil {
+		generator.GenerateCompletion(gram, packageName)); err != nil {
 		return err
 	}
 	if err := writeFile("lexer", filepath.Join(outputPath, "lexer_gen.go"),
-		generator.GenerateLexer(grammar, packageName, tokenTypes)); err != nil {
+		generator.GenerateLexer(gram, packageName, tokenTypes)); err != nil {
 		return err
 	}
 	if err := writeFile("services", filepath.Join(outputPath, "services_gen.go"),
-		generator.GenerateServices(grammar, packageName)); err != nil {
+		generator.GenerateServices(gram, packageName)); err != nil {
 		return err
 	}
 	if err := writeFile("atn", filepath.Join(outputPath, "atn_gen.go"),
-		generator.GenerateATN(grammar, packageName, tokenTypes)); err != nil {
+		generator.GenerateATN(gram, packageName, tokenTypes)); err != nil {
 		return err
 	}
 	if opts.atn {
 		if err := writeFile("atn-md", filepath.Join(outputPath, "atn.md"),
-			generator.GenerateATNMarkdown(grammar, packageName, tokenTypes)); err != nil {
+			generator.GenerateATNMarkdown(gram, packageName, tokenTypes)); err != nil {
 			return err
 		}
 	}
@@ -169,8 +169,8 @@ func runGenerateCLI(opts generateOptions) error {
 	return nil
 }
 
-func validateEntryRule(g grammarPkg.Grammar) (grammarPkg.ParserRule, error) {
-	var entries []grammarPkg.ParserRule
+func validateEntryRule(g grammar.Grammar) (grammar.ParserRule, error) {
+	var entries []grammar.ParserRule
 	for _, rule := range g.Rules() {
 		if rule.IsEntry() {
 			entries = append(entries, rule)

--- a/cmd/fastbelt/generate.go
+++ b/cmd/fastbelt/generate.go
@@ -14,7 +14,7 @@ import (
 
 	core "typefox.dev/fastbelt"
 	"typefox.dev/fastbelt/internal/generator"
-	"typefox.dev/fastbelt/internal/grammar"
+	grammarPkg "typefox.dev/fastbelt/internal/grammar"
 	"typefox.dev/fastbelt/textdoc"
 	"typefox.dev/fastbelt/util/service"
 	"typefox.dev/fastbelt/workspace"
@@ -54,7 +54,7 @@ func runGenerateCLI(opts generateOptions) error {
 		return err
 	}
 
-	sc := grammar.CreateServices()
+	sc := grammarPkg.CreateServices()
 	file, _ := textdoc.NewFile(lsp.URIFromPath(grammarPath), "fb", 0, string(grammarText))
 
 	document := core.NewDocument(file)
@@ -97,12 +97,17 @@ func runGenerateCLI(opts generateOptions) error {
 		return fmt.Errorf("aborting code generation due to %d errors", errCount)
 	}
 
-	grammar, ok := document.Root.(grammar.Grammar)
+	grammar, ok := document.Root.(grammarPkg.Grammar)
 	if !ok {
 		return fmt.Errorf("parser result is not a Grammar")
 	}
 	entryRule, err := validateEntryRule(grammar)
 	if err != nil {
+		return err
+	}
+	// Desugar infix rules once, so every generator below sees the synthesized
+	// operator token groups and flat rule bodies.
+	if err := grammarPkg.ExpandInfixRules(grammar); err != nil {
 		return err
 	}
 
@@ -164,8 +169,8 @@ func runGenerateCLI(opts generateOptions) error {
 	return nil
 }
 
-func validateEntryRule(g grammar.Grammar) (grammar.ParserRule, error) {
-	var entries []grammar.ParserRule
+func validateEntryRule(g grammarPkg.Grammar) (grammarPkg.ParserRule, error) {
+	var entries []grammarPkg.ParserRule
 	for _, rule := range g.Rules() {
 		if rule.IsEntry() {
 			entries = append(entries, rule)

--- a/cmd/fastbelt/generate.go
+++ b/cmd/fastbelt/generate.go
@@ -14,7 +14,7 @@ import (
 
 	core "typefox.dev/fastbelt"
 	"typefox.dev/fastbelt/internal/generator"
-	"typefox.dev/fastbelt/internal/grammar"
+	grammarPkg "typefox.dev/fastbelt/internal/grammar"
 	"typefox.dev/fastbelt/textdoc"
 	"typefox.dev/fastbelt/util/service"
 	"typefox.dev/fastbelt/workspace"
@@ -54,7 +54,7 @@ func runGenerateCLI(opts generateOptions) error {
 		return err
 	}
 
-	sc := grammar.CreateServices()
+	sc := grammarPkg.CreateServices()
 	file, _ := textdoc.NewFile(lsp.URIFromPath(grammarPath), "fb", 0, string(grammarText))
 
 	document := core.NewDocument(file)
@@ -97,17 +97,17 @@ func runGenerateCLI(opts generateOptions) error {
 		return fmt.Errorf("aborting code generation due to %d errors", errCount)
 	}
 
-	gram, ok := document.Root.(grammar.Grammar)
+	grammar, ok := document.Root.(grammarPkg.Grammar)
 	if !ok {
 		return fmt.Errorf("parser result is not a Grammar")
 	}
-	entryRule, err := validateEntryRule(gram)
+	entryRule, err := validateEntryRule(grammar)
 	if err != nil {
 		return err
 	}
 	// Desugar infix rules once, so every generator below sees the synthesized
 	// operator token groups and flat rule bodies.
-	if err := grammar.ExpandInfixRules(gram); err != nil {
+	if err := grammarPkg.ExpandInfixRules(grammar); err != nil {
 		return err
 	}
 
@@ -122,46 +122,46 @@ func runGenerateCLI(opts generateOptions) error {
 	}
 
 	if err := writeFile("linker", filepath.Join(outputPath, "linker_gen.go"),
-		generator.GenerateLinker(gram, packageName)); err != nil {
+		generator.GenerateLinker(grammar, packageName)); err != nil {
 		return err
 	}
 	if err := writeFile("types", filepath.Join(outputPath, "types_gen.go"),
-		generator.GenerateTypes(gram, packageName)); err != nil {
+		generator.GenerateTypes(grammar, packageName)); err != nil {
 		return err
 	}
-	tokenTypes := generator.GenerateTokenTypes(gram)
-	atnData := generator.BuildParserATNData(gram, tokenTypes)
+	tokenTypes := generator.GenerateTokenTypes(grammar)
+	atnData := generator.BuildParserATNData(grammar, tokenTypes)
 	if err := writeFile("parser", filepath.Join(outputPath, "parser_gen.go"),
-		generator.GenerateParser(gram, entryRule, packageName, tokenTypes, atnData)); err != nil {
+		generator.GenerateParser(grammar, entryRule, packageName, tokenTypes, atnData)); err != nil {
 		return err
 	}
 	if err := writeFile("completion-parser", filepath.Join(outputPath, "completion_parser_gen.go"),
-		generator.GenerateCompletionParser(gram, entryRule, packageName, tokenTypes, atnData)); err != nil {
+		generator.GenerateCompletionParser(grammar, entryRule, packageName, tokenTypes, atnData)); err != nil {
 		return err
 	}
 	if err := writeFile("parser-lookahead", filepath.Join(outputPath, "parser_lookahead_gen.go"),
-		generator.GenerateParserLookahead(gram, packageName, tokenTypes, atnData)); err != nil {
+		generator.GenerateParserLookahead(grammar, packageName, tokenTypes, atnData)); err != nil {
 		return err
 	}
 	if err := writeFile("completion", filepath.Join(outputPath, "completion_gen.go"),
-		generator.GenerateCompletion(gram, packageName)); err != nil {
+		generator.GenerateCompletion(grammar, packageName)); err != nil {
 		return err
 	}
 	if err := writeFile("lexer", filepath.Join(outputPath, "lexer_gen.go"),
-		generator.GenerateLexer(gram, packageName, tokenTypes)); err != nil {
+		generator.GenerateLexer(grammar, packageName, tokenTypes)); err != nil {
 		return err
 	}
 	if err := writeFile("services", filepath.Join(outputPath, "services_gen.go"),
-		generator.GenerateServices(gram, packageName)); err != nil {
+		generator.GenerateServices(grammar, packageName)); err != nil {
 		return err
 	}
 	if err := writeFile("atn", filepath.Join(outputPath, "atn_gen.go"),
-		generator.GenerateATN(gram, packageName, tokenTypes)); err != nil {
+		generator.GenerateATN(grammar, packageName, tokenTypes)); err != nil {
 		return err
 	}
 	if opts.atn {
 		if err := writeFile("atn-md", filepath.Join(outputPath, "atn.md"),
-			generator.GenerateATNMarkdown(gram, packageName, tokenTypes)); err != nil {
+			generator.GenerateATNMarkdown(grammar, packageName, tokenTypes)); err != nil {
 			return err
 		}
 	}
@@ -169,8 +169,8 @@ func runGenerateCLI(opts generateOptions) error {
 	return nil
 }
 
-func validateEntryRule(g grammar.Grammar) (grammar.ParserRule, error) {
-	var entries []grammar.ParserRule
+func validateEntryRule(g grammarPkg.Grammar) (grammarPkg.ParserRule, error) {
+	var entries []grammarPkg.ParserRule
 	for _, rule := range g.Rules() {
 		if rule.IsEntry() {
 			entries = append(entries, rule)

--- a/examples/arithmetics/arithmetics.fb
+++ b/examples/arithmetics/arithmetics.fb
@@ -63,16 +63,16 @@ Expression:
 infix BinaryExpression on PrimaryExpression:
     "%"
     > right "^"
-    > Multiplication
-    > Addition
+    > MultiplicationOp
+    > AdditionOp
 
 // Tests that Fastbelt can handle operators nested in token groups
-token group Multiplication {
+token group MultiplicationOp {
     "*"
     "/"
 }
 
-token group Addition {
+token group AdditionOp {
     "+"
     "-"
 }

--- a/examples/arithmetics/arithmetics.fb
+++ b/examples/arithmetics/arithmetics.fb
@@ -62,7 +62,7 @@ Expression:
 
 infix BinaryExpression on PrimaryExpression:
     "%"
-    > right assoc "^"
+    > right "^"
     > Multiplication
     > Addition
 

--- a/examples/arithmetics/arithmetics.fb
+++ b/examples/arithmetics/arithmetics.fb
@@ -58,19 +58,24 @@ Evaluation:
     Expression=Expression ";"
 
 Expression:
-    Addition
+    BinaryExpression
 
-Addition returns Expression:
-    Multiplication ({BinaryExpression.Left=current} Operator=("+" | "-") Right=Multiplication)*
+infix BinaryExpression on PrimaryExpression:
+    "%"
+    > right assoc "^"
+    > Multiplication
+    > Addition
 
-Multiplication returns Expression:
-    Exponentiation ({BinaryExpression.Left=current} Operator=("*" | "/") Right=Exponentiation)*
+// Tests that Fastbelt can handle operators nested in token groups
+token group Multiplication {
+    "*"
+    "/"
+}
 
-Exponentiation returns Expression:
-    Modulo ({BinaryExpression.Left=current} Operator="^" Right=Modulo)*
-
-Modulo returns Expression:
-    PrimaryExpression ({BinaryExpression.Left=current} Operator="%" Right=PrimaryExpression)*
+token group Addition {
+    "+"
+    "-"
+}
 
 PrimaryExpression returns Expression:
     "(" Expression ")" |

--- a/examples/arithmetics/atn_gen.go
+++ b/examples/arithmetics/atn_gen.go
@@ -20,16 +20,10 @@ const (
 	Evaluation__Stop
 	Expression__Start
 	Expression__Stop
-	Addition__Start
-	Addition__Stop
-	Multiplication__Start
-	Multiplication__Stop
-	Exponentiation__Start
-	Exponentiation__Stop
-	Modulo__Start
-	Modulo__Stop
 	PrimaryExpression__Start
 	PrimaryExpression__Stop
+	BinaryExpression__Start
+	BinaryExpression__Stop
 	Module_module
 	Module_Name_ID
 	Module__Basic_0
@@ -67,44 +61,6 @@ const (
 	Evaluation__Basic_1
 	Expression__Basic_0
 	Expression__Basic_1
-	Addition__Basic_0
-	Addition_Operator_Plus
-	Addition__Basic_1
-	Addition_Operator_Dash
-	Addition__Basic_2
-	Addition__Basic_3
-	Addition__BlockEnd
-	Addition__Basic_4
-	Addition__Basic_5
-	Addition__LoopEntry
-	Addition__LoopEnd
-	Addition__LoopBack
-	Multiplication__Basic_0
-	Multiplication_Operator_Asterisk
-	Multiplication__Basic_1
-	Multiplication_Operator_Slash
-	Multiplication__Basic_2
-	Multiplication__Basic_3
-	Multiplication__BlockEnd
-	Multiplication__Basic_4
-	Multiplication__Basic_5
-	Multiplication__LoopEntry
-	Multiplication__LoopEnd
-	Multiplication__LoopBack
-	Exponentiation__Basic_0
-	Exponentiation_Operator_Caret
-	Exponentiation__Basic_1
-	Exponentiation__Basic_2
-	Exponentiation__LoopEntry
-	Exponentiation__LoopEnd
-	Exponentiation__LoopBack
-	Modulo__Basic_0
-	Modulo_Operator_Percent
-	Modulo__Basic_1
-	Modulo__Basic_2
-	Modulo__LoopEntry
-	Modulo__LoopEnd
-	Modulo__LoopBack
 	PrimaryExpression_LeftParen_0
 	PrimaryExpression__Basic_0
 	PrimaryExpression_RightParen_0
@@ -125,6 +81,13 @@ const (
 	PrimaryExpression__Basic_7
 	PrimaryExpression__Basic_8
 	PrimaryExpression__BlockEnd
+	BinaryExpression__Basic_0
+	BinaryExpression_BinaryExpressionOperator
+	BinaryExpression__Basic_1
+	BinaryExpression__Basic_2
+	BinaryExpression__LoopEntry
+	BinaryExpression__LoopEnd
+	BinaryExpression__LoopBack
 )
 
 var once sync.Once
@@ -137,7 +100,7 @@ func ATN() *parser.RuntimeATN {
 	return atn
 }
 func BuildATN() *parser.RuntimeATN {
-	states := make([]*parser.RuntimeATNState, 117)
+	states := make([]*parser.RuntimeATNState, 80)
 	states[Module__Start] = parser.NewATNState(Module__Start, parser.ATNRuleStart, true)
 	states[Module__Stop] = parser.NewATNState(Module__Stop, parser.ATNRuleStop, false)
 	states[Statement__Start] = parser.NewATNState(Statement__Start, parser.ATNRuleStart, true)
@@ -150,16 +113,10 @@ func BuildATN() *parser.RuntimeATN {
 	states[Evaluation__Stop] = parser.NewATNState(Evaluation__Stop, parser.ATNRuleStop, false)
 	states[Expression__Start] = parser.NewATNState(Expression__Start, parser.ATNRuleStart, true)
 	states[Expression__Stop] = parser.NewATNState(Expression__Stop, parser.ATNRuleStop, false)
-	states[Addition__Start] = parser.NewATNState(Addition__Start, parser.ATNRuleStart, true)
-	states[Addition__Stop] = parser.NewATNState(Addition__Stop, parser.ATNRuleStop, false)
-	states[Multiplication__Start] = parser.NewATNState(Multiplication__Start, parser.ATNRuleStart, true)
-	states[Multiplication__Stop] = parser.NewATNState(Multiplication__Stop, parser.ATNRuleStop, false)
-	states[Exponentiation__Start] = parser.NewATNState(Exponentiation__Start, parser.ATNRuleStart, true)
-	states[Exponentiation__Stop] = parser.NewATNState(Exponentiation__Stop, parser.ATNRuleStop, false)
-	states[Modulo__Start] = parser.NewATNState(Modulo__Start, parser.ATNRuleStart, true)
-	states[Modulo__Stop] = parser.NewATNState(Modulo__Stop, parser.ATNRuleStop, false)
 	states[PrimaryExpression__Start] = parser.NewATNState(PrimaryExpression__Start, parser.ATNRuleStart, true)
 	states[PrimaryExpression__Stop] = parser.NewATNState(PrimaryExpression__Stop, parser.ATNRuleStop, false)
+	states[BinaryExpression__Start] = parser.NewATNState(BinaryExpression__Start, parser.ATNRuleStart, true)
+	states[BinaryExpression__Stop] = parser.NewATNState(BinaryExpression__Stop, parser.ATNRuleStop, false)
 	states[Module_module] = parser.NewATNState(Module_module, parser.ATNBasic, false)
 	states[Module_Name_ID] = parser.NewATNState(Module_Name_ID, parser.ATNBasic, false)
 	states[Module__Basic_0] = parser.NewATNState(Module__Basic_0, parser.ATNBasic, true)
@@ -197,44 +154,6 @@ func BuildATN() *parser.RuntimeATN {
 	states[Evaluation__Basic_1] = parser.NewATNState(Evaluation__Basic_1, parser.ATNBasic, true)
 	states[Expression__Basic_0] = parser.NewATNState(Expression__Basic_0, parser.ATNBasic, true)
 	states[Expression__Basic_1] = parser.NewATNState(Expression__Basic_1, parser.ATNBasic, true)
-	states[Addition__Basic_0] = parser.NewATNState(Addition__Basic_0, parser.ATNBasic, true)
-	states[Addition_Operator_Plus] = parser.NewATNState(Addition_Operator_Plus, parser.ATNBasic, false)
-	states[Addition__Basic_1] = parser.NewATNState(Addition__Basic_1, parser.ATNBasic, true)
-	states[Addition_Operator_Dash] = parser.NewATNState(Addition_Operator_Dash, parser.ATNBasic, false)
-	states[Addition__Basic_2] = parser.NewATNState(Addition__Basic_2, parser.ATNBasic, true)
-	states[Addition__Basic_3] = parser.NewATNState(Addition__Basic_3, parser.ATNBasic, true).SetDecision(4)
-	states[Addition__BlockEnd] = parser.NewATNState(Addition__BlockEnd, parser.ATNBlockEnd, true)
-	states[Addition__Basic_4] = parser.NewATNState(Addition__Basic_4, parser.ATNBasic, true)
-	states[Addition__Basic_5] = parser.NewATNState(Addition__Basic_5, parser.ATNBasic, true)
-	states[Addition__LoopEntry] = parser.NewATNState(Addition__LoopEntry, parser.ATNLoopEntry, true).SetDecision(5)
-	states[Addition__LoopEnd] = parser.NewATNState(Addition__LoopEnd, parser.ATNLoopEnd, true)
-	states[Addition__LoopBack] = parser.NewATNState(Addition__LoopBack, parser.ATNLoopBack, true)
-	states[Multiplication__Basic_0] = parser.NewATNState(Multiplication__Basic_0, parser.ATNBasic, true)
-	states[Multiplication_Operator_Asterisk] = parser.NewATNState(Multiplication_Operator_Asterisk, parser.ATNBasic, false)
-	states[Multiplication__Basic_1] = parser.NewATNState(Multiplication__Basic_1, parser.ATNBasic, true)
-	states[Multiplication_Operator_Slash] = parser.NewATNState(Multiplication_Operator_Slash, parser.ATNBasic, false)
-	states[Multiplication__Basic_2] = parser.NewATNState(Multiplication__Basic_2, parser.ATNBasic, true)
-	states[Multiplication__Basic_3] = parser.NewATNState(Multiplication__Basic_3, parser.ATNBasic, true).SetDecision(6)
-	states[Multiplication__BlockEnd] = parser.NewATNState(Multiplication__BlockEnd, parser.ATNBlockEnd, true)
-	states[Multiplication__Basic_4] = parser.NewATNState(Multiplication__Basic_4, parser.ATNBasic, true)
-	states[Multiplication__Basic_5] = parser.NewATNState(Multiplication__Basic_5, parser.ATNBasic, true)
-	states[Multiplication__LoopEntry] = parser.NewATNState(Multiplication__LoopEntry, parser.ATNLoopEntry, true).SetDecision(7)
-	states[Multiplication__LoopEnd] = parser.NewATNState(Multiplication__LoopEnd, parser.ATNLoopEnd, true)
-	states[Multiplication__LoopBack] = parser.NewATNState(Multiplication__LoopBack, parser.ATNLoopBack, true)
-	states[Exponentiation__Basic_0] = parser.NewATNState(Exponentiation__Basic_0, parser.ATNBasic, true)
-	states[Exponentiation_Operator_Caret] = parser.NewATNState(Exponentiation_Operator_Caret, parser.ATNBasic, false)
-	states[Exponentiation__Basic_1] = parser.NewATNState(Exponentiation__Basic_1, parser.ATNBasic, true)
-	states[Exponentiation__Basic_2] = parser.NewATNState(Exponentiation__Basic_2, parser.ATNBasic, true)
-	states[Exponentiation__LoopEntry] = parser.NewATNState(Exponentiation__LoopEntry, parser.ATNLoopEntry, true).SetDecision(8)
-	states[Exponentiation__LoopEnd] = parser.NewATNState(Exponentiation__LoopEnd, parser.ATNLoopEnd, true)
-	states[Exponentiation__LoopBack] = parser.NewATNState(Exponentiation__LoopBack, parser.ATNLoopBack, true)
-	states[Modulo__Basic_0] = parser.NewATNState(Modulo__Basic_0, parser.ATNBasic, true)
-	states[Modulo_Operator_Percent] = parser.NewATNState(Modulo_Operator_Percent, parser.ATNBasic, false)
-	states[Modulo__Basic_1] = parser.NewATNState(Modulo__Basic_1, parser.ATNBasic, true)
-	states[Modulo__Basic_2] = parser.NewATNState(Modulo__Basic_2, parser.ATNBasic, true)
-	states[Modulo__LoopEntry] = parser.NewATNState(Modulo__LoopEntry, parser.ATNLoopEntry, true).SetDecision(9)
-	states[Modulo__LoopEnd] = parser.NewATNState(Modulo__LoopEnd, parser.ATNLoopEnd, true)
-	states[Modulo__LoopBack] = parser.NewATNState(Modulo__LoopBack, parser.ATNLoopBack, true)
 	states[PrimaryExpression_LeftParen_0] = parser.NewATNState(PrimaryExpression_LeftParen_0, parser.ATNBasic, false)
 	states[PrimaryExpression__Basic_0] = parser.NewATNState(PrimaryExpression__Basic_0, parser.ATNBasic, true)
 	states[PrimaryExpression_RightParen_0] = parser.NewATNState(PrimaryExpression_RightParen_0, parser.ATNBasic, false)
@@ -247,14 +166,21 @@ func BuildATN() *parser.RuntimeATN {
 	states[PrimaryExpression_Comma] = parser.NewATNState(PrimaryExpression_Comma, parser.ATNBasic, false)
 	states[PrimaryExpression__Basic_4] = parser.NewATNState(PrimaryExpression__Basic_4, parser.ATNBasic, true)
 	states[PrimaryExpression__Basic_5] = parser.NewATNState(PrimaryExpression__Basic_5, parser.ATNBasic, true)
-	states[PrimaryExpression__LoopEntry] = parser.NewATNState(PrimaryExpression__LoopEntry, parser.ATNLoopEntry, true).SetDecision(10)
+	states[PrimaryExpression__LoopEntry] = parser.NewATNState(PrimaryExpression__LoopEntry, parser.ATNLoopEntry, true).SetDecision(4)
 	states[PrimaryExpression__LoopEnd] = parser.NewATNState(PrimaryExpression__LoopEnd, parser.ATNLoopEnd, true)
 	states[PrimaryExpression__LoopBack] = parser.NewATNState(PrimaryExpression__LoopBack, parser.ATNLoopBack, true)
 	states[PrimaryExpression_RightParen_1] = parser.NewATNState(PrimaryExpression_RightParen_1, parser.ATNBasic, false)
 	states[PrimaryExpression__Basic_6] = parser.NewATNState(PrimaryExpression__Basic_6, parser.ATNBasic, true)
-	states[PrimaryExpression__Basic_7] = parser.NewATNState(PrimaryExpression__Basic_7, parser.ATNBasic, true).SetDecision(11)
-	states[PrimaryExpression__Basic_8] = parser.NewATNState(PrimaryExpression__Basic_8, parser.ATNBasic, true).SetDecision(12)
+	states[PrimaryExpression__Basic_7] = parser.NewATNState(PrimaryExpression__Basic_7, parser.ATNBasic, true).SetDecision(5)
+	states[PrimaryExpression__Basic_8] = parser.NewATNState(PrimaryExpression__Basic_8, parser.ATNBasic, true).SetDecision(6)
 	states[PrimaryExpression__BlockEnd] = parser.NewATNState(PrimaryExpression__BlockEnd, parser.ATNBlockEnd, true)
+	states[BinaryExpression__Basic_0] = parser.NewATNState(BinaryExpression__Basic_0, parser.ATNBasic, true)
+	states[BinaryExpression_BinaryExpressionOperator] = parser.NewATNState(BinaryExpression_BinaryExpressionOperator, parser.ATNBasic, false)
+	states[BinaryExpression__Basic_1] = parser.NewATNState(BinaryExpression__Basic_1, parser.ATNBasic, true)
+	states[BinaryExpression__Basic_2] = parser.NewATNState(BinaryExpression__Basic_2, parser.ATNBasic, true)
+	states[BinaryExpression__LoopEntry] = parser.NewATNState(BinaryExpression__LoopEntry, parser.ATNLoopEntry, true).SetDecision(7)
+	states[BinaryExpression__LoopEnd] = parser.NewATNState(BinaryExpression__LoopEnd, parser.ATNLoopEnd, true)
+	states[BinaryExpression__LoopBack] = parser.NewATNState(BinaryExpression__LoopBack, parser.ATNLoopBack, true)
 	states[Module__Start].AppendTransitions(
 		parser.NewEpsilonTransition(states[Module_module]),
 	)
@@ -273,20 +199,11 @@ func BuildATN() *parser.RuntimeATN {
 	states[Expression__Start].AppendTransitions(
 		parser.NewEpsilonTransition(states[Expression__Basic_0]),
 	)
-	states[Addition__Start].AppendTransitions(
-		parser.NewEpsilonTransition(states[Addition__Basic_0]),
-	)
-	states[Multiplication__Start].AppendTransitions(
-		parser.NewEpsilonTransition(states[Multiplication__Basic_0]),
-	)
-	states[Exponentiation__Start].AppendTransitions(
-		parser.NewEpsilonTransition(states[Exponentiation__Basic_0]),
-	)
-	states[Modulo__Start].AppendTransitions(
-		parser.NewEpsilonTransition(states[Modulo__Basic_0]),
-	)
 	states[PrimaryExpression__Start].AppendTransitions(
 		parser.NewEpsilonTransition(states[PrimaryExpression__Basic_8]),
+	)
+	states[BinaryExpression__Start].AppendTransitions(
+		parser.NewEpsilonTransition(states[BinaryExpression__Basic_0]),
 	)
 	states[Module_module].AppendTransitions(
 		parser.NewAtomTransition(states[Module_Name_ID], Keyword_module, nil),
@@ -398,130 +315,10 @@ func BuildATN() *parser.RuntimeATN {
 		parser.NewEpsilonTransition(states[Evaluation__Stop]),
 	)
 	states[Expression__Basic_0].AppendTransitions(
-		parser.NewRuleTransition(states[Addition__Start], states[Expression__Basic_1], nil),
+		parser.NewRuleTransition(states[BinaryExpression__Start], states[Expression__Basic_1], nil),
 	)
 	states[Expression__Basic_1].AppendTransitions(
 		parser.NewEpsilonTransition(states[Expression__Stop]),
-	)
-	states[Addition__Basic_0].AppendTransitions(
-		parser.NewRuleTransition(states[Multiplication__Start], states[Addition__LoopEntry], nil),
-	)
-	states[Addition_Operator_Plus].AppendTransitions(
-		parser.NewAtomTransition(states[Addition__Basic_1], Keyword_Plus, nil),
-	)
-	states[Addition__Basic_1].AppendTransitions(
-		parser.NewEpsilonTransition(states[Addition__BlockEnd]),
-	)
-	states[Addition_Operator_Dash].AppendTransitions(
-		parser.NewAtomTransition(states[Addition__Basic_2], Keyword_Dash, nil),
-	)
-	states[Addition__Basic_2].AppendTransitions(
-		parser.NewEpsilonTransition(states[Addition__BlockEnd]),
-	)
-	states[Addition__Basic_3].AppendTransitions(
-		parser.NewEpsilonTransition(states[Addition_Operator_Plus]),
-		parser.NewEpsilonTransition(states[Addition_Operator_Dash]),
-	)
-	states[Addition__BlockEnd].AppendTransitions(
-		parser.NewEpsilonTransition(states[Addition__Basic_4]),
-	)
-	states[Addition__Basic_4].AppendTransitions(
-		parser.NewRuleTransition(states[Multiplication__Start], states[Addition__Basic_5], nil),
-	)
-	states[Addition__Basic_5].AppendTransitions(
-		parser.NewEpsilonTransition(states[Addition__LoopBack]),
-	)
-	states[Addition__LoopEntry].AppendTransitions(
-		parser.NewEpsilonTransition(states[Addition__Basic_3]),
-		parser.NewEpsilonTransition(states[Addition__LoopEnd]),
-	)
-	states[Addition__LoopEnd].AppendTransitions(
-		parser.NewEpsilonTransition(states[Addition__Stop]),
-	)
-	states[Addition__LoopBack].AppendTransitions(
-		parser.NewEpsilonTransition(states[Addition__LoopEntry]),
-	)
-	states[Multiplication__Basic_0].AppendTransitions(
-		parser.NewRuleTransition(states[Exponentiation__Start], states[Multiplication__LoopEntry], nil),
-	)
-	states[Multiplication_Operator_Asterisk].AppendTransitions(
-		parser.NewAtomTransition(states[Multiplication__Basic_1], Keyword_Asterisk, nil),
-	)
-	states[Multiplication__Basic_1].AppendTransitions(
-		parser.NewEpsilonTransition(states[Multiplication__BlockEnd]),
-	)
-	states[Multiplication_Operator_Slash].AppendTransitions(
-		parser.NewAtomTransition(states[Multiplication__Basic_2], Keyword_Slash, nil),
-	)
-	states[Multiplication__Basic_2].AppendTransitions(
-		parser.NewEpsilonTransition(states[Multiplication__BlockEnd]),
-	)
-	states[Multiplication__Basic_3].AppendTransitions(
-		parser.NewEpsilonTransition(states[Multiplication_Operator_Asterisk]),
-		parser.NewEpsilonTransition(states[Multiplication_Operator_Slash]),
-	)
-	states[Multiplication__BlockEnd].AppendTransitions(
-		parser.NewEpsilonTransition(states[Multiplication__Basic_4]),
-	)
-	states[Multiplication__Basic_4].AppendTransitions(
-		parser.NewRuleTransition(states[Exponentiation__Start], states[Multiplication__Basic_5], nil),
-	)
-	states[Multiplication__Basic_5].AppendTransitions(
-		parser.NewEpsilonTransition(states[Multiplication__LoopBack]),
-	)
-	states[Multiplication__LoopEntry].AppendTransitions(
-		parser.NewEpsilonTransition(states[Multiplication__Basic_3]),
-		parser.NewEpsilonTransition(states[Multiplication__LoopEnd]),
-	)
-	states[Multiplication__LoopEnd].AppendTransitions(
-		parser.NewEpsilonTransition(states[Multiplication__Stop]),
-	)
-	states[Multiplication__LoopBack].AppendTransitions(
-		parser.NewEpsilonTransition(states[Multiplication__LoopEntry]),
-	)
-	states[Exponentiation__Basic_0].AppendTransitions(
-		parser.NewRuleTransition(states[Modulo__Start], states[Exponentiation__LoopEntry], nil),
-	)
-	states[Exponentiation_Operator_Caret].AppendTransitions(
-		parser.NewAtomTransition(states[Exponentiation__Basic_1], Keyword_Caret, nil),
-	)
-	states[Exponentiation__Basic_1].AppendTransitions(
-		parser.NewRuleTransition(states[Modulo__Start], states[Exponentiation__Basic_2], nil),
-	)
-	states[Exponentiation__Basic_2].AppendTransitions(
-		parser.NewEpsilonTransition(states[Exponentiation__LoopBack]),
-	)
-	states[Exponentiation__LoopEntry].AppendTransitions(
-		parser.NewEpsilonTransition(states[Exponentiation_Operator_Caret]),
-		parser.NewEpsilonTransition(states[Exponentiation__LoopEnd]),
-	)
-	states[Exponentiation__LoopEnd].AppendTransitions(
-		parser.NewEpsilonTransition(states[Exponentiation__Stop]),
-	)
-	states[Exponentiation__LoopBack].AppendTransitions(
-		parser.NewEpsilonTransition(states[Exponentiation__LoopEntry]),
-	)
-	states[Modulo__Basic_0].AppendTransitions(
-		parser.NewRuleTransition(states[PrimaryExpression__Start], states[Modulo__LoopEntry], nil),
-	)
-	states[Modulo_Operator_Percent].AppendTransitions(
-		parser.NewAtomTransition(states[Modulo__Basic_1], Keyword_Percent, nil),
-	)
-	states[Modulo__Basic_1].AppendTransitions(
-		parser.NewRuleTransition(states[PrimaryExpression__Start], states[Modulo__Basic_2], nil),
-	)
-	states[Modulo__Basic_2].AppendTransitions(
-		parser.NewEpsilonTransition(states[Modulo__LoopBack]),
-	)
-	states[Modulo__LoopEntry].AppendTransitions(
-		parser.NewEpsilonTransition(states[Modulo_Operator_Percent]),
-		parser.NewEpsilonTransition(states[Modulo__LoopEnd]),
-	)
-	states[Modulo__LoopEnd].AppendTransitions(
-		parser.NewEpsilonTransition(states[Modulo__Stop]),
-	)
-	states[Modulo__LoopBack].AppendTransitions(
-		parser.NewEpsilonTransition(states[Modulo__LoopEntry]),
 	)
 	states[PrimaryExpression_LeftParen_0].AppendTransitions(
 		parser.NewAtomTransition(states[PrimaryExpression__Basic_0], Keyword_LeftParen, nil),
@@ -587,33 +384,45 @@ func BuildATN() *parser.RuntimeATN {
 	states[PrimaryExpression__BlockEnd].AppendTransitions(
 		parser.NewEpsilonTransition(states[PrimaryExpression__Stop]),
 	)
-	decisionStates := make([]*parser.RuntimeATNState, 13)
+	states[BinaryExpression__Basic_0].AppendTransitions(
+		parser.NewRuleTransition(states[PrimaryExpression__Start], states[BinaryExpression__LoopEntry], nil),
+	)
+	states[BinaryExpression_BinaryExpressionOperator].AppendTransitions(
+		parser.NewAtomTransition(states[BinaryExpression__Basic_1], Token_BinaryExpressionOperator, nil),
+	)
+	states[BinaryExpression__Basic_1].AppendTransitions(
+		parser.NewRuleTransition(states[PrimaryExpression__Start], states[BinaryExpression__Basic_2], nil),
+	)
+	states[BinaryExpression__Basic_2].AppendTransitions(
+		parser.NewEpsilonTransition(states[BinaryExpression__LoopBack]),
+	)
+	states[BinaryExpression__LoopEntry].AppendTransitions(
+		parser.NewEpsilonTransition(states[BinaryExpression_BinaryExpressionOperator]),
+		parser.NewEpsilonTransition(states[BinaryExpression__LoopEnd]),
+	)
+	states[BinaryExpression__LoopEnd].AppendTransitions(
+		parser.NewEpsilonTransition(states[BinaryExpression__Stop]),
+	)
+	states[BinaryExpression__LoopBack].AppendTransitions(
+		parser.NewEpsilonTransition(states[BinaryExpression__LoopEntry]),
+	)
+	decisionStates := make([]*parser.RuntimeATNState, 8)
 	decisionStates[0] = states[Module__LoopEntry]
 	decisionStates[1] = states[Statement__Basic_4]
 	decisionStates[2] = states[Definition__LoopEntry]
 	decisionStates[3] = states[Definition__Basic_4]
-	decisionStates[4] = states[Addition__Basic_3]
-	decisionStates[5] = states[Addition__LoopEntry]
-	decisionStates[6] = states[Multiplication__Basic_3]
-	decisionStates[7] = states[Multiplication__LoopEntry]
-	decisionStates[8] = states[Exponentiation__LoopEntry]
-	decisionStates[9] = states[Modulo__LoopEntry]
-	decisionStates[10] = states[PrimaryExpression__LoopEntry]
-	decisionStates[11] = states[PrimaryExpression__Basic_7]
-	decisionStates[12] = states[PrimaryExpression__Basic_8]
-	decisionMap := make([]*parser.RuntimeATNState, 13)
+	decisionStates[4] = states[PrimaryExpression__LoopEntry]
+	decisionStates[5] = states[PrimaryExpression__Basic_7]
+	decisionStates[6] = states[PrimaryExpression__Basic_8]
+	decisionStates[7] = states[BinaryExpression__LoopEntry]
+	decisionMap := make([]*parser.RuntimeATNState, 8)
 	decisionMap[0] = states[Module__LoopEntry]
 	decisionMap[1] = states[Statement__Basic_4]
 	decisionMap[2] = states[Definition__LoopEntry]
 	decisionMap[3] = states[Definition__Basic_4]
-	decisionMap[4] = states[Addition__Basic_3]
-	decisionMap[5] = states[Addition__LoopEntry]
-	decisionMap[6] = states[Multiplication__Basic_3]
-	decisionMap[7] = states[Multiplication__LoopEntry]
-	decisionMap[8] = states[Exponentiation__LoopEntry]
-	decisionMap[9] = states[Modulo__LoopEntry]
-	decisionMap[10] = states[PrimaryExpression__LoopEntry]
-	decisionMap[11] = states[PrimaryExpression__Basic_7]
-	decisionMap[12] = states[PrimaryExpression__Basic_8]
+	decisionMap[4] = states[PrimaryExpression__LoopEntry]
+	decisionMap[5] = states[PrimaryExpression__Basic_7]
+	decisionMap[6] = states[PrimaryExpression__Basic_8]
+	decisionMap[7] = states[BinaryExpression__LoopEntry]
 	return parser.NewRuntimeATN(states, decisionStates, decisionMap)
 }

--- a/examples/arithmetics/benchmark_test.go
+++ b/examples/arithmetics/benchmark_test.go
@@ -12,45 +12,96 @@ import (
 	"typefox.dev/fastbelt"
 	"typefox.dev/fastbelt/lexer"
 	"typefox.dev/fastbelt/parser"
+	"typefox.dev/fastbelt/test"
 	"typefox.dev/fastbelt/util/service"
 )
 
-// generateArithmeticsContent produces an expression-heavy module
-func generateArithmeticsContent(statements int) string {
-	var sb strings.Builder
-	sb.WriteString("module benchmark\n")
-	sb.WriteString("def base: 42;\n")
-	sb.WriteString("def calc(x, y): x * y + base % 2 - (x / y) ^ 2;\n")
-	for i := range statements {
-		fmt.Fprintf(&sb, "def val%d: %d + %d * 3 - base / (%d + 1);\n", i, i, i+1, i+2)
-		fmt.Fprintf(&sb, "calc(val%d, %d) + val%d * (base - %d);\n", i, i, i, i)
-	}
-	return sb.String()
+// TestBenchmarkContentParses guards the benchmarks: a syntax error in the
+// generated corpus would silently benchmark the error-recovery path instead.
+func TestBenchmarkContentParses(t *testing.T) {
+	f := test.New(t, CreateServices())
+	f.Parse(generateArithmeticsContent()).AssertNoParseErrors()
 }
 
-// BenchmarkParser benchmarks parsing a single expression-heavy arithmetics
-// document, reusing the pre-lexed token slice every iteration.
+// BenchmarkParser benchmarks parsing a single generated arithmetics document,
+// reusing the pre-lexed token slice every iteration.
 func BenchmarkParser(b *testing.B) {
-	content := generateArithmeticsContent(50)
+	content := generateArithmeticsContent()
 	srv := CreateServices()
 	lexerService := service.MustGet[lexer.Lexer](srv)
 	parserService := service.MustGet[parser.Parser](srv)
-	lexed := lexerService.Lex(content)
-	if len(lexed.Errors) > 0 {
-		b.Fatalf("lexer errors: %v", lexed.Errors)
-	}
-	doc, err := fastbelt.NewDocumentFromString("file:///workspace/benchmark.arithmetics", "arithmetics", content)
+	tokens := lexerService.Lex(content).Tokens
+	doc, err := fastbelt.NewDocumentFromString("file:///workspace/bench.calc", "arithmetics", content)
 	if err != nil {
 		b.Fatal(err)
 	}
-	doc.Tokens = lexed.Tokens
-	if result := parserService.Parse(doc); len(result.Errors) > 0 {
-		b.Fatalf("parser errors: %v", result.Errors)
-	}
+	doc.Tokens = tokens
 	b.SetBytes(int64(len(content)))
 	b.ResetTimer()
 	for b.Loop() {
 		result := parserService.Parse(doc)
 		doc.Root = result.Node
 	}
+}
+
+// BenchmarkLexerAndParser benchmarks a full lex + parse pass per iteration.
+func BenchmarkLexerAndParser(b *testing.B) {
+	content := generateArithmeticsContent()
+	srv := CreateServices()
+	lexerService := service.MustGet[lexer.Lexer](srv)
+	parserService := service.MustGet[parser.Parser](srv)
+	doc, err := fastbelt.NewDocumentFromString("file:///workspace/bench.calc", "arithmetics", content)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.SetBytes(int64(len(content)))
+	b.ResetTimer()
+	for b.Loop() {
+		doc.Tokens = lexerService.Lex(content).Tokens
+		result := parserService.Parse(doc)
+		doc.Root = result.Node
+	}
+}
+
+// generateArithmeticsContent generates a syntactically valid arithmetics
+// document dominated by binary expressions: 100 definitions and 100
+// evaluations, each holding a 40-operator expression mixing all six operators
+// with parenthesized sub-expressions and calls to earlier definitions.
+func generateArithmeticsContent() string {
+	const numDefs = 100
+	const opsPerExpr = 40
+	operators := []string{"+", "-", "*", "/", "^", "%"}
+
+	var sb strings.Builder
+	sb.WriteString("module bench\n\n")
+
+	writeExpr := func(defIdx int) {
+		for op := range opsPerExpr {
+			operand := fmt.Sprintf("%d", (defIdx+op)%97+1)
+			if op%7 == 3 && defIdx > 0 {
+				// Reference an earlier definition to include cross-references.
+				operand = fmt.Sprintf("d%d", defIdx%op)
+			}
+			if op%5 == 2 {
+				operand = "(" + operand + " " + operators[(defIdx+op)%len(operators)] + " 2)"
+			}
+			sb.WriteString(operand)
+			if op < opsPerExpr-1 {
+				sb.WriteString(" ")
+				sb.WriteString(operators[(defIdx*7+op)%len(operators)])
+				sb.WriteString(" ")
+			}
+		}
+	}
+
+	for d := range numDefs {
+		fmt.Fprintf(&sb, "def d%d: ", d)
+		writeExpr(d)
+		sb.WriteString(";\n")
+	}
+	for d := range numDefs {
+		writeExpr(d)
+		sb.WriteString(";\n")
+	}
+	return sb.String()
 }

--- a/examples/arithmetics/completion_gen.go
+++ b/examples/arithmetics/completion_gen.go
@@ -92,16 +92,8 @@ func (a *ArithmeticsCompletionAdapter) HasAssignment(node core.AstNode, property
 }
 
 func (a *ArithmeticsCompletionAdapter) ApplyAction(actionType, property string, value core.AstNode) core.AstNode {
-	switch actionType {
-	case "BinaryExpression":
-		node := NewBinaryExpression()
-		switch property {
-		case "Left":
-			if v, ok := value.(Expression); ok {
-				node.SetLeft(v)
-			}
-		}
-		return node
-	}
+	_ = actionType
+	_ = property
+	_ = value
 	return nil
 }

--- a/examples/arithmetics/completion_parser_gen.go
+++ b/examples/arithmetics/completion_parser_gen.go
@@ -175,130 +175,8 @@ func (p *CompletionParser) ParseExpression() {
 	defer p.cp.ExitRule()
 	{
 		p.state.EnterRule(Expression__Basic_1)
-		p.ParseAddition()
+		p.ParseBinaryExpression()
 		p.state.ExitRule()
-	}
-}
-
-func (p *CompletionParser) ParseAddition() {
-	p.cp.EnterRule("Addition", Addition__Start)
-	defer p.cp.ExitRule()
-	{
-		p.state.EnterRule(Addition__LoopEntry)
-		p.ParseMultiplication()
-		p.state.ExitRule()
-	}
-	p.cp.RecordSnapshot(Addition__LoopEntry)
-	p.state.Sync(Addition__LoopEntry)
-	for p.lookahead.AdditionLoop(p.state) {
-		{
-			p.cp.MarkAssignment("Operator")
-			switch prediction, _ := p.lookahead.AdditionOperatorAlternatives(p.state); prediction {
-			case 0:
-				p.state.Consume(Keyword_Plus)
-			case 1:
-				p.state.Consume(Keyword_Dash)
-			}
-			p.cp.ClearAssignment()
-		}
-		{
-			p.cp.MarkAssignment("Right")
-			p.state.EnterRule(Addition__Basic_5)
-			p.ParseMultiplication()
-			p.state.ExitRule()
-			p.cp.ClearAssignment()
-		}
-		p.cp.RecordSnapshot(Addition__LoopEntry)
-		p.state.Sync(Addition__LoopEntry)
-	}
-}
-
-func (p *CompletionParser) ParseMultiplication() {
-	p.cp.EnterRule("Multiplication", Multiplication__Start)
-	defer p.cp.ExitRule()
-	{
-		p.state.EnterRule(Multiplication__LoopEntry)
-		p.ParseExponentiation()
-		p.state.ExitRule()
-	}
-	p.cp.RecordSnapshot(Multiplication__LoopEntry)
-	p.state.Sync(Multiplication__LoopEntry)
-	for p.lookahead.MultiplicationLoop(p.state) {
-		{
-			p.cp.MarkAssignment("Operator")
-			switch prediction, _ := p.lookahead.MultiplicationOperatorAlternatives(p.state); prediction {
-			case 0:
-				p.state.Consume(Keyword_Asterisk)
-			case 1:
-				p.state.Consume(Keyword_Slash)
-			}
-			p.cp.ClearAssignment()
-		}
-		{
-			p.cp.MarkAssignment("Right")
-			p.state.EnterRule(Multiplication__Basic_5)
-			p.ParseExponentiation()
-			p.state.ExitRule()
-			p.cp.ClearAssignment()
-		}
-		p.cp.RecordSnapshot(Multiplication__LoopEntry)
-		p.state.Sync(Multiplication__LoopEntry)
-	}
-}
-
-func (p *CompletionParser) ParseExponentiation() {
-	p.cp.EnterRule("Exponentiation", Exponentiation__Start)
-	defer p.cp.ExitRule()
-	{
-		p.state.EnterRule(Exponentiation__LoopEntry)
-		p.ParseModulo()
-		p.state.ExitRule()
-	}
-	p.cp.RecordSnapshot(Exponentiation__LoopEntry)
-	p.state.Sync(Exponentiation__LoopEntry)
-	for p.lookahead.ExponentiationLoop(p.state) {
-		{
-			p.cp.MarkAssignment("Operator")
-			p.state.Consume(Keyword_Caret)
-			p.cp.ClearAssignment()
-		}
-		{
-			p.cp.MarkAssignment("Right")
-			p.state.EnterRule(Exponentiation__Basic_2)
-			p.ParseModulo()
-			p.state.ExitRule()
-			p.cp.ClearAssignment()
-		}
-		p.cp.RecordSnapshot(Exponentiation__LoopEntry)
-		p.state.Sync(Exponentiation__LoopEntry)
-	}
-}
-
-func (p *CompletionParser) ParseModulo() {
-	p.cp.EnterRule("Modulo", Modulo__Start)
-	defer p.cp.ExitRule()
-	{
-		p.state.EnterRule(Modulo__LoopEntry)
-		p.ParsePrimaryExpression()
-		p.state.ExitRule()
-	}
-	p.cp.RecordSnapshot(Modulo__LoopEntry)
-	p.state.Sync(Modulo__LoopEntry)
-	for p.lookahead.ModuloLoop(p.state) {
-		{
-			p.cp.MarkAssignment("Operator")
-			p.state.Consume(Keyword_Percent)
-			p.cp.ClearAssignment()
-		}
-		{
-			p.cp.MarkAssignment("Right")
-			p.state.EnterRule(Modulo__Basic_2)
-			p.ParsePrimaryExpression()
-			p.state.ExitRule()
-			p.cp.ClearAssignment()
-		}
-		p.cp.RecordSnapshot(Modulo__LoopEntry)
-		p.state.Sync(Modulo__LoopEntry)
 	}
 }
 
@@ -365,5 +243,29 @@ func (p *CompletionParser) ParsePrimaryExpression() {
 		}
 	default:
 		p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
+	}
+}
+
+func (p *CompletionParser) ParseBinaryExpression() {
+	p.cp.EnterRule("BinaryExpression", BinaryExpression__Start)
+	defer p.cp.ExitRule()
+	{
+		p.state.EnterRule(BinaryExpression__LoopEntry)
+		p.ParsePrimaryExpression()
+		p.state.ExitRule()
+	}
+	p.cp.RecordSnapshot(BinaryExpression__LoopEntry)
+	p.state.Sync(BinaryExpression__LoopEntry)
+	for p.lookahead.BinaryExpressionLoop(p.state) {
+		{
+			p.state.Consume(Token_BinaryExpressionOperator)
+		}
+		{
+			p.state.EnterRule(BinaryExpression__Basic_2)
+			p.ParsePrimaryExpression()
+			p.state.ExitRule()
+		}
+		p.cp.RecordSnapshot(BinaryExpression__LoopEntry)
+		p.state.Sync(BinaryExpression__LoopEntry)
 	}
 }

--- a/examples/arithmetics/infix_test.go
+++ b/examples/arithmetics/infix_test.go
@@ -57,7 +57,7 @@ func TestBinaryExpressionTokens(t *testing.T) {
 	}
 }
 
-// TestExponentiationRightAssociative verifies that the "right assoc" group of
+// TestExponentiationRightAssociative verifies that the "right" group of
 // the infix rule produces a right-leaning tree, while the left-associative
 // groups keep producing left-leaning trees.
 func TestExponentiationRightAssociative(t *testing.T) {

--- a/examples/arithmetics/infix_test.go
+++ b/examples/arithmetics/infix_test.go
@@ -1,0 +1,150 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+package arithmetics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	core "typefox.dev/fastbelt"
+	"typefox.dev/fastbelt/server"
+	"typefox.dev/fastbelt/test"
+	"typefox.dev/fastbelt/util/service"
+	"typefox.dev/lsp"
+)
+
+// TestSingleOperandPassThrough asserts that an expression without operators
+// is returned unchanged - no BinaryExpression wrapper is created.
+func TestSingleOperandPassThrough(t *testing.T) {
+	expr := parseExpression(t, "42")
+	_, isNumber := expr.(NumberLiteral)
+	assert.True(t, isNumber, "expected a NumberLiteral, got %T", expr)
+}
+
+// TestBinaryExpressionTokens verifies that after the infix tree rewrite every
+// BinaryExpression node owns exactly its operator token, with correct
+// Element, Kind, concrete token type, and a text range spanning its operands.
+func TestBinaryExpressionTokens(t *testing.T) {
+	expr := parseExpression(t, "1 + 2 * 3")
+
+	add, ok := expr.(BinaryExpression)
+	require.True(t, ok)
+	mul, ok := add.Right().(BinaryExpression)
+	require.True(t, ok)
+
+	cases := []struct {
+		node      BinaryExpression
+		image     string
+		tokenType *core.TokenType
+		text      string
+	}{
+		{add, "+", Keyword_Plus, "1 + 2 * 3"},
+		{mul, "*", Keyword_Asterisk, "2 * 3"},
+	}
+	for _, c := range cases {
+		tokens := c.node.Tokens()
+		require.Len(t, tokens, 1, "a binary node owns exactly its operator token")
+		token := tokens[0]
+		assert.Equal(t, c.image, token.Image)
+		assert.Same(t, c.node, token.Element, "operator token must be assigned to its binary node")
+		assert.Equal(t, BinaryExpression_BinaryExpressionOperator, token.Kind)
+		assert.Same(t, c.tokenType, token.Type, "the token keeps its concrete member type, not the group type")
+		assert.Equal(t, c.text, c.node.Text(), "node range spans left operand start to right operand end")
+	}
+}
+
+// TestExponentiationRightAssociative verifies that the "right assoc" group of
+// the infix rule produces a right-leaning tree, while the left-associative
+// groups keep producing left-leaning trees.
+func TestExponentiationRightAssociative(t *testing.T) {
+	expr := parseExpression(t, "2 ^ 3 ^ 2 ^ 1")
+	assert.Equal(t, "(2 ^ (3 ^ (2 ^ 1)))", printExpression(expr))
+
+	expr = parseExpression(t, "1 - 2 - 3")
+	assert.Equal(t, "((1 - 2) - 3)", printExpression(expr))
+
+	// Mixed with tighter ("%") and looser ("*") levels.
+	expr = parseExpression(t, "1 * 2 ^ 3 % 4 ^ 5")
+	assert.Equal(t, "(1 * (2 ^ ((3 % 4) ^ 5)))", printExpression(expr))
+}
+
+// TestDanglingOperator checks error tolerance: a trailing operator without a
+// right operand reports a parse error but still produces a binary node.
+func TestDanglingOperator(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse("module test 1 + ;")
+	assert.NotEmpty(t, doc.Document.ParserErrors, "dangling operator should produce a parse error")
+
+	module := test.MustFindNode[Module](doc)
+	expr := module.Statements()[0].(Evaluation).Expression()
+	add, ok := expr.(BinaryExpression)
+	require.True(t, ok, "expected a BinaryExpression, got %T", expr)
+	assert.Equal(t, "1", printExpression(add.Left()))
+	assert.Equal(t, "+", add.Operator())
+}
+
+type operatorCompletionContributor struct {
+	server.DefaultCompletionContributor
+}
+
+func (c *operatorCompletionContributor) CompletionForToken(_ context.Context, tt *core.TokenType, _ int, _ server.ContributorContext, accept server.CompletionAcceptor) {
+	if tt != nil {
+		// Show all keywords, including those in the BinaryExpressionOperator group,
+		// which the default contributor suppresses.
+		for _, keyword := range tt.MatchingTokens {
+			accept(lsp.CompletionItem{
+				Label: keyword.Name,
+			})
+		}
+	}
+}
+
+// TestOperatorCompletion verifies that after an operand the completion engine
+// offers every operator of the infix rule.
+func TestOperatorCompletion(t *testing.T) {
+	sc := service.NewContainer()
+	SetupServices(sc)
+	SetupGeneratedServerServices(sc)
+	server.SetupDefaultServices(sc)
+	var contributor server.CompletionContributor = &operatorCompletionContributor{}
+	service.Override(sc, contributor)
+	sc.Seal()
+	doc := test.New(t, sc).Parse("module test 1 <|cursor>")
+
+	items := doc.CompletionItems("cursor")
+	labels := make(map[string]bool, len(items))
+	for _, item := range items {
+		labels[item.Label] = true
+	}
+	for _, operator := range []string{"+", "-", "*", "/", "^", "%"} {
+		assert.True(t, labels[operator], "expected operator %q in completion items, got %v", operator, labels)
+	}
+}
+
+// TestAfterOperatorCompletion verifies that after an operator, the completion
+// engine will offer to complete an expression again.
+func TestAfterOperatorCompletion(t *testing.T) {
+	sc := service.NewContainer()
+	SetupServices(sc)
+	SetupGeneratedServerServices(sc)
+	server.SetupDefaultServices(sc)
+	var contributor server.CompletionContributor = &operatorCompletionContributor{}
+	service.Override(sc, contributor)
+	sc.Seal()
+	doc := test.New(t, sc).Parse(`
+	module test
+	def x: 1;
+	1 + 2 * <|cursor>
+	`)
+
+	items := doc.CompletionItems("cursor")
+	labels := make(map[string]bool, len(items))
+	for _, item := range items {
+		labels[item.Label] = true
+	}
+	assert.True(t, labels["x"], "expected reference to definition 'x' in completion items, got %v", labels)
+}

--- a/examples/arithmetics/lexer_gen.go
+++ b/examples/arithmetics/lexer_gen.go
@@ -712,12 +712,12 @@ var Token_SL_COMMENT_Accepting = [3]bool{
 	2: true,
 }
 
-const Token_Addition_Idx = 19
+const Token_AdditionOp_Idx = 19
 
-var Token_Addition = core.NewTokenGroup(
-	Token_Addition_Idx,
-	"Addition",
-	"Addition",
+var Token_AdditionOp = core.NewTokenGroup(
+	Token_AdditionOp_Idx,
+	"AdditionOp",
+	"AdditionOp",
 	[]*core.TokenType{
 		Keyword_Dash,
 		Keyword_Plus,
@@ -733,17 +733,17 @@ var Token_BinaryExpressionOperator = core.NewTokenGroup(
 	[]*core.TokenType{
 		Keyword_Caret,
 		Keyword_Percent,
-		Token_Addition,
-		Token_Multiplication,
+		Token_AdditionOp,
+		Token_MultiplicationOp,
 	},
 )
 
-const Token_Multiplication_Idx = 21
+const Token_MultiplicationOp_Idx = 21
 
-var Token_Multiplication = core.NewTokenGroup(
-	Token_Multiplication_Idx,
-	"Multiplication",
-	"Multiplication",
+var Token_MultiplicationOp = core.NewTokenGroup(
+	Token_MultiplicationOp_Idx,
+	"MultiplicationOp",
+	"MultiplicationOp",
 	[]*core.TokenType{
 		Keyword_Asterisk,
 		Keyword_Slash,

--- a/examples/arithmetics/lexer_gen.go
+++ b/examples/arithmetics/lexer_gen.go
@@ -712,6 +712,44 @@ var Token_SL_COMMENT_Accepting = [3]bool{
 	2: true,
 }
 
+const Token_Addition_Idx = 19
+
+var Token_Addition = core.NewTokenGroup(
+	Token_Addition_Idx,
+	"Addition",
+	"Addition",
+	[]*core.TokenType{
+		Keyword_Dash,
+		Keyword_Plus,
+	},
+)
+
+const Token_BinaryExpressionOperator_Idx = 20
+
+var Token_BinaryExpressionOperator = core.NewTokenGroup(
+	Token_BinaryExpressionOperator_Idx,
+	"BinaryExpressionOperator",
+	"BinaryExpressionOperator",
+	[]*core.TokenType{
+		Keyword_Caret,
+		Keyword_Percent,
+		Token_Addition,
+		Token_Multiplication,
+	},
+)
+
+const Token_Multiplication_Idx = 21
+
+var Token_Multiplication = core.NewTokenGroup(
+	Token_Multiplication_Idx,
+	"Multiplication",
+	"Multiplication",
+	[]*core.TokenType{
+		Keyword_Asterisk,
+		Keyword_Slash,
+	},
+)
+
 func NewLexer() lexer.Lexer {
 	return lexer.NewDefaultLexer(
 		Keyword_Percent,

--- a/examples/arithmetics/parser_gen.go
+++ b/examples/arithmetics/parser_gen.go
@@ -204,195 +204,15 @@ func (p *Parser) ParseEvaluation() Evaluation {
 }
 
 func (p *Parser) ParseExpression() Expression {
-	var current Expression
+	current := NewExpression()
+	current.SetTextRangeStart(p.state.LA(1).Range.Start)
 	{
 		{
 			p.state.EnterRule(Expression__Basic_1)
-			result := p.ParseAddition()
+			result := p.ParseBinaryExpression()
 			p.state.ExitRule()
+			core.MergeTokens(result, current.Tokens())
 			current = result
-		}
-	}
-	current.SetTextRangeEnd(p.state.LA(0).Range.End)
-	return current
-}
-
-func (p *Parser) ParseAddition() Expression {
-	var current Expression
-	{
-		{
-			p.state.EnterRule(Addition__LoopEntry)
-			result := p.ParseMultiplication()
-			p.state.ExitRule()
-			current = result
-		}
-		p.state.Sync(Addition__LoopEntry)
-		for p.lookahead.AdditionLoop(p.state) {
-			{
-				result := NewBinaryExpression()
-				result.SetTextRange(current.TextRange())
-				result.SetLeft(current)
-				current.SetTextRangeEnd(p.state.LA(0).Range.End)
-				current = result
-			}
-			current := current.(BinaryExpression)
-			{
-				switch prediction, _ := p.lookahead.AdditionOperatorAlternatives(p.state); prediction {
-				case 0:
-					token := p.state.Consume(Keyword_Plus)
-					core.AssignToken(current, token, Addition_Operator_Plus)
-					if token != nil {
-						current.SetOperator(token)
-					}
-				case 1:
-					token := p.state.Consume(Keyword_Dash)
-					core.AssignToken(current, token, Addition_Operator_Dash)
-					if token != nil {
-						current.SetOperator(token)
-					}
-				}
-			}
-			{
-				p.state.EnterRule(Addition__Basic_5)
-				result := p.ParseMultiplication()
-				p.state.ExitRule()
-				if result != nil {
-					current.SetRight(result)
-				}
-			}
-			p.state.Sync(Addition__LoopEntry)
-		}
-	}
-	current.SetTextRangeEnd(p.state.LA(0).Range.End)
-	return current
-}
-
-func (p *Parser) ParseMultiplication() Expression {
-	var current Expression
-	{
-		{
-			p.state.EnterRule(Multiplication__LoopEntry)
-			result := p.ParseExponentiation()
-			p.state.ExitRule()
-			current = result
-		}
-		p.state.Sync(Multiplication__LoopEntry)
-		for p.lookahead.MultiplicationLoop(p.state) {
-			{
-				result := NewBinaryExpression()
-				result.SetTextRange(current.TextRange())
-				result.SetLeft(current)
-				current.SetTextRangeEnd(p.state.LA(0).Range.End)
-				current = result
-			}
-			current := current.(BinaryExpression)
-			{
-				switch prediction, _ := p.lookahead.MultiplicationOperatorAlternatives(p.state); prediction {
-				case 0:
-					token := p.state.Consume(Keyword_Asterisk)
-					core.AssignToken(current, token, Multiplication_Operator_Asterisk)
-					if token != nil {
-						current.SetOperator(token)
-					}
-				case 1:
-					token := p.state.Consume(Keyword_Slash)
-					core.AssignToken(current, token, Multiplication_Operator_Slash)
-					if token != nil {
-						current.SetOperator(token)
-					}
-				}
-			}
-			{
-				p.state.EnterRule(Multiplication__Basic_5)
-				result := p.ParseExponentiation()
-				p.state.ExitRule()
-				if result != nil {
-					current.SetRight(result)
-				}
-			}
-			p.state.Sync(Multiplication__LoopEntry)
-		}
-	}
-	current.SetTextRangeEnd(p.state.LA(0).Range.End)
-	return current
-}
-
-func (p *Parser) ParseExponentiation() Expression {
-	var current Expression
-	{
-		{
-			p.state.EnterRule(Exponentiation__LoopEntry)
-			result := p.ParseModulo()
-			p.state.ExitRule()
-			current = result
-		}
-		p.state.Sync(Exponentiation__LoopEntry)
-		for p.lookahead.ExponentiationLoop(p.state) {
-			{
-				result := NewBinaryExpression()
-				result.SetTextRange(current.TextRange())
-				result.SetLeft(current)
-				current.SetTextRangeEnd(p.state.LA(0).Range.End)
-				current = result
-			}
-			current := current.(BinaryExpression)
-			{
-				token := p.state.Consume(Keyword_Caret)
-				core.AssignToken(current, token, Exponentiation_Operator_Caret)
-				if token != nil {
-					current.SetOperator(token)
-				}
-			}
-			{
-				p.state.EnterRule(Exponentiation__Basic_2)
-				result := p.ParseModulo()
-				p.state.ExitRule()
-				if result != nil {
-					current.SetRight(result)
-				}
-			}
-			p.state.Sync(Exponentiation__LoopEntry)
-		}
-	}
-	current.SetTextRangeEnd(p.state.LA(0).Range.End)
-	return current
-}
-
-func (p *Parser) ParseModulo() Expression {
-	var current Expression
-	{
-		{
-			p.state.EnterRule(Modulo__LoopEntry)
-			result := p.ParsePrimaryExpression()
-			p.state.ExitRule()
-			current = result
-		}
-		p.state.Sync(Modulo__LoopEntry)
-		for p.lookahead.ModuloLoop(p.state) {
-			{
-				result := NewBinaryExpression()
-				result.SetTextRange(current.TextRange())
-				result.SetLeft(current)
-				current.SetTextRangeEnd(p.state.LA(0).Range.End)
-				current = result
-			}
-			current := current.(BinaryExpression)
-			{
-				token := p.state.Consume(Keyword_Percent)
-				core.AssignToken(current, token, Modulo_Operator_Percent)
-				if token != nil {
-					current.SetOperator(token)
-				}
-			}
-			{
-				p.state.EnterRule(Modulo__Basic_2)
-				result := p.ParsePrimaryExpression()
-				p.state.ExitRule()
-				if result != nil {
-					current.SetRight(result)
-				}
-			}
-			p.state.Sync(Modulo__LoopEntry)
 		}
 	}
 	current.SetTextRangeEnd(p.state.LA(0).Range.End)
@@ -495,4 +315,58 @@ func (p *Parser) ParsePrimaryExpression() Expression {
 	}
 	current.SetTextRangeEnd(p.state.LA(0).Range.End)
 	return current
+}
+
+var BinaryExpressionPrecedence = map[int]parser.InfixPrecedence{
+	Keyword_Percent_Idx:  {Level: 0},
+	Keyword_Caret_Idx:    {Level: 1, Right: true},
+	Keyword_Asterisk_Idx: {Level: 2},
+	Keyword_Slash_Idx:    {Level: 2},
+	Keyword_Dash_Idx:     {Level: 3},
+	Keyword_Plus_Idx:     {Level: 3},
+}
+
+func (p *Parser) ParseBinaryExpression() Expression {
+	var parts []Expression
+	var operators []*core.Token
+	{
+		p.state.EnterRule(BinaryExpression__LoopEntry)
+		result := p.ParsePrimaryExpression()
+		p.state.ExitRule()
+		parts = append(parts, result)
+	}
+	p.state.Sync(BinaryExpression__LoopEntry)
+	for p.lookahead.BinaryExpressionLoop(p.state) {
+		if token := p.state.Consume(Token_BinaryExpressionOperator); token != nil {
+			operators = append(operators, token)
+		}
+		{
+			p.state.EnterRule(BinaryExpression__Basic_2)
+			result := p.ParsePrimaryExpression()
+			p.state.ExitRule()
+			parts = append(parts, result)
+		}
+		p.state.Sync(BinaryExpression__LoopEntry)
+	}
+	if len(parts) == 1 {
+		// A lone operand is returned unchanged; no binary node is created.
+		return parts[0]
+	}
+	return parser.BuildInfixTree(parts, operators, BinaryExpressionPrecedence, func(left Expression, operator *core.Token, right Expression) Expression {
+		result := NewBinaryExpression()
+		if left != nil {
+			result.SetLeft(left)
+			result.SetTextRangeStart(left.TextRange().Start)
+		}
+		if operator != nil {
+			core.AssignToken(result, operator, BinaryExpression_BinaryExpressionOperator)
+			result.SetOperator(operator)
+			result.SetTextRangeEnd(operator.Range.End)
+		}
+		if right != nil {
+			result.SetRight(right)
+			result.SetTextRangeEnd(right.TextRange().End)
+		}
+		return result
+	})
 }

--- a/examples/arithmetics/parser_lookahead_gen.go
+++ b/examples/arithmetics/parser_lookahead_gen.go
@@ -7,29 +7,9 @@ import (
 	"typefox.dev/fastbelt/parser"
 )
 
-var AdditionLoop = parser.LL1Lookahead{
-	Types:  []*core.TokenType{Keyword_Plus, Keyword_Dash},
-	Lookup: []int{5: 1, 7: 1},
-}
-
-var AdditionOperatorAlternatives = parser.LL1Lookahead{
-	Types:  []*core.TokenType{Keyword_Plus, Keyword_Dash},
-	Lookup: []int{5: 1, 7: 2},
-}
-
 var ModuleStatementsLoop = parser.LL1Lookahead{
 	Types:  []*core.TokenType{Keyword_LeftParen, Keyword_def, Token_ID, Token_NUMBER},
 	Lookup: []int{2: 1, 12: 1, 14: 1, 15: 1},
-}
-
-var MultiplicationLoop = parser.LL1Lookahead{
-	Types:  []*core.TokenType{Keyword_Asterisk, Keyword_Slash},
-	Lookup: []int{4: 1, 8: 1},
-}
-
-var MultiplicationOperatorAlternatives = parser.LL1Lookahead{
-	Types:  []*core.TokenType{Keyword_Asterisk, Keyword_Slash},
-	Lookup: []int{4: 1, 8: 2},
 }
 
 var PrimaryExpressionAlternatives = parser.LL1Lookahead{
@@ -49,15 +29,10 @@ var StatementAlternatives = parser.LL1Lookahead{
 type ArithmeticsParserLookahead interface {
 	parser.ParserLookahead
 
-	AdditionLoop(state *parser.ParserState) bool
-	AdditionOperatorAlternatives(state *parser.ParserState) (int, *parser.PredictionFailure)
+	BinaryExpressionLoop(state *parser.ParserState) bool
 	DefinitionLoop(state *parser.ParserState) bool
 	DefinitionOptional(state *parser.ParserState) bool
-	ExponentiationLoop(state *parser.ParserState) bool
 	ModuleStatementsLoop(state *parser.ParserState) bool
-	ModuloLoop(state *parser.ParserState) bool
-	MultiplicationLoop(state *parser.ParserState) bool
-	MultiplicationOperatorAlternatives(state *parser.ParserState) (int, *parser.PredictionFailure)
 	PrimaryExpressionAlternatives(state *parser.ParserState) (int, *parser.PredictionFailure)
 	PrimaryExpressionLoop(state *parser.ParserState) bool
 	PrimaryExpressionOptional(state *parser.ParserState) bool
@@ -74,13 +49,8 @@ func NewDefaultArithmeticsParserLookahead() ArithmeticsParserLookahead {
 	return &DefaultArithmeticsParserLookahead{}
 }
 
-func (l *DefaultArithmeticsParserLookahead) AdditionLoop(state *parser.ParserState) bool {
-	prediction, _ := state.Lookahead(AdditionLoop)
-	return prediction == 0
-}
-
-func (l *DefaultArithmeticsParserLookahead) AdditionOperatorAlternatives(state *parser.ParserState) (int, *parser.PredictionFailure) {
-	return state.Lookahead(AdditionOperatorAlternatives)
+func (l *DefaultArithmeticsParserLookahead) BinaryExpressionLoop(state *parser.ParserState) bool {
+	return Token_BinaryExpressionOperator.Matches(state.LA(1).Type)
 }
 
 func (l *DefaultArithmeticsParserLookahead) DefinitionLoop(state *parser.ParserState) bool {
@@ -91,26 +61,9 @@ func (l *DefaultArithmeticsParserLookahead) DefinitionOptional(state *parser.Par
 	return state.LA(1).Type == Keyword_LeftParen
 }
 
-func (l *DefaultArithmeticsParserLookahead) ExponentiationLoop(state *parser.ParserState) bool {
-	return state.LA(1).Type == Keyword_Caret
-}
-
 func (l *DefaultArithmeticsParserLookahead) ModuleStatementsLoop(state *parser.ParserState) bool {
 	prediction, _ := state.Lookahead(ModuleStatementsLoop)
 	return prediction == 0
-}
-
-func (l *DefaultArithmeticsParserLookahead) ModuloLoop(state *parser.ParserState) bool {
-	return state.LA(1).Type == Keyword_Percent
-}
-
-func (l *DefaultArithmeticsParserLookahead) MultiplicationLoop(state *parser.ParserState) bool {
-	prediction, _ := state.Lookahead(MultiplicationLoop)
-	return prediction == 0
-}
-
-func (l *DefaultArithmeticsParserLookahead) MultiplicationOperatorAlternatives(state *parser.ParserState) (int, *parser.PredictionFailure) {
-	return state.Lookahead(MultiplicationOperatorAlternatives)
 }
 
 func (l *DefaultArithmeticsParserLookahead) PrimaryExpressionAlternatives(state *parser.ParserState) (int, *parser.PredictionFailure) {

--- a/grammar/doc.go
+++ b/grammar/doc.go
@@ -375,7 +375,7 @@
 //
 //	infix BinaryExpression on PrimaryExpression:
 //	    "%"
-//	    > right assoc "^"
+//	    > right "^"
 //	    > "*" | "/"
 //	    > "+" | "-"
 //
@@ -386,12 +386,12 @@
 // ">" and ordered tightest-binding first: in the example, "%" binds tightest
 // and "+" | "-" bind loosest, so "1 + 2 * 3" parses as "1 + (2 * 3)".
 //
-// Groups are left-associative by default; prefix a group with "right assoc"
-// (or explicitly "left assoc") to control associativity:
+// Groups are left-associative by default; prefix a group with "right"
+// (or explicitly "left") to control associativity:
 //
 //	infix BinaryExpression on PrimaryExpression:
 //	    "+" | "-"
-//	    > right assoc "^"
+//	    > right "^"
 //
 // Operators can be keywords, token references, or token group references:
 //

--- a/grammar/doc.go
+++ b/grammar/doc.go
@@ -362,7 +362,8 @@
 //
 // An infix rule parses binary expressions with operator precedence and
 // associativity in a single flat pass, replacing a cascade of tree-rewriting
-// action rules (one per precedence level) with one rule:
+// action rules (one per precedence level) with one rule, which speeds up parsing
+// and simplifies the grammar:
 //
 //	interface Expression {}
 //	interface BinaryExpression extends Expression {
@@ -386,8 +387,10 @@
 // ">" and ordered tightest-binding first: in the example, "%" binds tightest
 // and "+" | "-" bind loosest, so "1 + 2 * 3" parses as "1 + (2 * 3)".
 //
-// Groups are left-associative by default; prefix a group with "right"
-// (or explicitly "left") to control associativity:
+// Groups are left-associative by default. Meaning that an expression like
+// "1 + 2 + 3" gets parsed as "(1 + 2) + 3" by default. Prefix a group with "right"
+// (or explicitly "left") to control associativity. In this following example
+// the "^" operator is right-associative, so "1 ^ 2 ^ 3" parses as "1 ^ (2 ^ 3)":
 //
 //	infix BinaryExpression on PrimaryExpression:
 //	    "+" | "-"

--- a/grammar/doc.go
+++ b/grammar/doc.go
@@ -358,6 +358,60 @@
 // becomes the current object. The operator += is also valid for tree-rewriting
 // actions on slice properties.
 //
+// # Infix Rules
+//
+// An infix rule parses binary expressions with operator precedence and
+// associativity in a single flat pass, replacing a cascade of tree-rewriting
+// action rules (one per precedence level) with one rule:
+//
+//	interface Expression {}
+//	interface BinaryExpression extends Expression {
+//	    Left Expression
+//	    Operator string
+//	    Right Expression
+//	}
+//
+//	Expression: BinaryExpression
+//
+//	infix BinaryExpression on PrimaryExpression:
+//	    "%"
+//	    > "^"
+//	    > "*" | "/"
+//	    > "+" | "-"
+//
+// The rule name must resolve to an interface declaring the fields Left,
+// Right (of an interface type both the rule's return type and node type are
+// assignable to), and Operator (of type string). The rule after "on" is the
+// operand rule, parsed between operators. Precedence groups are separated by
+// ">" and ordered tightest-binding first: in the example, "%" binds tightest
+// and "+" | "-" bind loosest, so "1 + 2 * 3" parses as "1 + (2 * 3)".
+//
+// Groups are left-associative by default; prefix a group with "right assoc"
+// (or explicitly "left assoc") to control associativity:
+//
+//	infix BinaryExpression on PrimaryExpression:
+//	    "+" | "-"
+//	    > right assoc "="
+//
+// Operators can be keywords, token references, or token group references:
+//
+//	token group MulOp { "*" "/" }
+//	infix BinaryExpression on PrimaryExpression:
+//	    MulOp
+//	    > "+" | "-"
+//
+// The return type of an infix rule defaults to the operand rule's return
+// type; "returns" overrides it. A lone operand is returned unchanged — no
+// binary node is wrapped around it.
+//
+// For parsing, all operators of an infix rule are unified into a generated
+// token group named "<RuleName>Operator" (that rule name must be unused),
+// so the parser consumes any operator with a single token-set check per
+// operator — considerably faster than the nested action-rule encoding.
+// Note that a token-referenced operator is matched by the lexer with the
+// usual longest-match rules: if its pattern also matches a keyword used
+// elsewhere in the grammar, the keyword wins at equal length.
+//
 // # Composite Rules
 //
 // A composite rule matches a structured token value such as a qualified name

--- a/grammar/doc.go
+++ b/grammar/doc.go
@@ -368,23 +368,24 @@
 //	          | Expression "*" Expression
 //	          | PrimaryExpression
 //
-// In this example, the "*" operator binds tighter than "+", so "a + b * c" parses
-// as "a + (b * c)". This however, only works in parser generators that support left
-// recursion. Since Fastbelt does not support left recursion, the grammar would have
+// In this example, the "*" operator is supposed to bind tighter than "+", so "a + b * c"
+// parses as "a + (b * c)". This however, only works in parser generators that support
+// left recursion. Since Fastbelt does not support left recursion, the grammar would have
 // to be rewritten to avoid it:
 //
 //	Expression: Addition
 //	Addition: Multiplication ("+" Multiplication)*
 //	Multiplication: PrimaryExpression ("*" PrimaryExpression)*
+//	PrimaryExpression: INT | "(" Expression ")"
 //
 // This approach works, but it is verbose and requires a separate rule for each precedence
 // level. Fastbelt offers a more concise and efficient solution via infix rules:
 //
 //	interface Expression {}
 //	interface BinaryExpression extends Expression {
-//	    Left Expression
-//	    Operator string
-//	    Right Expression
+//		Left Expression
+//		Operator string
+//		Right Expression
 //	}
 //
 //	Expression: BinaryExpression
@@ -396,10 +397,10 @@
 //	    > "+" | "-"
 //
 // The rule name must resolve to an interface declaring the fields Left,
-// Right (of an interface type both the rule's return type and node type are
-// assignable to), and Operator (of type string). The rule after "on" is the
-// operand rule, parsed between operators. Precedence groups are separated by
-// ">" and ordered tightest-binding first: in the example, "%" binds tightest
+// Right (of an interface type both the rule's return type and operand rule's
+// type are assignable to), and Operator (of type string). The rule after "on"
+// is the operand rule, parsed between operators. Precedence groups are separated
+// by ">" and ordered tightest-binding first: in the example, "%" binds tightest
 // and "+" | "-" bind loosest, so "1 + 2 * 3" parses as "1 + (2 * 3)".
 //
 // Groups are left-associative by default. Meaning that an expression like
@@ -415,8 +416,8 @@
 //	    > "+" | "-"
 //
 // The return type of an infix rule defaults to the operand rule's return
-// type; "returns" overrides it. A lone operand is returned unchanged - no
-// binary node is wrapped around it.
+// type; an additional "returns" clause overrides it. A lone operand is returned
+// unchanged - no binary node is wrapped around it.
 //
 // For parsing, all operators of an infix rule are unified into a generated
 // token group named "<RuleName>Operator" for performance reasons.

--- a/grammar/doc.go
+++ b/grammar/doc.go
@@ -350,20 +350,35 @@
 // structures that would require left recursion if written directly. The
 // current object is referred to by the keyword current:
 //
-//	Addition returns Expression:
-//	    SimpleExpr ({Addition.Left=current} "+" Right=SimpleExpr)*
+//	Member returns Expression:
+//	    Expression ({Member.Previous=current} "." Value=[Var:ID])*
 //
-// When the "+" keyword is found, a new Addition object is created, the
-// object parsed so far is stored in its Left property, and that new Addition
+// When the "." keyword is found, a new "Member" object is created, the
+// object parsed so far is stored in its "Previous" property, and that new "Member"
 // becomes the current object. The operator += is also valid for tree-rewriting
 // actions on slice properties.
 //
 // # Infix Rules
 //
-// An infix rule parses binary expressions with operator precedence and
-// associativity in a single flat pass, replacing a cascade of tree-rewriting
-// action rules (one per precedence level) with one rule, which speeds up parsing
-// and simplifies the grammar:
+// Parsing infix expressions (i.e. "a + b * c") is a common problem in language
+// design. Some parser generators solve this by writing a list of alternatives for
+// each precedence level, like this:
+//
+//	Expression: Expression "+" Expression
+//	          | Expression "*" Expression
+//	          | PrimaryExpression
+//
+// In this example, the "*" operator binds tighter than "+", so "a + b * c" parses
+// as "a + (b * c)". This however, only works in parser generators that support left
+// recursion. Since Fastbelt does not support left recursion, the grammar would have
+// to be rewritten to avoid it:
+//
+//	Expression: Addition
+//	Addition: Multiplication ("+" Multiplication)*
+//	Multiplication: PrimaryExpression ("*" PrimaryExpression)*
+//
+// This approach works, but it is verbose and requires a separate rule for each precedence
+// level. Fastbelt offers a more concise and efficient solution via infix rules:
 //
 //	interface Expression {}
 //	interface BinaryExpression extends Expression {
@@ -389,12 +404,8 @@
 //
 // Groups are left-associative by default. Meaning that an expression like
 // "1 + 2 + 3" gets parsed as "(1 + 2) + 3" by default. Prefix a group with "right"
-// (or explicitly "left") to control associativity. In this following example
-// the "^" operator is right-associative, so "1 ^ 2 ^ 3" parses as "1 ^ (2 ^ 3)":
-//
-//	infix BinaryExpression on PrimaryExpression:
-//	    "+" | "-"
-//	    > right "^"
+// (or explicitly "left") to control associativity. In the example above
+// the "^" operator is right-associative, so "1 ^ 2 ^ 3" parses as "1 ^ (2 ^ 3)".
 //
 // Operators can be keywords, token references, or token group references:
 //
@@ -404,7 +415,7 @@
 //	    > "+" | "-"
 //
 // The return type of an infix rule defaults to the operand rule's return
-// type; "returns" overrides it. A lone operand is returned unchanged — no
+// type; "returns" overrides it. A lone operand is returned unchanged - no
 // binary node is wrapped around it.
 //
 // For parsing, all operators of an infix rule are unified into a generated

--- a/grammar/doc.go
+++ b/grammar/doc.go
@@ -375,7 +375,7 @@
 //
 //	infix BinaryExpression on PrimaryExpression:
 //	    "%"
-//	    > "^"
+//	    > right assoc "^"
 //	    > "*" | "/"
 //	    > "+" | "-"
 //
@@ -391,7 +391,7 @@
 //
 //	infix BinaryExpression on PrimaryExpression:
 //	    "+" | "-"
-//	    > right assoc "="
+//	    > right assoc "^"
 //
 // Operators can be keywords, token references, or token group references:
 //
@@ -405,12 +405,7 @@
 // binary node is wrapped around it.
 //
 // For parsing, all operators of an infix rule are unified into a generated
-// token group named "<RuleName>Operator" (that rule name must be unused),
-// so the parser consumes any operator with a single token-set check per
-// operator — considerably faster than the nested action-rule encoding.
-// Note that a token-referenced operator is matched by the lexer with the
-// usual longest-match rules: if its pattern also matches a keyword used
-// elsewhere in the grammar, the keyword wins at equal length.
+// token group named "<RuleName>Operator" for performance reasons.
 //
 // # Composite Rules
 //

--- a/infix.go
+++ b/infix.go
@@ -1,0 +1,65 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+package fastbelt
+
+import "math"
+
+// InfixPrecedence describes one operator token type of an infix rule.
+type InfixPrecedence struct {
+	// Level is the precedence group index of the operator.
+	// Groups are declared tightest-binding first, so a larger level binds looser.
+	Level int
+	// Right reports whether the operator's precedence group is right-associative.
+	Right bool
+}
+
+// BuildInfixTree folds the flat parts/operators lists collected by a generated
+// infix rule parser into a binary expression tree.
+//
+// The tree is built by recursively splitting at the loosest-binding operator
+// (the one with the largest level). Between operators of the same level, the
+// rightmost one becomes the split point for left-associative groups (yielding
+// a left-leaning tree) and the leftmost one for right-associative groups.
+//
+// precedence is keyed by the leaf token type id ([Token.TypeId]); an operator
+// token missing from the map is treated as binding loosest. build constructs a
+// single node; right is the zero value of T when a trailing operator has no
+// operand (parse error tolerance). A single part is returned unchanged.
+func BuildInfixTree[T AstNode](parts []T, operators []*Token,
+	precedence map[int]InfixPrecedence,
+	build func(left T, operator *Token, right T) T) T {
+	var zero T
+	if len(parts) == 0 {
+		return zero
+	}
+	// rec builds the tree for operators[lo:hi] and their surrounding parts.
+	var rec func(lo, hi int) T
+	rec = func(lo, hi int) T {
+		if lo == hi {
+			if lo < len(parts) {
+				return parts[lo]
+			}
+			return zero
+		}
+		pivot := lo
+		bestLevel := -1
+		for i := lo; i < hi; i++ {
+			level, right := math.MaxInt, false
+			if p, ok := precedence[operators[i].TypeId]; ok {
+				level, right = p.Level, p.Right
+			}
+			if level > bestLevel {
+				bestLevel = level
+				pivot = i
+			} else if level == bestLevel && !right {
+				// Left-associative: the rightmost operator of the loosest
+				// level becomes the root. Right-associative: keep the leftmost.
+				pivot = i
+			}
+		}
+		return build(rec(lo, pivot), operators[pivot], rec(pivot+1, hi))
+	}
+	return rec(0, len(operators))
+}

--- a/infix_test.go
+++ b/infix_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+package fastbelt
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type infixTestNode struct {
+	AstNodeBase
+	name        string
+	left, right *infixTestNode
+	op          string
+}
+
+func (n *infixTestNode) String() string {
+	if n == nil {
+		return "<nil>"
+	}
+	if n.op == "" {
+		return n.name
+	}
+	return "(" + n.left.String() + " " + n.op + " " + n.right.String() + ")"
+}
+
+// parseInfixInput splits "1 + 2 * 3" into leaf nodes and operator tokens,
+// assigning each distinct operator symbol a stable token type id.
+func parseInfixInput(input string, typeIds map[string]int) (parts []*infixTestNode, operators []*Token) {
+	for i, field := range strings.Fields(input) {
+		if i%2 == 0 {
+			parts = append(parts, &infixTestNode{name: field})
+		} else {
+			operators = append(operators, &Token{Image: field, TypeId: typeIds[field]})
+		}
+	}
+	return parts, operators
+}
+
+func buildInfixTestNode(left *infixTestNode, operator *Token, right *infixTestNode) *infixTestNode {
+	op := "?"
+	if operator != nil {
+		op = operator.Image
+	}
+	return &infixTestNode{left: left, right: right, op: op}
+}
+
+func TestBuildInfixTree(t *testing.T) {
+	typeIds := map[string]int{"%": 1, "^": 2, "*": 3, "/": 4, "+": 5, "-": 6, "=": 7}
+	// Mirrors the arithmetics grammar: "%" > "^" > "*" | "/" > "+" | "-",
+	// plus a loosest right-associative "=" level.
+	precedence := map[int]InfixPrecedence{
+		typeIds["%"]: {Level: 0},
+		typeIds["^"]: {Level: 1},
+		typeIds["*"]: {Level: 2},
+		typeIds["/"]: {Level: 2},
+		typeIds["+"]: {Level: 3},
+		typeIds["-"]: {Level: 3},
+		typeIds["="]: {Level: 4, Right: true},
+	}
+
+	cases := map[string]string{
+		"1":                 "1",
+		"1 + 2":             "(1 + 2)",
+		"1 + 2 * 3":         "(1 + (2 * 3))",
+		"1 * 2 + 3":         "((1 * 2) + 3)",
+		"1 + 2 + 3":         "((1 + 2) + 3)",
+		"1 - 2 - 3":         "((1 - 2) - 3)",
+		"1 + 2 * 3 / 4":     "(1 + ((2 * 3) / 4))",
+		"1 + 2 ^ 3 * 4 % 5": "(1 + ((2 ^ 3) * (4 % 5)))",
+		"a = b = c":         "(a = (b = c))",
+		"a = b + c = d":     "(a = ((b + c) = d))",
+	}
+	for input, expected := range cases {
+		parts, operators := parseInfixInput(input, typeIds)
+		tree := BuildInfixTree(parts, operators, precedence, buildInfixTestNode)
+		assert.Equal(t, expected, tree.String(), "input %q", input)
+	}
+}
+
+func TestBuildInfixTreeSinglePartIsReturnedUnchanged(t *testing.T) {
+	part := &infixTestNode{name: "1"}
+	tree := BuildInfixTree([]*infixTestNode{part}, nil, nil, buildInfixTestNode)
+	assert.Same(t, part, tree)
+}
+
+func TestBuildInfixTreeEmptyParts(t *testing.T) {
+	tree := BuildInfixTree(nil, nil, nil, buildInfixTestNode)
+	assert.Nil(t, tree)
+}
+
+func TestBuildInfixTreeDanglingOperator(t *testing.T) {
+	precedence := map[int]InfixPrecedence{1: {Level: 0}, 2: {Level: 0}}
+
+	// "1 + 2 -" — the trailing operator has no right operand.
+	parts := []*infixTestNode{{name: "1"}, {name: "2"}}
+	operators := []*Token{
+		{Image: "+", TypeId: 1},
+		{Image: "-", TypeId: 2},
+	}
+	tree := BuildInfixTree(parts, operators, precedence, buildInfixTestNode)
+	assert.Equal(t, "((1 + 2) - <nil>)", tree.String())
+}
+
+func TestBuildInfixTreeUnknownOperatorBindsLoosest(t *testing.T) {
+	precedence := map[int]InfixPrecedence{1: {Level: 0}}
+	parts := []*infixTestNode{{name: "1"}, {name: "2"}, {name: "3"}}
+	operators := []*Token{
+		{Image: "?", TypeId: 99},
+		{Image: "*", TypeId: 1},
+	}
+	tree := BuildInfixTree(parts, operators, precedence, buildInfixTestNode)
+	assert.Equal(t, "(1 ? (2 * 3))", tree.String())
+}

--- a/internal/atn/atn.go
+++ b/internal/atn/atn.go
@@ -110,6 +110,9 @@ func CreateATN(grammr grammar.Grammar, tokenTypeIds map[string]int) (*ATN, map[s
 	for _, gr := range grammr.Rules() {
 		byName[gr.Name()] = gr
 	}
+	for _, gr := range grammr.InfixRules() {
+		byName[gr.Name()] = gr
+	}
 	builder := NewATNBuilder(lookaheadNames, tokenTypeIds, byName)
 
 	entries := map[grammar.AbstractRuleWithBody]ATNRuleBuilder{}
@@ -118,6 +121,9 @@ func CreateATN(grammr grammar.Grammar, tokenTypeIds map[string]int) (*ATN, map[s
 		allRules = append(allRules, gr)
 	}
 	for _, gr := range grammr.Composites() {
+		allRules = append(allRules, gr)
+	}
+	for _, gr := range grammr.InfixRules() {
 		allRules = append(allRules, gr)
 	}
 	for _, gr := range allRules {
@@ -159,6 +165,9 @@ func ComputeLookaheadNames(grammr grammar.Grammar) map[grammar.Element]string {
 	for node := range fastbelt.AllNodes(grammr) {
 		switch e := node.(type) {
 		case grammar.ParserRule:
+			counters = make(map[reflect.Type]int)
+			ruleName = e.Name()
+		case grammar.InfixRule:
 			counters = make(map[reflect.Type]int)
 			ruleName = e.Name()
 		case grammar.Keyword, grammar.RuleCall, grammar.CrossRef, grammar.Alternatives, grammar.Group:

--- a/internal/atn/state_names.go
+++ b/internal/atn/state_names.go
@@ -27,6 +27,9 @@ func BuildElementNames(grammr grammar.Grammar) map[grammar.Element]string {
 	for _, composite := range grammr.Composites() {
 		collectElementNames(result, composite.Name(), composite.Body())
 	}
+	for _, infix := range grammr.InfixRules() {
+		collectElementNames(result, infix.Name(), infix.Body())
+	}
 	return result
 }
 
@@ -53,7 +56,8 @@ func collectElementNames(names map[grammar.Element]string, prefix string, node f
 		collectElementNames(names, prefix, n.Rule())
 	case grammar.RuleCall:
 		ruleRef := n.Rule().Ref(context.Background())
-		if token, ok := ruleRef.(grammar.Token); ok {
+		if token, ok := ruleRef.(grammar.AbstractTokenRule); ok {
+			// Covers plain token rules and token groups alike.
 			names[n] = prefix + "_" + token.Name()
 		}
 	}

--- a/internal/generator/atn_generator.go
+++ b/internal/generator/atn_generator.go
@@ -10,6 +10,7 @@ import (
 )
 
 func GenerateATN(grammr grammar.Grammar, packageName string, tokenTypes GenerateTokenTypesResult) string {
+	mustExpandInfixRules(grammr)
 	a, _ := atn.CreateATN(grammr, tokenTypes.TokenTypeIds)
 	source := atn.EmitGoSource(packageName, a, grammr, tokenTypes.TokenTypeVarNames)
 	return FormatIfPossible(source.String())

--- a/internal/generator/atn_md_generator.go
+++ b/internal/generator/atn_md_generator.go
@@ -10,6 +10,7 @@ import (
 )
 
 func GenerateATNMarkdown(grammr grammar.Grammar, packageName string, tokenTypes GenerateTokenTypesResult) string {
+	mustExpandInfixRules(grammr)
 	a, _ := atn.CreateATN(grammr, tokenTypes.TokenTypeIds)
 	source := atn.EmitMarkdownSource(packageName, grammr, a, tokenTypes.TokenTypeNames)
 	return source.String()

--- a/internal/generator/infix_generator.go
+++ b/internal/generator/infix_generator.go
@@ -29,7 +29,7 @@ func mustExpandInfixRules(grammr grammar.Grammar) {
 // alternatives decision), then folds them into a binary tree with
 // parser.BuildInfixTree.
 func generateInfixParseFunction(node codegen.Node, context *ParserGeneratorContext, rule grammar.InfixRule, groupMembers map[string][]string) {
-	returnType := grammar.FindInfixReturnType(rule, ctx.Background())
+	returnType := grammar.FindReturnType(rule, ctx.Background())
 	if returnType == nil {
 		panic("Unable to find return type for infix rule: " + rule.Name())
 	}

--- a/internal/generator/infix_generator.go
+++ b/internal/generator/infix_generator.go
@@ -27,7 +27,7 @@ func mustExpandInfixRules(grammr grammar.Grammar) {
 // synthesized flat body. The real parser collects operands and operator
 // tokens in flat slices with a single token-group consume per operator (no
 // alternatives decision), then folds them into a binary tree with
-// core.BuildInfixTree.
+// parser.BuildInfixTree.
 func generateInfixParseFunction(node codegen.Node, context *ParserGeneratorContext, rule grammar.InfixRule, groupMembers map[string][]string) {
 	returnType := grammar.FindInfixReturnType(rule, ctx.Background())
 	if returnType == nil {
@@ -101,7 +101,7 @@ func generateInfixParseFunction(node codegen.Node, context *ParserGeneratorConte
 			in.AppendLine("return parts[0]")
 		})
 		n.AppendLine("}")
-		n.AppendLine("return core.BuildInfixTree(parts, operators, ", precedenceVar, ", func(left ", returnType.Name(), ", operator *core.Token, right ", returnType.Name(), ") ", returnType.Name(), " {")
+		n.AppendLine("return parser.BuildInfixTree(parts, operators, ", precedenceVar, ", func(left ", returnType.Name(), ", operator *core.Token, right ", returnType.Name(), ") ", returnType.Name(), " {")
 		n.Indent(func(in codegen.Node) {
 			in.AppendLine("result := New", rule.Name(), "()")
 			in.AppendLine("if left != nil {")
@@ -135,7 +135,7 @@ func generateInfixParseFunction(node codegen.Node, context *ParserGeneratorConte
 // keyed by leaf token type id. Token-group operators are expanded to their
 // leaf members so the runtime lookup is a single map access on Token.TypeId.
 func generateInfixPrecedenceVar(node codegen.Node, name string, rule grammar.InfixRule, groupMembers map[string][]string) {
-	node.AppendLine("var ", name, " = map[int]core.InfixPrecedence{")
+	node.AppendLine("var ", name, " = map[int]parser.InfixPrecedence{")
 	node.Indent(func(n codegen.Node) {
 		seen := map[string]bool{}
 		for level, group := range rule.Groups() {

--- a/internal/generator/infix_generator.go
+++ b/internal/generator/infix_generator.go
@@ -1,0 +1,183 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+package generator
+
+import (
+	ctx "context"
+	"strconv"
+
+	"typefox.dev/fastbelt/internal/grammar"
+	"typefox.dev/fastbelt/util/codegen"
+)
+
+// mustExpandInfixRules desugars all infix rules of the grammar (idempotent).
+// Every generator entry point calls it so the synthesized rule bodies and
+// operator token groups exist regardless of the order generators run in.
+func mustExpandInfixRules(grammr grammar.Grammar) {
+	if err := grammar.ExpandInfixRules(grammr); err != nil {
+		panic(err.Error())
+	}
+}
+
+// generateInfixParseFunction emits the Parse function of an infix rule.
+//
+// The completion parser reuses the generic element emitter over the
+// synthesized flat body. The real parser collects operands and operator
+// tokens in flat slices with a single token-group consume per operator (no
+// alternatives decision), then folds them into a binary tree with
+// core.BuildInfixTree.
+func generateInfixParseFunction(node codegen.Node, context *ParserGeneratorContext, rule grammar.InfixRule, groupMembers map[string][]string) {
+	returnType := grammar.FindInfixReturnType(rule, ctx.Background())
+	if returnType == nil {
+		panic("Unable to find return type for infix rule: " + rule.Name())
+	}
+	context.inCompositeRule = false
+	receiverType := context.receiverType()
+
+	if context.completion {
+		node.AppendLine("func (p *", receiverType, ") Parse", rule.Name(), "() {")
+		node.Indent(func(n codegen.Node) {
+			n.AppendLine("p.cp.EnterRule(", strconv.Quote(rule.Name()), ", ", context.atnData.ruleStart(rule), ")")
+			n.AppendLine("defer p.cp.ExitRule()")
+			generateAbstractElementParser(n, context, rule.Body())
+		})
+		node.AppendLine("}")
+		node.AppendLine()
+		return
+	}
+
+	// Destructure the body synthesized by grammar.ExpandInfixRules:
+	// Group [ RuleCall(operand), Group* [ RuleCall(operatorGroup), RuleCall(operand) ] ]
+	outer := rule.Body().(grammar.Group)
+	firstCall := outer.Elements()[0].(grammar.RuleCall)
+	inner := outer.Elements()[1].(grammar.Group)
+	operatorCall := inner.Elements()[0].(grammar.RuleCall)
+	secondCall := inner.Elements()[1].(grammar.RuleCall)
+	operand := firstCall.Rule().Ref(ctx.Background()).(grammar.ParserRule)
+	operatorGroup := operatorCall.Rule().Ref(ctx.Background()).(grammar.AbstractTokenRule)
+
+	precedenceVar := rule.Name() + "Precedence"
+	generateInfixPrecedenceVar(node, precedenceVar, rule, groupMembers)
+
+	syncCall := buildSyncCall(context, inner)
+	operatorState := context.atnData.elementStateName(operatorCall)
+	emitOperand := func(n codegen.Node, call grammar.RuleCall) {
+		n.AppendLine("{")
+		n.Indent(func(in codegen.Node) {
+			in.AppendLine("p.state.EnterRule(", context.atnData.followState(call), ")")
+			in.AppendLine("result := p.Parse", operand.Name(), "()")
+			in.AppendLine("p.state.ExitRule()")
+			in.AppendLine("parts = append(parts, result)")
+		})
+		n.AppendLine("}")
+	}
+
+	node.AppendLine("func (p *", receiverType, ") Parse", rule.Name(), "() ", returnType.Name(), " {")
+	node.Indent(func(n codegen.Node) {
+		n.AppendLine("var parts []", returnType.Name())
+		n.AppendLine("var operators []*core.Token")
+		emitOperand(n, firstCall)
+		if syncCall != "" {
+			n.AppendLine(syncCall)
+		}
+		n.AppendLine("for ", guardCall(context, inner), " {")
+		n.Indent(func(in codegen.Node) {
+			in.AppendLine("if token := p.state.Consume(", GeneratedTokenName(operatorGroup), "); token != nil {")
+			in.Indent(func(iin codegen.Node) {
+				iin.AppendLine("operators = append(operators, token)")
+			})
+			in.AppendLine("}")
+			emitOperand(in, secondCall)
+			if syncCall != "" {
+				in.AppendLine(syncCall)
+			}
+		})
+		n.AppendLine("}")
+		n.AppendLine("if len(parts) == 1 {")
+		n.Indent(func(in codegen.Node) {
+			in.AppendLine("// A lone operand is returned unchanged; no binary node is created.")
+			in.AppendLine("return parts[0]")
+		})
+		n.AppendLine("}")
+		n.AppendLine("return core.BuildInfixTree(parts, operators, ", precedenceVar, ", func(left ", returnType.Name(), ", operator *core.Token, right ", returnType.Name(), ") ", returnType.Name(), " {")
+		n.Indent(func(in codegen.Node) {
+			in.AppendLine("result := New", rule.Name(), "()")
+			in.AppendLine("if left != nil {")
+			in.Indent(func(iin codegen.Node) {
+				iin.AppendLine("result.SetLeft(left)")
+				iin.AppendLine("result.SetTextRangeStart(left.TextRange().Start)")
+			})
+			in.AppendLine("}")
+			in.AppendLine("if operator != nil {")
+			in.Indent(func(iin codegen.Node) {
+				iin.AppendLine("core.AssignToken(result, operator, ", operatorState, ")")
+				iin.AppendLine("result.SetOperator(operator)")
+				iin.AppendLine("result.SetTextRangeEnd(operator.Range.End)")
+			})
+			in.AppendLine("}")
+			in.AppendLine("if right != nil {")
+			in.Indent(func(iin codegen.Node) {
+				iin.AppendLine("result.SetRight(right)")
+				iin.AppendLine("result.SetTextRangeEnd(right.TextRange().End)")
+			})
+			in.AppendLine("}")
+			in.AppendLine("return result")
+		})
+		n.AppendLine("})")
+	})
+	node.AppendLine("}")
+	node.AppendLine()
+}
+
+// generateInfixPrecedenceVar emits the precedence table of an infix rule,
+// keyed by leaf token type id. Token-group operators are expanded to their
+// leaf members so the runtime lookup is a single map access on Token.TypeId.
+func generateInfixPrecedenceVar(node codegen.Node, name string, rule grammar.InfixRule, groupMembers map[string][]string) {
+	node.AppendLine("var ", name, " = map[int]core.InfixPrecedence{")
+	node.Indent(func(n codegen.Node) {
+		seen := map[string]bool{}
+		for level, group := range rule.Groups() {
+			right := ""
+			if group.Associativity() == "right" {
+				right = ", Right: true"
+			}
+			for _, operator := range group.Operators() {
+				var operatorVar string
+				switch op := operator.(type) {
+				case grammar.Keyword:
+					operatorVar = GeneratedTokenName(op)
+				case grammar.RuleCall:
+					operatorVar = GeneratedTokenName(op.Rule().Ref(ctx.Background()))
+				default:
+					continue
+				}
+				for _, leaf := range leafTokenVarNames(operatorVar, groupMembers, seen) {
+					n.AppendLine(leaf, "_Idx: {Level: ", strconv.Itoa(level), right, "},")
+				}
+			}
+		}
+	})
+	node.AppendLine("}")
+	node.AppendLine()
+}
+
+// leafTokenVarNames recursively expands a token var name to its leaf member
+// var names, resolving token groups through groupMembers. Names already in
+// seen are skipped (and recorded), so duplicate operators produce a single
+// map entry.
+func leafTokenVarNames(varName string, groupMembers map[string][]string, seen map[string]bool) []string {
+	if members, ok := groupMembers[varName]; ok {
+		var result []string
+		for _, member := range members {
+			result = append(result, leafTokenVarNames(member, groupMembers, seen)...)
+		}
+		return result
+	}
+	if seen[varName] {
+		return nil
+	}
+	seen[varName] = true
+	return []string{varName}
+}

--- a/internal/generator/lexer_generator.go
+++ b/internal/generator/lexer_generator.go
@@ -33,6 +33,7 @@ type GenerateTokenTypesResult struct {
 }
 
 func GenerateTokenTypes(grammr grammar.Grammar) GenerateTokenTypesResult {
+	mustExpandInfixRules(grammr)
 	tokens := grammr.Terminals()
 	tokenGroups := grammr.TokenGroups()
 	keywords := GetAllKeywords(grammr)

--- a/internal/generator/parser_generator.go
+++ b/internal/generator/parser_generator.go
@@ -1665,66 +1665,19 @@ func ll1DecisionOpt(atnData *parserATNData, element grammar.Element) LL1Decision
 	}
 }
 
-// getDeclaringInterface returns the name of the interface that declares
-// the property being assigned by the given assignment. Searches backwards
-// through the sequential context for the nearest preceding Action (which
-// re-types 'current') and falls back to FindReturnType on the containing
-// ParserRule.
+// getDeclaringInterface returns the name of the interface that declares the
+// property being assigned. The ReferencesConstructor methods are named after
+// the interface that declares the field, which may be a parent (extended)
+// interface of the current rule's return type — so resolve the property
+// reference to its exact Field node and use that field's container.
 func getDeclaringInterface(assignment grammar.Assignment) string {
-	action, parserRule := findPrecedingAction(assignment)
-	if action != nil {
-		return action.Type().Text()
+	field := assignment.Property().Ref(ctx.Background())
+	if field == nil {
+		panic("Unresolved property reference: " + assignment.Property().Text())
 	}
-	if parserRule != nil {
-		if iface := grammar.FindReturnType(parserRule, ctx.Background()); iface != nil {
-			return iface.Name()
-		}
-		panic("No return type for rule: " + parserRule.Name())
+	iface, ok := field.Container().(grammar.Interface)
+	if !ok {
+		panic("Property is not declared on an interface: " + field.Name())
 	}
-	panic("Unable to find containing parser rule for cross-reference assignment")
-}
-
-// findPrecedingAction searches backwards from element through its containing
-// sequential contexts (Groups) for the most recent preceding grammar.Action.
-// Stops at ParserRule boundaries (returning the rule). Passes through other
-// container types such as Alternatives by recursing upward without scanning
-// their siblings. Panics for unexpected container types (e.g. CompositeRule,
-// which cannot contain assignments by design).
-func findPrecedingAction(element grammar.Element) (grammar.Action, grammar.ParserRule) {
-	container := element.Container()
-	switch c := container.(type) {
-	case grammar.Group:
-		elements := c.Elements()
-		idx := slices.Index(elements, element)
-		for j := idx - 1; j >= 0; j-- {
-			if act := lastActionIn(elements[j]); act != nil {
-				return act, nil
-			}
-		}
-		return findPrecedingAction(c)
-	case grammar.ParserRule:
-		return nil, c
-	case grammar.Element:
-		return findPrecedingAction(c)
-	default:
-		panic("Unable to find parser rule for element")
-	}
-}
-
-// lastActionIn returns the last grammar.Action in the sequential tail of
-// element, scanning backwards. Used to check whether a Group preceding the
-// assignment contains a trailing action that re-typed 'current'. Returns nil
-// for Alternatives (conditional branches are not scanned).
-func lastActionIn(element grammar.Element) grammar.Action {
-	switch e := element.(type) {
-	case grammar.Action:
-		return e
-	case grammar.Group:
-		for i := len(e.Elements()) - 1; i >= 0; i-- {
-			if act := lastActionIn(e.Elements()[i]); act != nil {
-				return act
-			}
-		}
-	}
-	return nil
+	return iface.Name()
 }

--- a/internal/generator/parser_generator.go
+++ b/internal/generator/parser_generator.go
@@ -37,6 +37,7 @@ type parserATNData struct {
 // GenerateParser, GenerateCompletionParser, and GenerateParserLookahead.
 // Returns nil when the ATN cannot be built (invalid grammar).
 func BuildParserATNData(grammr grammar.Grammar, tokenTypes GenerateTokenTypesResult) *parserATNData {
+	mustExpandInfixRules(grammr)
 	builtATN, _ := internalATN.CreateATN(grammr, tokenTypes.TokenTypeIds)
 	if builtATN == nil {
 		return nil
@@ -287,6 +288,7 @@ func (ctx *ParserGeneratorContext) nextLoopLabel() string {
 // file shares a package with parser_gen.go, it reuses the lookahead tables and
 // ATN-decision indices defined there.
 func GenerateParserLookahead(grammr grammar.Grammar, packageName string, tokenTypes GenerateTokenTypesResult, atnData *parserATNData) string {
+	mustExpandInfixRules(grammr)
 	context := &ParserGeneratorContext{
 		grammar:      grammr,
 		lookaheads:   make(map[core.AstNode]LookaheadValue),
@@ -504,6 +506,7 @@ func decisionConstName(methodName string) string {
 }
 
 func GenerateParser(grammr grammar.Grammar, entryRule grammar.ParserRule, packageName string, tokenTypes GenerateTokenTypesResult, atnData *parserATNData) string {
+	mustExpandInfixRules(grammr)
 	context := &ParserGeneratorContext{
 		grammar:      grammr,
 		lookaheads:   make(map[core.AstNode]LookaheadValue),
@@ -562,6 +565,10 @@ func GenerateParser(grammr grammar.Grammar, entryRule grammar.ParserRule, packag
 	for _, composite := range grammr.Composites() {
 		generateCompositeParseFunction(node, context, composite)
 	}
+	groupMembers := buildGroupVarNameToMembers(grammr)
+	for _, infix := range grammr.InfixRules() {
+		generateInfixParseFunction(node, context, infix, groupMembers)
+	}
 
 	return FormatIfPossible(node.String())
 }
@@ -574,6 +581,7 @@ func GenerateParser(grammr grammar.Grammar, entryRule grammar.ParserRule, packag
 // The generated file reuses the lookahead tables and ATN builder defined by
 // GenerateParser/EmitGoSource, so it must be emitted into the same package.
 func GenerateCompletionParser(grammr grammar.Grammar, entryRule grammar.ParserRule, packageName string, tokenTypes GenerateTokenTypesResult, atnData *parserATNData) string {
+	mustExpandInfixRules(grammr)
 	context := &ParserGeneratorContext{
 		grammar:      grammr,
 		lookaheads:   make(map[core.AstNode]LookaheadValue),
@@ -640,6 +648,9 @@ func GenerateCompletionParser(grammr grammar.Grammar, entryRule grammar.ParserRu
 	}
 	for _, composite := range grammr.Composites() {
 		generateCompositeParseFunction(node, context, composite)
+	}
+	for _, infix := range grammr.InfixRules() {
+		generateInfixParseFunction(node, context, infix, nil)
 	}
 
 	return FormatIfPossible(node.String())
@@ -899,6 +910,9 @@ func populateContext(context *ParserGeneratorContext) {
 	}
 	for _, composite := range context.grammar.Composites() {
 		decls = collectLookaheadDecls(context, decls, composite.Name(), composite.Body())
+	}
+	for _, infix := range context.grammar.InfixRules() {
+		decls = collectLookaheadDecls(context, decls, infix.Name(), infix.Body())
 	}
 
 	// Names are derived structurally from the rule/property path plus the kind of
@@ -1268,6 +1282,15 @@ func generateRuleCallParser(node codegen.Node, context *ParserGeneratorContext, 
 				n.AppendLine("core.AssignToken(current, token, ", context.atnData.elementStateName(ruleCall), ")")
 			}
 		case grammar.ParserRule:
+			followName := context.atnData.followState(ruleCall)
+			n.AppendLine("p.state.EnterRule(", followName, ")")
+			if context.completion {
+				n.AppendLine("p.Parse", t.Name(), "()")
+			} else {
+				n.AppendLine("result ", eq, " p.Parse", t.Name(), "()")
+			}
+			n.AppendLine("p.state.ExitRule()")
+		case grammar.InfixRule:
 			followName := context.atnData.followState(ruleCall)
 			n.AppendLine("p.state.EnterRule(", followName, ")")
 			if context.completion {

--- a/internal/grammar/atn.md
+++ b/internal/grammar/atn.md
@@ -892,37 +892,33 @@ flowchart TD
     q336["PrecedenceGroup__Basic_1 (336)<br/>Basic<br/>"]
     q337{"PrecedenceGroup__Basic_2 (337)<br/>Basic<br/><br/>dec=42"}
     q338["PrecedenceGroup__BlockEnd (338)<br/>BlockEnd<br/>"]
-    q339["PrecedenceGroup_assoc (339)<br/>Basic<br/>"]
-    q340["PrecedenceGroup__Basic_3 (340)<br/>Basic<br/>"]
-    q341{"PrecedenceGroup__Basic_4 (341)<br/>Basic<br/><br/>dec=43"}
+    q339{"PrecedenceGroup__Basic_3 (339)<br/>Basic<br/><br/>dec=43"}
+    q340["PrecedenceGroup__Basic_4 (340)<br/>Basic<br/>"]
+    q341["PrecedenceGroup_Pipe (341)<br/>Basic<br/>"]
     q342["PrecedenceGroup__Basic_5 (342)<br/>Basic<br/>"]
-    q343["PrecedenceGroup_Pipe (343)<br/>Basic<br/>"]
-    q344["PrecedenceGroup__Basic_6 (344)<br/>Basic<br/>"]
-    q345["PrecedenceGroup__Basic_7 (345)<br/>Basic<br/>"]
-    q346{"PrecedenceGroup__LoopEntry (346)<br/>LoopEntry<br/><br/>dec=44"}
-    q347["PrecedenceGroup__LoopEnd (347)<br/>LoopEnd<br/>"]
-    q348["PrecedenceGroup__LoopBack (348)<br/>LoopBack<br/>"]
+    q343["PrecedenceGroup__Basic_6 (343)<br/>Basic<br/>"]
+    q344{"PrecedenceGroup__LoopEntry (344)<br/>LoopEntry<br/><br/>dec=44"}
+    q345["PrecedenceGroup__LoopEnd (345)<br/>LoopEnd<br/>"]
+    q346["PrecedenceGroup__LoopBack (346)<br/>LoopBack<br/>"]
 
-    q54 --> q341
+    q54 --> q339
     q333 -->|"tok(&quot;left&quot;)"| q334
     q334 --> q338
     q335 -->|"tok(&quot;right&quot;)"| q336
     q336 --> q338
     q337 --> q333
     q337 --> q335
-    q338 --> q339
-    q339 -->|"tok(&quot;assoc&quot;)"| q340
-    q340 --> q342
-    q341 --> q337
-    q341 --> q340
-    q342 -.->|"[InfixOperator]"| q346
-    q343 -->|"tok(&quot;|&quot;)"| q344
-    q344 -.->|"[InfixOperator]"| q345
-    q345 --> q348
-    q346 --> q343
-    q346 --> q347
-    q347 --> q55
-    q348 --> q346
+    q338 --> q340
+    q339 --> q337
+    q339 --> q338
+    q340 -.->|"[InfixOperator]"| q344
+    q341 -->|"tok(&quot;|&quot;)"| q342
+    q342 -.->|"[InfixOperator]"| q343
+    q343 --> q346
+    q344 --> q341
+    q344 --> q345
+    q345 --> q55
+    q346 --> q344
 ```
 
 ## InfixOperator
@@ -931,20 +927,20 @@ flowchart TD
 flowchart TD
     q56(["InfixOperator__Start (56)<br/>RuleStart"])
     q57(["InfixOperator__Stop (57)<br/>RuleStop"])
-    q349["InfixOperator__Basic_0 (349)<br/>Basic<br/>"]
-    q350["InfixOperator__Basic_1 (350)<br/>Basic<br/>"]
-    q351["InfixOperator__Basic_2 (351)<br/>Basic<br/>"]
-    q352["InfixOperator__Basic_3 (352)<br/>Basic<br/>"]
-    q353{"InfixOperator__Basic_4 (353)<br/>Basic<br/><br/>dec=45"}
-    q354["InfixOperator__BlockEnd (354)<br/>BlockEnd<br/>"]
+    q347["InfixOperator__Basic_0 (347)<br/>Basic<br/>"]
+    q348["InfixOperator__Basic_1 (348)<br/>Basic<br/>"]
+    q349["InfixOperator__Basic_2 (349)<br/>Basic<br/>"]
+    q350["InfixOperator__Basic_3 (350)<br/>Basic<br/>"]
+    q351{"InfixOperator__Basic_4 (351)<br/>Basic<br/><br/>dec=45"}
+    q352["InfixOperator__BlockEnd (352)<br/>BlockEnd<br/>"]
 
-    q56 --> q353
-    q349 -.->|"[Keyword]"| q350
-    q350 --> q354
-    q351 -.->|"[RuleCall]"| q352
-    q352 --> q354
-    q353 --> q349
-    q353 --> q351
-    q354 --> q57
+    q56 --> q351
+    q347 -.->|"[Keyword]"| q348
+    q348 --> q352
+    q349 -.->|"[RuleCall]"| q350
+    q350 --> q352
+    q351 --> q347
+    q351 --> q349
+    q352 --> q57
 ```
 

--- a/internal/grammar/atn.md
+++ b/internal/grammar/atn.md
@@ -6,54 +6,59 @@
 flowchart TD
     q0(["Grammar__Start (0)<br/>RuleStart"])
     q1(["Grammar__Stop (1)<br/>RuleStop"])
-    q52["Grammar_grammar (52)<br/>Basic<br/>"]
-    q53["Grammar_Name_ID (53)<br/>Basic<br/>"]
-    q54["Grammar_Semicolon (54)<br/>Basic<br/>"]
-    q55["Grammar__Basic_0 (55)<br/>Basic<br/>"]
-    q56{"Grammar__Basic_1 (56)<br/>Basic<br/><br/>dec=0"}
-    q57["Grammar__Basic_2 (57)<br/>Basic<br/>"]
-    q58["Grammar__Basic_3 (58)<br/>Basic<br/>"]
-    q59["Grammar__Basic_4 (59)<br/>Basic<br/>"]
-    q60["Grammar__Basic_5 (60)<br/>Basic<br/>"]
-    q61["Grammar__Basic_6 (61)<br/>Basic<br/>"]
-    q62["Grammar__Basic_7 (62)<br/>Basic<br/>"]
-    q63["Grammar__Basic_8 (63)<br/>Basic<br/>"]
-    q64["Grammar__Basic_9 (64)<br/>Basic<br/>"]
-    q65["Grammar__Basic_10 (65)<br/>Basic<br/>"]
-    q66["Grammar__Basic_11 (66)<br/>Basic<br/>"]
-    q67{"Grammar__Basic_12 (67)<br/>Basic<br/><br/>dec=1"}
-    q68["Grammar__BlockEnd (68)<br/>BlockEnd<br/>"]
-    q69{"Grammar__LoopEntry (69)<br/>LoopEntry<br/><br/>dec=2"}
-    q70["Grammar__LoopEnd (70)<br/>LoopEnd<br/>"]
-    q71["Grammar__LoopBack (71)<br/>LoopBack<br/>"]
+    q58["Grammar_grammar (58)<br/>Basic<br/>"]
+    q59["Grammar_Name_ID (59)<br/>Basic<br/>"]
+    q60["Grammar_Semicolon (60)<br/>Basic<br/>"]
+    q61["Grammar__Basic_0 (61)<br/>Basic<br/>"]
+    q62{"Grammar__Basic_1 (62)<br/>Basic<br/><br/>dec=0"}
+    q63["Grammar__Basic_2 (63)<br/>Basic<br/>"]
+    q64["Grammar__Basic_3 (64)<br/>Basic<br/>"]
+    q65["Grammar__Basic_4 (65)<br/>Basic<br/>"]
+    q66["Grammar__Basic_5 (66)<br/>Basic<br/>"]
+    q67["Grammar__Basic_6 (67)<br/>Basic<br/>"]
+    q68["Grammar__Basic_7 (68)<br/>Basic<br/>"]
+    q69["Grammar__Basic_8 (69)<br/>Basic<br/>"]
+    q70["Grammar__Basic_9 (70)<br/>Basic<br/>"]
+    q71["Grammar__Basic_10 (71)<br/>Basic<br/>"]
+    q72["Grammar__Basic_11 (72)<br/>Basic<br/>"]
+    q73["Grammar__Basic_12 (73)<br/>Basic<br/>"]
+    q74["Grammar__Basic_13 (74)<br/>Basic<br/>"]
+    q75{"Grammar__Basic_14 (75)<br/>Basic<br/><br/>dec=1"}
+    q76["Grammar__BlockEnd (76)<br/>BlockEnd<br/>"]
+    q77{"Grammar__LoopEntry (77)<br/>LoopEntry<br/><br/>dec=2"}
+    q78["Grammar__LoopEnd (78)<br/>LoopEnd<br/>"]
+    q79["Grammar__LoopBack (79)<br/>LoopBack<br/>"]
 
-    q0 --> q52
-    q52 -->|"tok(&quot;grammar&quot;)"| q53
-    q53 -->|"tok(ID)"| q56
-    q54 -->|"tok(&quot;;&quot;)"| q55
-    q55 --> q69
-    q56 --> q54
-    q56 --> q55
-    q57 -.->|"[ParserRule]"| q58
-    q58 --> q68
-    q59 -.->|"[Token]"| q60
-    q60 --> q68
-    q61 -.->|"[TokenGroup]"| q62
-    q62 --> q68
-    q63 -.->|"[Interface]"| q64
-    q64 --> q68
-    q65 -.->|"[CompositeRule]"| q66
-    q66 --> q68
-    q67 --> q57
-    q67 --> q59
-    q67 --> q61
-    q67 --> q63
-    q67 --> q65
-    q68 --> q71
-    q69 --> q67
-    q69 --> q70
-    q70 --> q1
-    q71 --> q69
+    q0 --> q58
+    q58 -->|"tok(&quot;grammar&quot;)"| q59
+    q59 -->|"tok(ID)"| q62
+    q60 -->|"tok(&quot;;&quot;)"| q61
+    q61 --> q77
+    q62 --> q60
+    q62 --> q61
+    q63 -.->|"[ParserRule]"| q64
+    q64 --> q76
+    q65 -.->|"[Token]"| q66
+    q66 --> q76
+    q67 -.->|"[TokenGroup]"| q68
+    q68 --> q76
+    q69 -.->|"[Interface]"| q70
+    q70 --> q76
+    q71 -.->|"[CompositeRule]"| q72
+    q72 --> q76
+    q73 -.->|"[InfixRule]"| q74
+    q74 --> q76
+    q75 --> q63
+    q75 --> q65
+    q75 --> q67
+    q75 --> q69
+    q75 --> q71
+    q75 --> q73
+    q76 --> q79
+    q77 --> q75
+    q77 --> q78
+    q78 --> q1
+    q79 --> q77
 ```
 
 ## Interface
@@ -62,49 +67,49 @@ flowchart TD
 flowchart TD
     q2(["Interface__Start (2)<br/>RuleStart"])
     q3(["Interface__Stop (3)<br/>RuleStop"])
-    q72["Interface_interface (72)<br/>Basic<br/>"]
-    q73["Interface_Name_ID (73)<br/>Basic<br/>"]
-    q74["Interface_extends (74)<br/>Basic<br/>"]
-    q75["Interface_Extends_ID_0 (75)<br/>Basic<br/>"]
-    q76["Interface_Comma (76)<br/>Basic<br/>"]
-    q77["Interface_Extends_ID_1 (77)<br/>Basic<br/>"]
-    q78["Interface__Basic_0 (78)<br/>Basic<br/>"]
-    q79{"Interface__LoopEntry_0 (79)<br/>LoopEntry<br/><br/>dec=3"}
-    q80["Interface__LoopEnd_0 (80)<br/>LoopEnd<br/>"]
-    q81["Interface__LoopBack_0 (81)<br/>LoopBack<br/>"]
-    q82{"Interface__Basic_1 (82)<br/>Basic<br/><br/>dec=4"}
-    q83["Interface_LeftBrace (83)<br/>Basic<br/>"]
-    q84["Interface__Basic_2 (84)<br/>Basic<br/>"]
-    q85["Interface__Basic_3 (85)<br/>Basic<br/>"]
-    q86{"Interface__LoopEntry_1 (86)<br/>LoopEntry<br/><br/>dec=5"}
-    q87["Interface__LoopEnd_1 (87)<br/>LoopEnd<br/>"]
-    q88["Interface__LoopBack_1 (88)<br/>LoopBack<br/>"]
-    q89["Interface_RightBrace (89)<br/>Basic<br/>"]
-    q90["Interface__Basic_4 (90)<br/>Basic<br/>"]
+    q80["Interface_interface (80)<br/>Basic<br/>"]
+    q81["Interface_Name_ID (81)<br/>Basic<br/>"]
+    q82["Interface_extends (82)<br/>Basic<br/>"]
+    q83["Interface_Extends_ID_0 (83)<br/>Basic<br/>"]
+    q84["Interface_Comma (84)<br/>Basic<br/>"]
+    q85["Interface_Extends_ID_1 (85)<br/>Basic<br/>"]
+    q86["Interface__Basic_0 (86)<br/>Basic<br/>"]
+    q87{"Interface__LoopEntry_0 (87)<br/>LoopEntry<br/><br/>dec=3"}
+    q88["Interface__LoopEnd_0 (88)<br/>LoopEnd<br/>"]
+    q89["Interface__LoopBack_0 (89)<br/>LoopBack<br/>"]
+    q90{"Interface__Basic_1 (90)<br/>Basic<br/><br/>dec=4"}
+    q91["Interface_LeftBrace (91)<br/>Basic<br/>"]
+    q92["Interface__Basic_2 (92)<br/>Basic<br/>"]
+    q93["Interface__Basic_3 (93)<br/>Basic<br/>"]
+    q94{"Interface__LoopEntry_1 (94)<br/>LoopEntry<br/><br/>dec=5"}
+    q95["Interface__LoopEnd_1 (95)<br/>LoopEnd<br/>"]
+    q96["Interface__LoopBack_1 (96)<br/>LoopBack<br/>"]
+    q97["Interface_RightBrace (97)<br/>Basic<br/>"]
+    q98["Interface__Basic_4 (98)<br/>Basic<br/>"]
 
-    q2 --> q72
-    q72 -->|"tok(&quot;interface&quot;)"| q73
-    q73 -->|"tok(ID)"| q82
-    q74 -->|"tok(&quot;extends&quot;)"| q75
-    q75 -->|"tok(ID)"| q79
-    q76 -->|"tok(&quot;,&quot;)"| q77
-    q77 -->|"tok(ID)"| q78
-    q78 --> q81
-    q79 --> q76
-    q79 --> q80
-    q80 --> q83
-    q81 --> q79
-    q82 --> q74
-    q82 --> q80
-    q83 -->|"tok(&quot;{&quot;)"| q86
-    q84 -.->|"[Field]"| q85
-    q85 --> q88
-    q86 --> q84
-    q86 --> q87
-    q87 --> q89
-    q88 --> q86
-    q89 -->|"tok(&quot;}&quot;)"| q90
-    q90 --> q3
+    q2 --> q80
+    q80 -->|"tok(&quot;interface&quot;)"| q81
+    q81 -->|"tok(ID)"| q90
+    q82 -->|"tok(&quot;extends&quot;)"| q83
+    q83 -->|"tok(ID)"| q87
+    q84 -->|"tok(&quot;,&quot;)"| q85
+    q85 -->|"tok(ID)"| q86
+    q86 --> q89
+    q87 --> q84
+    q87 --> q88
+    q88 --> q91
+    q89 --> q87
+    q90 --> q82
+    q90 --> q88
+    q91 -->|"tok(&quot;{&quot;)"| q94
+    q92 -.->|"[Field]"| q93
+    q93 --> q96
+    q94 --> q92
+    q94 --> q95
+    q95 --> q97
+    q96 --> q94
+    q97 -->|"tok(&quot;}&quot;)"| q98
+    q98 --> q3
 ```
 
 ## Field
@@ -113,14 +118,14 @@ flowchart TD
 flowchart TD
     q4(["Field__Start (4)<br/>RuleStart"])
     q5(["Field__Stop (5)<br/>RuleStop"])
-    q91["Field_Name_ID (91)<br/>Basic<br/>"]
-    q92["Field__Basic_0 (92)<br/>Basic<br/>"]
-    q93["Field__Basic_1 (93)<br/>Basic<br/>"]
+    q99["Field_Name_ID (99)<br/>Basic<br/>"]
+    q100["Field__Basic_0 (100)<br/>Basic<br/>"]
+    q101["Field__Basic_1 (101)<br/>Basic<br/>"]
 
-    q4 --> q91
-    q91 -->|"tok(ID)"| q92
-    q92 -.->|"[FieldType]"| q93
-    q93 --> q5
+    q4 --> q99
+    q99 -->|"tok(ID)"| q100
+    q100 -.->|"[FieldType]"| q101
+    q101 --> q5
 ```
 
 ## FieldType
@@ -129,31 +134,31 @@ flowchart TD
 flowchart TD
     q6(["FieldType__Start (6)<br/>RuleStart"])
     q7(["FieldType__Stop (7)<br/>RuleStop"])
-    q94["FieldType__Basic_0 (94)<br/>Basic<br/>"]
-    q95["FieldType__Basic_1 (95)<br/>Basic<br/>"]
-    q96["FieldType__Basic_2 (96)<br/>Basic<br/>"]
-    q97["FieldType__Basic_3 (97)<br/>Basic<br/>"]
-    q98["FieldType__Basic_4 (98)<br/>Basic<br/>"]
-    q99["FieldType__Basic_5 (99)<br/>Basic<br/>"]
-    q100["FieldType__Basic_6 (100)<br/>Basic<br/>"]
-    q101["FieldType__Basic_7 (101)<br/>Basic<br/>"]
-    q102{"FieldType__Basic_8 (102)<br/>Basic<br/><br/>dec=6"}
-    q103["FieldType__BlockEnd (103)<br/>BlockEnd<br/>"]
+    q102["FieldType__Basic_0 (102)<br/>Basic<br/>"]
+    q103["FieldType__Basic_1 (103)<br/>Basic<br/>"]
+    q104["FieldType__Basic_2 (104)<br/>Basic<br/>"]
+    q105["FieldType__Basic_3 (105)<br/>Basic<br/>"]
+    q106["FieldType__Basic_4 (106)<br/>Basic<br/>"]
+    q107["FieldType__Basic_5 (107)<br/>Basic<br/>"]
+    q108["FieldType__Basic_6 (108)<br/>Basic<br/>"]
+    q109["FieldType__Basic_7 (109)<br/>Basic<br/>"]
+    q110{"FieldType__Basic_8 (110)<br/>Basic<br/><br/>dec=6"}
+    q111["FieldType__BlockEnd (111)<br/>BlockEnd<br/>"]
 
-    q6 --> q102
-    q94 -.->|"[SimpleType]"| q95
-    q95 --> q103
-    q96 -.->|"[ReferenceType]"| q97
-    q97 --> q103
-    q98 -.->|"[ArrayType]"| q99
-    q99 --> q103
-    q100 -.->|"[PrimitiveType]"| q101
-    q101 --> q103
-    q102 --> q94
-    q102 --> q96
-    q102 --> q98
-    q102 --> q100
-    q103 --> q7
+    q6 --> q110
+    q102 -.->|"[SimpleType]"| q103
+    q103 --> q111
+    q104 -.->|"[ReferenceType]"| q105
+    q105 --> q111
+    q106 -.->|"[ArrayType]"| q107
+    q107 --> q111
+    q108 -.->|"[PrimitiveType]"| q109
+    q109 --> q111
+    q110 --> q102
+    q110 --> q104
+    q110 --> q106
+    q110 --> q108
+    q111 --> q7
 ```
 
 ## ArrayType
@@ -162,16 +167,16 @@ flowchart TD
 flowchart TD
     q8(["ArrayType__Start (8)<br/>RuleStart"])
     q9(["ArrayType__Stop (9)<br/>RuleStop"])
-    q104["ArrayType_LeftBracket (104)<br/>Basic<br/>"]
-    q105["ArrayType_RightBracket (105)<br/>Basic<br/>"]
-    q106["ArrayType__Basic_0 (106)<br/>Basic<br/>"]
-    q107["ArrayType__Basic_1 (107)<br/>Basic<br/>"]
+    q112["ArrayType_LeftBracket (112)<br/>Basic<br/>"]
+    q113["ArrayType_RightBracket (113)<br/>Basic<br/>"]
+    q114["ArrayType__Basic_0 (114)<br/>Basic<br/>"]
+    q115["ArrayType__Basic_1 (115)<br/>Basic<br/>"]
 
-    q8 --> q104
-    q104 -->|"tok(&quot;[&quot;)"| q105
-    q105 -->|"tok(&quot;]&quot;)"| q106
-    q106 -.->|"[FieldType]"| q107
-    q107 --> q9
+    q8 --> q112
+    q112 -->|"tok(&quot;[&quot;)"| q113
+    q113 -->|"tok(&quot;]&quot;)"| q114
+    q114 -.->|"[FieldType]"| q115
+    q115 --> q9
 ```
 
 ## ReferenceType
@@ -180,14 +185,14 @@ flowchart TD
 flowchart TD
     q10(["ReferenceType__Start (10)<br/>RuleStart"])
     q11(["ReferenceType__Stop (11)<br/>RuleStop"])
-    q108["ReferenceType_Asterisk (108)<br/>Basic<br/>"]
-    q109["ReferenceType_Type_ID (109)<br/>Basic<br/>"]
-    q110["ReferenceType__Basic (110)<br/>Basic<br/>"]
+    q116["ReferenceType_Asterisk (116)<br/>Basic<br/>"]
+    q117["ReferenceType_Type_ID (117)<br/>Basic<br/>"]
+    q118["ReferenceType__Basic (118)<br/>Basic<br/>"]
 
-    q10 --> q108
-    q108 -->|"tok(&quot;*&quot;)"| q109
-    q109 -->|"tok(ID)"| q110
-    q110 --> q11
+    q10 --> q116
+    q116 -->|"tok(&quot;*&quot;)"| q117
+    q117 -->|"tok(ID)"| q118
+    q118 --> q11
 ```
 
 ## SimpleType
@@ -196,12 +201,12 @@ flowchart TD
 flowchart TD
     q12(["SimpleType__Start (12)<br/>RuleStart"])
     q13(["SimpleType__Stop (13)<br/>RuleStop"])
-    q111["SimpleType_Type_ID (111)<br/>Basic<br/>"]
-    q112["SimpleType__Basic (112)<br/>Basic<br/>"]
+    q119["SimpleType_Type_ID (119)<br/>Basic<br/>"]
+    q120["SimpleType__Basic (120)<br/>Basic<br/>"]
 
-    q12 --> q111
-    q111 -->|"tok(ID)"| q112
-    q112 --> q13
+    q12 --> q119
+    q119 -->|"tok(ID)"| q120
+    q120 --> q13
 ```
 
 ## PrimitiveType
@@ -210,26 +215,26 @@ flowchart TD
 flowchart TD
     q14(["PrimitiveType__Start (14)<br/>RuleStart"])
     q15(["PrimitiveType__Stop (15)<br/>RuleStop"])
-    q113["PrimitiveType_Type_string (113)<br/>Basic<br/>"]
-    q114["PrimitiveType__Basic_0 (114)<br/>Basic<br/>"]
-    q115["PrimitiveType_Type_bool (115)<br/>Basic<br/>"]
-    q116["PrimitiveType__Basic_1 (116)<br/>Basic<br/>"]
-    q117["PrimitiveType_Type_composite (117)<br/>Basic<br/>"]
-    q118["PrimitiveType__Basic_2 (118)<br/>Basic<br/>"]
-    q119{"PrimitiveType__Basic_3 (119)<br/>Basic<br/><br/>dec=7"}
-    q120["PrimitiveType__BlockEnd (120)<br/>BlockEnd<br/>"]
+    q121["PrimitiveType_Type_string (121)<br/>Basic<br/>"]
+    q122["PrimitiveType__Basic_0 (122)<br/>Basic<br/>"]
+    q123["PrimitiveType_Type_bool (123)<br/>Basic<br/>"]
+    q124["PrimitiveType__Basic_1 (124)<br/>Basic<br/>"]
+    q125["PrimitiveType_Type_composite (125)<br/>Basic<br/>"]
+    q126["PrimitiveType__Basic_2 (126)<br/>Basic<br/>"]
+    q127{"PrimitiveType__Basic_3 (127)<br/>Basic<br/><br/>dec=7"}
+    q128["PrimitiveType__BlockEnd (128)<br/>BlockEnd<br/>"]
 
-    q14 --> q119
-    q113 -->|"tok(&quot;string&quot;)"| q114
-    q114 --> q120
-    q115 -->|"tok(&quot;bool&quot;)"| q116
-    q116 --> q120
-    q117 -->|"tok(&quot;composite&quot;)"| q118
-    q118 --> q120
-    q119 --> q113
-    q119 --> q115
-    q119 --> q117
-    q120 --> q15
+    q14 --> q127
+    q121 -->|"tok(&quot;string&quot;)"| q122
+    q122 --> q128
+    q123 -->|"tok(&quot;bool&quot;)"| q124
+    q124 --> q128
+    q125 -->|"tok(&quot;composite&quot;)"| q126
+    q126 --> q128
+    q127 --> q121
+    q127 --> q123
+    q127 --> q125
+    q128 --> q15
 ```
 
 ## ParserRule
@@ -238,37 +243,37 @@ flowchart TD
 flowchart TD
     q16(["ParserRule__Start (16)<br/>RuleStart"])
     q17(["ParserRule__Stop (17)<br/>RuleStop"])
-    q121["ParserRule_Entry_entry (121)<br/>Basic<br/>"]
-    q122["ParserRule__Basic_0 (122)<br/>Basic<br/>"]
-    q123{"ParserRule__Basic_1 (123)<br/>Basic<br/><br/>dec=8"}
-    q124["ParserRule_Name_ID (124)<br/>Basic<br/>"]
-    q125["ParserRule_returns (125)<br/>Basic<br/>"]
-    q126["ParserRule_ReturnType_ID (126)<br/>Basic<br/>"]
-    q127["ParserRule__Basic_2 (127)<br/>Basic<br/>"]
-    q128{"ParserRule__Basic_3 (128)<br/>Basic<br/><br/>dec=9"}
-    q129["ParserRule_Colon (129)<br/>Basic<br/>"]
-    q130["ParserRule__Basic_4 (130)<br/>Basic<br/>"]
-    q131["ParserRule_Semicolon (131)<br/>Basic<br/>"]
-    q132["ParserRule__Basic_5 (132)<br/>Basic<br/>"]
-    q133{"ParserRule__Basic_6 (133)<br/>Basic<br/><br/>dec=10"}
+    q129["ParserRule_Entry_entry (129)<br/>Basic<br/>"]
+    q130["ParserRule__Basic_0 (130)<br/>Basic<br/>"]
+    q131{"ParserRule__Basic_1 (131)<br/>Basic<br/><br/>dec=8"}
+    q132["ParserRule_Name_ID (132)<br/>Basic<br/>"]
+    q133["ParserRule_returns (133)<br/>Basic<br/>"]
+    q134["ParserRule_ReturnType_ID (134)<br/>Basic<br/>"]
+    q135["ParserRule__Basic_2 (135)<br/>Basic<br/>"]
+    q136{"ParserRule__Basic_3 (136)<br/>Basic<br/><br/>dec=9"}
+    q137["ParserRule_Colon (137)<br/>Basic<br/>"]
+    q138["ParserRule__Basic_4 (138)<br/>Basic<br/>"]
+    q139["ParserRule_Semicolon (139)<br/>Basic<br/>"]
+    q140["ParserRule__Basic_5 (140)<br/>Basic<br/>"]
+    q141{"ParserRule__Basic_6 (141)<br/>Basic<br/><br/>dec=10"}
 
-    q16 --> q123
-    q121 -->|"tok(&quot;entry&quot;)"| q122
-    q122 --> q124
-    q123 --> q121
-    q123 --> q122
-    q124 -->|"tok(ID)"| q128
-    q125 -->|"tok(&quot;returns&quot;)"| q126
-    q126 -->|"tok(ID)"| q127
-    q127 --> q129
-    q128 --> q125
-    q128 --> q127
-    q129 -->|"tok(&quot;:&quot;)"| q130
-    q130 -.->|"[Alternatives]"| q133
-    q131 -->|"tok(&quot;;&quot;)"| q132
-    q132 --> q17
-    q133 --> q131
-    q133 --> q132
+    q16 --> q131
+    q129 -->|"tok(&quot;entry&quot;)"| q130
+    q130 --> q132
+    q131 --> q129
+    q131 --> q130
+    q132 -->|"tok(ID)"| q136
+    q133 -->|"tok(&quot;returns&quot;)"| q134
+    q134 -->|"tok(ID)"| q135
+    q135 --> q137
+    q136 --> q133
+    q136 --> q135
+    q137 -->|"tok(&quot;:&quot;)"| q138
+    q138 -.->|"[Alternatives]"| q141
+    q139 -->|"tok(&quot;;&quot;)"| q140
+    q140 --> q17
+    q141 --> q139
+    q141 --> q140
 ```
 
 ## Token
@@ -277,39 +282,39 @@ flowchart TD
 flowchart TD
     q18(["Token__Start (18)<br/>RuleStart"])
     q19(["Token__Stop (19)<br/>RuleStop"])
-    q134["Token_Type_hidden (134)<br/>Basic<br/>"]
-    q135["Token__Basic_0 (135)<br/>Basic<br/>"]
-    q136["Token_Type_comment (136)<br/>Basic<br/>"]
-    q137["Token__Basic_1 (137)<br/>Basic<br/>"]
-    q138{"Token__Basic_2 (138)<br/>Basic<br/><br/>dec=11"}
-    q139["Token__BlockEnd (139)<br/>BlockEnd<br/>"]
-    q140{"Token__Basic_3 (140)<br/>Basic<br/><br/>dec=12"}
-    q141["Token_token (141)<br/>Basic<br/>"]
-    q142["Token_Name_ID (142)<br/>Basic<br/>"]
-    q143["Token_Colon (143)<br/>Basic<br/>"]
-    q144["Token_Regexp_RegexLiteral (144)<br/>Basic<br/>"]
-    q145["Token_Semicolon (145)<br/>Basic<br/>"]
-    q146["Token__Basic_4 (146)<br/>Basic<br/>"]
-    q147{"Token__Basic_5 (147)<br/>Basic<br/><br/>dec=13"}
+    q142["Token_Type_hidden (142)<br/>Basic<br/>"]
+    q143["Token__Basic_0 (143)<br/>Basic<br/>"]
+    q144["Token_Type_comment (144)<br/>Basic<br/>"]
+    q145["Token__Basic_1 (145)<br/>Basic<br/>"]
+    q146{"Token__Basic_2 (146)<br/>Basic<br/><br/>dec=11"}
+    q147["Token__BlockEnd (147)<br/>BlockEnd<br/>"]
+    q148{"Token__Basic_3 (148)<br/>Basic<br/><br/>dec=12"}
+    q149["Token_token (149)<br/>Basic<br/>"]
+    q150["Token_Name_ID (150)<br/>Basic<br/>"]
+    q151["Token_Colon (151)<br/>Basic<br/>"]
+    q152["Token_Regexp_RegexLiteral (152)<br/>Basic<br/>"]
+    q153["Token_Semicolon (153)<br/>Basic<br/>"]
+    q154["Token__Basic_4 (154)<br/>Basic<br/>"]
+    q155{"Token__Basic_5 (155)<br/>Basic<br/><br/>dec=13"}
 
-    q18 --> q140
-    q134 -->|"tok(&quot;hidden&quot;)"| q135
-    q135 --> q139
-    q136 -->|"tok(&quot;comment&quot;)"| q137
-    q137 --> q139
-    q138 --> q134
-    q138 --> q136
-    q139 --> q141
-    q140 --> q138
-    q140 --> q139
-    q141 -->|"tok(&quot;token&quot;)"| q142
-    q142 -->|"tok(ID)"| q143
-    q143 -->|"tok(&quot;:&quot;)"| q144
-    q144 -->|"tok(RegexLiteral)"| q147
-    q145 -->|"tok(&quot;;&quot;)"| q146
-    q146 --> q19
-    q147 --> q145
-    q147 --> q146
+    q18 --> q148
+    q142 -->|"tok(&quot;hidden&quot;)"| q143
+    q143 --> q147
+    q144 -->|"tok(&quot;comment&quot;)"| q145
+    q145 --> q147
+    q146 --> q142
+    q146 --> q144
+    q147 --> q149
+    q148 --> q146
+    q148 --> q147
+    q149 -->|"tok(&quot;token&quot;)"| q150
+    q150 -->|"tok(ID)"| q151
+    q151 -->|"tok(&quot;:&quot;)"| q152
+    q152 -->|"tok(RegexLiteral)"| q155
+    q153 -->|"tok(&quot;;&quot;)"| q154
+    q154 --> q19
+    q155 --> q153
+    q155 --> q154
 ```
 
 ## TokenGroup
@@ -318,47 +323,47 @@ flowchart TD
 flowchart TD
     q20(["TokenGroup__Start (20)<br/>RuleStart"])
     q21(["TokenGroup__Stop (21)<br/>RuleStop"])
-    q148["TokenGroup_token (148)<br/>Basic<br/>"]
-    q149["TokenGroup_group (149)<br/>Basic<br/>"]
-    q150["TokenGroup_Name_ID (150)<br/>Basic<br/>"]
-    q151["TokenGroup_LeftBrace (151)<br/>Basic<br/>"]
-    q152["TokenGroup_TokenRefs_ID (152)<br/>Basic<br/>"]
-    q153["TokenGroup__Basic_0 (153)<br/>Basic<br/>"]
-    q154["TokenGroup_keywords (154)<br/>Basic<br/>"]
-    q155["TokenGroup_Regexps_RegexLiteral (155)<br/>Basic<br/>"]
-    q156["TokenGroup__Basic_1 (156)<br/>Basic<br/>"]
-    q157["TokenGroup__Basic_2 (157)<br/>Basic<br/>"]
-    q158["TokenGroup__Basic_3 (158)<br/>Basic<br/>"]
-    q159{"TokenGroup__Basic_4 (159)<br/>Basic<br/><br/>dec=14"}
-    q160["TokenGroup__BlockEnd (160)<br/>BlockEnd<br/>"]
-    q161{"TokenGroup__LoopEntry (161)<br/>LoopEntry<br/><br/>dec=15"}
-    q162["TokenGroup__LoopEnd (162)<br/>LoopEnd<br/>"]
-    q163["TokenGroup__LoopBack (163)<br/>LoopBack<br/>"]
-    q164["TokenGroup_RightBrace (164)<br/>Basic<br/>"]
-    q165["TokenGroup__Basic_5 (165)<br/>Basic<br/>"]
+    q156["TokenGroup_token (156)<br/>Basic<br/>"]
+    q157["TokenGroup_group (157)<br/>Basic<br/>"]
+    q158["TokenGroup_Name_ID (158)<br/>Basic<br/>"]
+    q159["TokenGroup_LeftBrace (159)<br/>Basic<br/>"]
+    q160["TokenGroup_TokenRefs_ID (160)<br/>Basic<br/>"]
+    q161["TokenGroup__Basic_0 (161)<br/>Basic<br/>"]
+    q162["TokenGroup_keywords (162)<br/>Basic<br/>"]
+    q163["TokenGroup_Regexps_RegexLiteral (163)<br/>Basic<br/>"]
+    q164["TokenGroup__Basic_1 (164)<br/>Basic<br/>"]
+    q165["TokenGroup__Basic_2 (165)<br/>Basic<br/>"]
+    q166["TokenGroup__Basic_3 (166)<br/>Basic<br/>"]
+    q167{"TokenGroup__Basic_4 (167)<br/>Basic<br/><br/>dec=14"}
+    q168["TokenGroup__BlockEnd (168)<br/>BlockEnd<br/>"]
+    q169{"TokenGroup__LoopEntry (169)<br/>LoopEntry<br/><br/>dec=15"}
+    q170["TokenGroup__LoopEnd (170)<br/>LoopEnd<br/>"]
+    q171["TokenGroup__LoopBack (171)<br/>LoopBack<br/>"]
+    q172["TokenGroup_RightBrace (172)<br/>Basic<br/>"]
+    q173["TokenGroup__Basic_5 (173)<br/>Basic<br/>"]
 
-    q20 --> q148
-    q148 -->|"tok(&quot;token&quot;)"| q149
-    q149 -->|"tok(&quot;group&quot;)"| q150
-    q150 -->|"tok(ID)"| q151
-    q151 -->|"tok(&quot;{&quot;)"| q161
-    q152 -->|"tok(ID)"| q153
-    q153 --> q160
-    q154 -->|"tok(&quot;keywords&quot;)"| q155
-    q155 -->|"tok(RegexLiteral)"| q156
-    q156 --> q160
-    q157 -.->|"[Keyword]"| q158
-    q158 --> q160
-    q159 --> q152
-    q159 --> q154
-    q159 --> q157
-    q160 --> q163
-    q161 --> q159
-    q161 --> q162
-    q162 --> q164
-    q163 --> q161
-    q164 -->|"tok(&quot;}&quot;)"| q165
-    q165 --> q21
+    q20 --> q156
+    q156 -->|"tok(&quot;token&quot;)"| q157
+    q157 -->|"tok(&quot;group&quot;)"| q158
+    q158 -->|"tok(ID)"| q159
+    q159 -->|"tok(&quot;{&quot;)"| q169
+    q160 -->|"tok(ID)"| q161
+    q161 --> q168
+    q162 -->|"tok(&quot;keywords&quot;)"| q163
+    q163 -->|"tok(RegexLiteral)"| q164
+    q164 --> q168
+    q165 -.->|"[Keyword]"| q166
+    q166 --> q168
+    q167 --> q160
+    q167 --> q162
+    q167 --> q165
+    q168 --> q171
+    q169 --> q167
+    q169 --> q170
+    q170 --> q172
+    q171 --> q169
+    q172 -->|"tok(&quot;}&quot;)"| q173
+    q173 --> q21
 ```
 
 ## Alternatives
@@ -367,24 +372,24 @@ flowchart TD
 flowchart TD
     q22(["Alternatives__Start (22)<br/>RuleStart"])
     q23(["Alternatives__Stop (23)<br/>RuleStop"])
-    q166["Alternatives__Basic_0 (166)<br/>Basic<br/>"]
-    q167["Alternatives_Pipe (167)<br/>Basic<br/>"]
-    q168["Alternatives__Basic_1 (168)<br/>Basic<br/>"]
-    q169["Alternatives__Basic_2 (169)<br/>Basic<br/>"]
-    q170{"Alternatives__LoopBack (170)<br/>LoopBack<br/><br/>dec=16"}
-    q171["Alternatives__LoopEnd (171)<br/>LoopEnd<br/>"]
-    q172{"Alternatives__Basic_3 (172)<br/>Basic<br/><br/>dec=17"}
+    q174["Alternatives__Basic_0 (174)<br/>Basic<br/>"]
+    q175["Alternatives_Pipe (175)<br/>Basic<br/>"]
+    q176["Alternatives__Basic_1 (176)<br/>Basic<br/>"]
+    q177["Alternatives__Basic_2 (177)<br/>Basic<br/>"]
+    q178{"Alternatives__LoopBack (178)<br/>LoopBack<br/><br/>dec=16"}
+    q179["Alternatives__LoopEnd (179)<br/>LoopEnd<br/>"]
+    q180{"Alternatives__Basic_3 (180)<br/>Basic<br/><br/>dec=17"}
 
-    q22 --> q166
-    q166 -.->|"[Group]"| q172
-    q167 -->|"tok(&quot;|&quot;)"| q168
-    q168 -.->|"[Group]"| q169
-    q169 --> q170
-    q170 --> q167
-    q170 --> q171
-    q171 --> q23
-    q172 --> q167
-    q172 --> q171
+    q22 --> q174
+    q174 -.->|"[Group]"| q180
+    q175 -->|"tok(&quot;|&quot;)"| q176
+    q176 -.->|"[Group]"| q177
+    q177 --> q178
+    q178 --> q175
+    q178 --> q179
+    q179 --> q23
+    q180 --> q175
+    q180 --> q179
 ```
 
 ## Group
@@ -393,22 +398,22 @@ flowchart TD
 flowchart TD
     q24(["Group__Start (24)<br/>RuleStart"])
     q25(["Group__Stop (25)<br/>RuleStop"])
-    q173["Group__Basic_0 (173)<br/>Basic<br/>"]
-    q174["Group__Basic_1 (174)<br/>Basic<br/>"]
-    q175["Group__Basic_2 (175)<br/>Basic<br/>"]
-    q176{"Group__LoopBack (176)<br/>LoopBack<br/><br/>dec=18"}
-    q177["Group__LoopEnd (177)<br/>LoopEnd<br/>"]
-    q178{"Group__Basic_3 (178)<br/>Basic<br/><br/>dec=19"}
+    q181["Group__Basic_0 (181)<br/>Basic<br/>"]
+    q182["Group__Basic_1 (182)<br/>Basic<br/>"]
+    q183["Group__Basic_2 (183)<br/>Basic<br/>"]
+    q184{"Group__LoopBack (184)<br/>LoopBack<br/><br/>dec=18"}
+    q185["Group__LoopEnd (185)<br/>LoopEnd<br/>"]
+    q186{"Group__Basic_3 (186)<br/>Basic<br/><br/>dec=19"}
 
-    q24 --> q173
-    q173 -.->|"[Element]"| q178
-    q174 -.->|"[Element]"| q175
-    q175 --> q176
-    q176 --> q174
-    q176 --> q177
-    q177 --> q25
-    q178 --> q174
-    q178 --> q177
+    q24 --> q181
+    q181 -.->|"[Element]"| q186
+    q182 -.->|"[Element]"| q183
+    q183 --> q184
+    q184 --> q182
+    q184 --> q185
+    q185 --> q25
+    q186 --> q182
+    q186 --> q185
 ```
 
 ## Element
@@ -417,61 +422,61 @@ flowchart TD
 flowchart TD
     q26(["Element__Start (26)<br/>RuleStart"])
     q27(["Element__Stop (27)<br/>RuleStop"])
-    q179["Element__Basic_0 (179)<br/>Basic<br/>"]
-    q180["Element__Basic_1 (180)<br/>Basic<br/>"]
-    q181["Element__Basic_2 (181)<br/>Basic<br/>"]
-    q182["Element__Basic_3 (182)<br/>Basic<br/>"]
-    q183["Element__Basic_4 (183)<br/>Basic<br/>"]
-    q184["Element__Basic_5 (184)<br/>Basic<br/>"]
-    q185["Element__Basic_6 (185)<br/>Basic<br/>"]
-    q186["Element__Basic_7 (186)<br/>Basic<br/>"]
-    q187["Element_LeftParen (187)<br/>Basic<br/>"]
-    q188["Element__Basic_8 (188)<br/>Basic<br/>"]
-    q189["Element_RightParen (189)<br/>Basic<br/>"]
-    q190["Element__Basic_9 (190)<br/>Basic<br/>"]
-    q191{"Element__Basic_10 (191)<br/>Basic<br/><br/>dec=20"}
-    q192["Element__BlockEnd_0 (192)<br/>BlockEnd<br/>"]
-    q193["Element_Cardinality_Asterisk (193)<br/>Basic<br/>"]
-    q194["Element__Basic_11 (194)<br/>Basic<br/>"]
-    q195["Element_Cardinality_Plus (195)<br/>Basic<br/>"]
-    q196["Element__Basic_12 (196)<br/>Basic<br/>"]
-    q197["Element_Cardinality_Question (197)<br/>Basic<br/>"]
-    q198["Element__Basic_13 (198)<br/>Basic<br/>"]
-    q199{"Element__Basic_14 (199)<br/>Basic<br/><br/>dec=21"}
-    q200["Element__BlockEnd_1 (200)<br/>BlockEnd<br/>"]
-    q201{"Element__Basic_15 (201)<br/>Basic<br/><br/>dec=22"}
+    q187["Element__Basic_0 (187)<br/>Basic<br/>"]
+    q188["Element__Basic_1 (188)<br/>Basic<br/>"]
+    q189["Element__Basic_2 (189)<br/>Basic<br/>"]
+    q190["Element__Basic_3 (190)<br/>Basic<br/>"]
+    q191["Element__Basic_4 (191)<br/>Basic<br/>"]
+    q192["Element__Basic_5 (192)<br/>Basic<br/>"]
+    q193["Element__Basic_6 (193)<br/>Basic<br/>"]
+    q194["Element__Basic_7 (194)<br/>Basic<br/>"]
+    q195["Element_LeftParen (195)<br/>Basic<br/>"]
+    q196["Element__Basic_8 (196)<br/>Basic<br/>"]
+    q197["Element_RightParen (197)<br/>Basic<br/>"]
+    q198["Element__Basic_9 (198)<br/>Basic<br/>"]
+    q199{"Element__Basic_10 (199)<br/>Basic<br/><br/>dec=20"}
+    q200["Element__BlockEnd_0 (200)<br/>BlockEnd<br/>"]
+    q201["Element_Cardinality_Asterisk (201)<br/>Basic<br/>"]
+    q202["Element__Basic_11 (202)<br/>Basic<br/>"]
+    q203["Element_Cardinality_Plus (203)<br/>Basic<br/>"]
+    q204["Element__Basic_12 (204)<br/>Basic<br/>"]
+    q205["Element_Cardinality_Question (205)<br/>Basic<br/>"]
+    q206["Element__Basic_13 (206)<br/>Basic<br/>"]
+    q207{"Element__Basic_14 (207)<br/>Basic<br/><br/>dec=21"}
+    q208["Element__BlockEnd_1 (208)<br/>BlockEnd<br/>"]
+    q209{"Element__Basic_15 (209)<br/>Basic<br/><br/>dec=22"}
 
-    q26 --> q191
-    q179 -.->|"[Keyword]"| q180
-    q180 --> q192
-    q181 -.->|"[Assignment]"| q182
-    q182 --> q192
-    q183 -.->|"[RuleCall]"| q184
-    q184 --> q192
-    q185 -.->|"[Action]"| q186
-    q186 --> q192
-    q187 -->|"tok(&quot;(&quot;)"| q188
-    q188 -.->|"[Alternatives]"| q189
-    q189 -->|"tok(&quot;)&quot;)"| q190
-    q190 --> q192
-    q191 --> q179
-    q191 --> q181
-    q191 --> q183
-    q191 --> q185
-    q191 --> q187
-    q192 --> q201
-    q193 -->|"tok(&quot;*&quot;)"| q194
+    q26 --> q199
+    q187 -.->|"[Keyword]"| q188
+    q188 --> q200
+    q189 -.->|"[Assignment]"| q190
+    q190 --> q200
+    q191 -.->|"[RuleCall]"| q192
+    q192 --> q200
+    q193 -.->|"[Action]"| q194
     q194 --> q200
-    q195 -->|"tok(&quot;+&quot;)"| q196
-    q196 --> q200
-    q197 -->|"tok(&quot;?&quot;)"| q198
+    q195 -->|"tok(&quot;(&quot;)"| q196
+    q196 -.->|"[Alternatives]"| q197
+    q197 -->|"tok(&quot;)&quot;)"| q198
     q198 --> q200
+    q199 --> q187
+    q199 --> q189
+    q199 --> q191
     q199 --> q193
     q199 --> q195
-    q199 --> q197
-    q200 --> q27
-    q201 --> q199
-    q201 --> q200
+    q200 --> q209
+    q201 -->|"tok(&quot;*&quot;)"| q202
+    q202 --> q208
+    q203 -->|"tok(&quot;+&quot;)"| q204
+    q204 --> q208
+    q205 -->|"tok(&quot;?&quot;)"| q206
+    q206 --> q208
+    q207 --> q201
+    q207 --> q203
+    q207 --> q205
+    q208 --> q27
+    q209 --> q207
+    q209 --> q208
 ```
 
 ## Keyword
@@ -480,12 +485,12 @@ flowchart TD
 flowchart TD
     q28(["Keyword__Start (28)<br/>RuleStart"])
     q29(["Keyword__Stop (29)<br/>RuleStop"])
-    q202["Keyword_Value_StringLiteral (202)<br/>Basic<br/>"]
-    q203["Keyword__Basic (203)<br/>Basic<br/>"]
+    q210["Keyword_Value_StringLiteral (210)<br/>Basic<br/>"]
+    q211["Keyword__Basic (211)<br/>Basic<br/>"]
 
-    q28 --> q202
-    q202 -->|"tok(StringLiteral)"| q203
-    q203 --> q29
+    q28 --> q210
+    q210 -->|"tok(StringLiteral)"| q211
+    q211 --> q29
 ```
 
 ## Assignment
@@ -494,32 +499,32 @@ flowchart TD
 flowchart TD
     q30(["Assignment__Start (30)<br/>RuleStart"])
     q31(["Assignment__Stop (31)<br/>RuleStop"])
-    q204["Assignment_Property_ID (204)<br/>Basic<br/>"]
-    q205["Assignment_Operator_PlusEquals (205)<br/>Basic<br/>"]
-    q206["Assignment__Basic_0 (206)<br/>Basic<br/>"]
-    q207["Assignment_Operator_Equals (207)<br/>Basic<br/>"]
-    q208["Assignment__Basic_1 (208)<br/>Basic<br/>"]
-    q209["Assignment_Operator_QuestionEquals (209)<br/>Basic<br/>"]
-    q210["Assignment__Basic_2 (210)<br/>Basic<br/>"]
-    q211{"Assignment__Basic_3 (211)<br/>Basic<br/><br/>dec=23"}
-    q212["Assignment__BlockEnd (212)<br/>BlockEnd<br/>"]
-    q213["Assignment__Basic_4 (213)<br/>Basic<br/>"]
-    q214["Assignment__Basic_5 (214)<br/>Basic<br/>"]
+    q212["Assignment_Property_ID (212)<br/>Basic<br/>"]
+    q213["Assignment_Operator_PlusEquals (213)<br/>Basic<br/>"]
+    q214["Assignment__Basic_0 (214)<br/>Basic<br/>"]
+    q215["Assignment_Operator_Equals (215)<br/>Basic<br/>"]
+    q216["Assignment__Basic_1 (216)<br/>Basic<br/>"]
+    q217["Assignment_Operator_QuestionEquals (217)<br/>Basic<br/>"]
+    q218["Assignment__Basic_2 (218)<br/>Basic<br/>"]
+    q219{"Assignment__Basic_3 (219)<br/>Basic<br/><br/>dec=23"}
+    q220["Assignment__BlockEnd (220)<br/>BlockEnd<br/>"]
+    q221["Assignment__Basic_4 (221)<br/>Basic<br/>"]
+    q222["Assignment__Basic_5 (222)<br/>Basic<br/>"]
 
-    q30 --> q204
-    q204 -->|"tok(ID)"| q211
-    q205 -->|"tok(&quot;+=&quot;)"| q206
-    q206 --> q212
-    q207 -->|"tok(&quot;=&quot;)"| q208
-    q208 --> q212
-    q209 -->|"tok(&quot;?=&quot;)"| q210
-    q210 --> q212
-    q211 --> q205
-    q211 --> q207
-    q211 --> q209
-    q212 --> q213
-    q213 -.->|"[Assignable]"| q214
-    q214 --> q31
+    q30 --> q212
+    q212 -->|"tok(ID)"| q219
+    q213 -->|"tok(&quot;+=&quot;)"| q214
+    q214 --> q220
+    q215 -->|"tok(&quot;=&quot;)"| q216
+    q216 --> q220
+    q217 -->|"tok(&quot;?=&quot;)"| q218
+    q218 --> q220
+    q219 --> q213
+    q219 --> q215
+    q219 --> q217
+    q220 --> q221
+    q221 -.->|"[Assignable]"| q222
+    q222 --> q31
 ```
 
 ## Assignable
@@ -528,35 +533,35 @@ flowchart TD
 flowchart TD
     q32(["Assignable__Start (32)<br/>RuleStart"])
     q33(["Assignable__Stop (33)<br/>RuleStop"])
-    q215["Assignable__Basic_0 (215)<br/>Basic<br/>"]
-    q216["Assignable__Basic_1 (216)<br/>Basic<br/>"]
-    q217["Assignable__Basic_2 (217)<br/>Basic<br/>"]
-    q218["Assignable__Basic_3 (218)<br/>Basic<br/>"]
-    q219["Assignable__Basic_4 (219)<br/>Basic<br/>"]
-    q220["Assignable__Basic_5 (220)<br/>Basic<br/>"]
-    q221["Assignable_LeftParen (221)<br/>Basic<br/>"]
-    q222["Assignable__Basic_6 (222)<br/>Basic<br/>"]
-    q223["Assignable_RightParen (223)<br/>Basic<br/>"]
-    q224["Assignable__Basic_7 (224)<br/>Basic<br/>"]
-    q225{"Assignable__Basic_8 (225)<br/>Basic<br/><br/>dec=24"}
-    q226["Assignable__BlockEnd (226)<br/>BlockEnd<br/>"]
+    q223["Assignable__Basic_0 (223)<br/>Basic<br/>"]
+    q224["Assignable__Basic_1 (224)<br/>Basic<br/>"]
+    q225["Assignable__Basic_2 (225)<br/>Basic<br/>"]
+    q226["Assignable__Basic_3 (226)<br/>Basic<br/>"]
+    q227["Assignable__Basic_4 (227)<br/>Basic<br/>"]
+    q228["Assignable__Basic_5 (228)<br/>Basic<br/>"]
+    q229["Assignable_LeftParen (229)<br/>Basic<br/>"]
+    q230["Assignable__Basic_6 (230)<br/>Basic<br/>"]
+    q231["Assignable_RightParen (231)<br/>Basic<br/>"]
+    q232["Assignable__Basic_7 (232)<br/>Basic<br/>"]
+    q233{"Assignable__Basic_8 (233)<br/>Basic<br/><br/>dec=24"}
+    q234["Assignable__BlockEnd (234)<br/>BlockEnd<br/>"]
 
-    q32 --> q225
-    q215 -.->|"[Keyword]"| q216
-    q216 --> q226
-    q217 -.->|"[RuleCall]"| q218
-    q218 --> q226
-    q219 -.->|"[CrossRef]"| q220
-    q220 --> q226
-    q221 -->|"tok(&quot;(&quot;)"| q222
-    q222 -.->|"[AssignableAlternatives]"| q223
-    q223 -->|"tok(&quot;)&quot;)"| q224
-    q224 --> q226
-    q225 --> q215
-    q225 --> q217
-    q225 --> q219
-    q225 --> q221
-    q226 --> q33
+    q32 --> q233
+    q223 -.->|"[Keyword]"| q224
+    q224 --> q234
+    q225 -.->|"[RuleCall]"| q226
+    q226 --> q234
+    q227 -.->|"[CrossRef]"| q228
+    q228 --> q234
+    q229 -->|"tok(&quot;(&quot;)"| q230
+    q230 -.->|"[AssignableAlternatives]"| q231
+    q231 -->|"tok(&quot;)&quot;)"| q232
+    q232 --> q234
+    q233 --> q223
+    q233 --> q225
+    q233 --> q227
+    q233 --> q229
+    q234 --> q33
 ```
 
 ## AssignableWithoutAlts
@@ -565,26 +570,26 @@ flowchart TD
 flowchart TD
     q34(["AssignableWithoutAlts__Start (34)<br/>RuleStart"])
     q35(["AssignableWithoutAlts__Stop (35)<br/>RuleStop"])
-    q227["AssignableWithoutAlts__Basic_0 (227)<br/>Basic<br/>"]
-    q228["AssignableWithoutAlts__Basic_1 (228)<br/>Basic<br/>"]
-    q229["AssignableWithoutAlts__Basic_2 (229)<br/>Basic<br/>"]
-    q230["AssignableWithoutAlts__Basic_3 (230)<br/>Basic<br/>"]
-    q231["AssignableWithoutAlts__Basic_4 (231)<br/>Basic<br/>"]
-    q232["AssignableWithoutAlts__Basic_5 (232)<br/>Basic<br/>"]
-    q233{"AssignableWithoutAlts__Basic_6 (233)<br/>Basic<br/><br/>dec=25"}
-    q234["AssignableWithoutAlts__BlockEnd (234)<br/>BlockEnd<br/>"]
+    q235["AssignableWithoutAlts__Basic_0 (235)<br/>Basic<br/>"]
+    q236["AssignableWithoutAlts__Basic_1 (236)<br/>Basic<br/>"]
+    q237["AssignableWithoutAlts__Basic_2 (237)<br/>Basic<br/>"]
+    q238["AssignableWithoutAlts__Basic_3 (238)<br/>Basic<br/>"]
+    q239["AssignableWithoutAlts__Basic_4 (239)<br/>Basic<br/>"]
+    q240["AssignableWithoutAlts__Basic_5 (240)<br/>Basic<br/>"]
+    q241{"AssignableWithoutAlts__Basic_6 (241)<br/>Basic<br/><br/>dec=25"}
+    q242["AssignableWithoutAlts__BlockEnd (242)<br/>BlockEnd<br/>"]
 
-    q34 --> q233
-    q227 -.->|"[Keyword]"| q228
-    q228 --> q234
-    q229 -.->|"[RuleCall]"| q230
-    q230 --> q234
-    q231 -.->|"[CrossRef]"| q232
-    q232 --> q234
-    q233 --> q227
-    q233 --> q229
-    q233 --> q231
-    q234 --> q35
+    q34 --> q241
+    q235 -.->|"[Keyword]"| q236
+    q236 --> q242
+    q237 -.->|"[RuleCall]"| q238
+    q238 --> q242
+    q239 -.->|"[CrossRef]"| q240
+    q240 --> q242
+    q241 --> q235
+    q241 --> q237
+    q241 --> q239
+    q242 --> q35
 ```
 
 ## AssignableAlternatives
@@ -593,24 +598,24 @@ flowchart TD
 flowchart TD
     q36(["AssignableAlternatives__Start (36)<br/>RuleStart"])
     q37(["AssignableAlternatives__Stop (37)<br/>RuleStop"])
-    q235["AssignableAlternatives__Basic_0 (235)<br/>Basic<br/>"]
-    q236["AssignableAlternatives_Pipe (236)<br/>Basic<br/>"]
-    q237["AssignableAlternatives__Basic_1 (237)<br/>Basic<br/>"]
-    q238["AssignableAlternatives__Basic_2 (238)<br/>Basic<br/>"]
-    q239{"AssignableAlternatives__LoopBack (239)<br/>LoopBack<br/><br/>dec=26"}
-    q240["AssignableAlternatives__LoopEnd (240)<br/>LoopEnd<br/>"]
-    q241{"AssignableAlternatives__Basic_3 (241)<br/>Basic<br/><br/>dec=27"}
+    q243["AssignableAlternatives__Basic_0 (243)<br/>Basic<br/>"]
+    q244["AssignableAlternatives_Pipe (244)<br/>Basic<br/>"]
+    q245["AssignableAlternatives__Basic_1 (245)<br/>Basic<br/>"]
+    q246["AssignableAlternatives__Basic_2 (246)<br/>Basic<br/>"]
+    q247{"AssignableAlternatives__LoopBack (247)<br/>LoopBack<br/><br/>dec=26"}
+    q248["AssignableAlternatives__LoopEnd (248)<br/>LoopEnd<br/>"]
+    q249{"AssignableAlternatives__Basic_3 (249)<br/>Basic<br/><br/>dec=27"}
 
-    q36 --> q235
-    q235 -.->|"[AssignableWithoutAlts]"| q241
-    q236 -->|"tok(&quot;|&quot;)"| q237
-    q237 -.->|"[AssignableWithoutAlts]"| q238
-    q238 --> q239
-    q239 --> q236
-    q239 --> q240
-    q240 --> q37
-    q241 --> q236
-    q241 --> q240
+    q36 --> q243
+    q243 -.->|"[AssignableWithoutAlts]"| q249
+    q244 -->|"tok(&quot;|&quot;)"| q245
+    q245 -.->|"[AssignableWithoutAlts]"| q246
+    q246 --> q247
+    q247 --> q244
+    q247 --> q248
+    q248 --> q37
+    q249 --> q244
+    q249 --> q248
 ```
 
 ## CrossRef
@@ -619,25 +624,25 @@ flowchart TD
 flowchart TD
     q38(["CrossRef__Start (38)<br/>RuleStart"])
     q39(["CrossRef__Stop (39)<br/>RuleStop"])
-    q242["CrossRef_LeftBracket (242)<br/>Basic<br/>"]
-    q243["CrossRef_Type_ID (243)<br/>Basic<br/>"]
-    q244["CrossRef_Colon (244)<br/>Basic<br/>"]
-    q245["CrossRef__Basic_0 (245)<br/>Basic<br/>"]
-    q246["CrossRef__Basic_1 (246)<br/>Basic<br/>"]
-    q247{"CrossRef__Basic_2 (247)<br/>Basic<br/><br/>dec=28"}
-    q248["CrossRef_RightBracket (248)<br/>Basic<br/>"]
-    q249["CrossRef__Basic_3 (249)<br/>Basic<br/>"]
+    q250["CrossRef_LeftBracket (250)<br/>Basic<br/>"]
+    q251["CrossRef_Type_ID (251)<br/>Basic<br/>"]
+    q252["CrossRef_Colon (252)<br/>Basic<br/>"]
+    q253["CrossRef__Basic_0 (253)<br/>Basic<br/>"]
+    q254["CrossRef__Basic_1 (254)<br/>Basic<br/>"]
+    q255{"CrossRef__Basic_2 (255)<br/>Basic<br/><br/>dec=28"}
+    q256["CrossRef_RightBracket (256)<br/>Basic<br/>"]
+    q257["CrossRef__Basic_3 (257)<br/>Basic<br/>"]
 
-    q38 --> q242
-    q242 -->|"tok(&quot;[&quot;)"| q243
-    q243 -->|"tok(ID)"| q247
-    q244 -->|"tok(&quot;:&quot;)"| q245
-    q245 -.->|"[RuleCall]"| q246
-    q246 --> q248
-    q247 --> q244
-    q247 --> q246
-    q248 -->|"tok(&quot;]&quot;)"| q249
-    q249 --> q39
+    q38 --> q250
+    q250 -->|"tok(&quot;[&quot;)"| q251
+    q251 -->|"tok(ID)"| q255
+    q252 -->|"tok(&quot;:&quot;)"| q253
+    q253 -.->|"[RuleCall]"| q254
+    q254 --> q256
+    q255 --> q252
+    q255 --> q254
+    q256 -->|"tok(&quot;]&quot;)"| q257
+    q257 --> q39
 ```
 
 ## RuleCall
@@ -646,12 +651,12 @@ flowchart TD
 flowchart TD
     q40(["RuleCall__Start (40)<br/>RuleStart"])
     q41(["RuleCall__Stop (41)<br/>RuleStop"])
-    q250["RuleCall_Rule_ID (250)<br/>Basic<br/>"]
-    q251["RuleCall__Basic (251)<br/>Basic<br/>"]
+    q258["RuleCall_Rule_ID (258)<br/>Basic<br/>"]
+    q259["RuleCall__Basic (259)<br/>Basic<br/>"]
 
-    q40 --> q250
-    q250 -->|"tok(ID)"| q251
-    q251 --> q41
+    q40 --> q258
+    q258 -->|"tok(ID)"| q259
+    q259 --> q41
 ```
 
 ## Action
@@ -660,40 +665,40 @@ flowchart TD
 flowchart TD
     q42(["Action__Start (42)<br/>RuleStart"])
     q43(["Action__Stop (43)<br/>RuleStop"])
-    q252["Action_LeftBrace (252)<br/>Basic<br/>"]
-    q253["Action_Type_ID (253)<br/>Basic<br/>"]
-    q254["Action_Dot (254)<br/>Basic<br/>"]
-    q255["Action_Property_ID (255)<br/>Basic<br/>"]
-    q256["Action_Operator_PlusEquals (256)<br/>Basic<br/>"]
-    q257["Action__Basic_0 (257)<br/>Basic<br/>"]
-    q258["Action_Operator_Equals (258)<br/>Basic<br/>"]
-    q259["Action__Basic_1 (259)<br/>Basic<br/>"]
-    q260{"Action__Basic_2 (260)<br/>Basic<br/><br/>dec=29"}
-    q261["Action__BlockEnd (261)<br/>BlockEnd<br/>"]
-    q262["Action_current (262)<br/>Basic<br/>"]
-    q263["Action__Basic_3 (263)<br/>Basic<br/>"]
-    q264{"Action__Basic_4 (264)<br/>Basic<br/><br/>dec=30"}
-    q265["Action_RightBrace (265)<br/>Basic<br/>"]
-    q266["Action__Basic_5 (266)<br/>Basic<br/>"]
+    q260["Action_LeftBrace (260)<br/>Basic<br/>"]
+    q261["Action_Type_ID (261)<br/>Basic<br/>"]
+    q262["Action_Dot (262)<br/>Basic<br/>"]
+    q263["Action_Property_ID (263)<br/>Basic<br/>"]
+    q264["Action_Operator_PlusEquals (264)<br/>Basic<br/>"]
+    q265["Action__Basic_0 (265)<br/>Basic<br/>"]
+    q266["Action_Operator_Equals (266)<br/>Basic<br/>"]
+    q267["Action__Basic_1 (267)<br/>Basic<br/>"]
+    q268{"Action__Basic_2 (268)<br/>Basic<br/><br/>dec=29"}
+    q269["Action__BlockEnd (269)<br/>BlockEnd<br/>"]
+    q270["Action_current (270)<br/>Basic<br/>"]
+    q271["Action__Basic_3 (271)<br/>Basic<br/>"]
+    q272{"Action__Basic_4 (272)<br/>Basic<br/><br/>dec=30"}
+    q273["Action_RightBrace (273)<br/>Basic<br/>"]
+    q274["Action__Basic_5 (274)<br/>Basic<br/>"]
 
-    q42 --> q252
-    q252 -->|"tok(&quot;{&quot;)"| q253
-    q253 -->|"tok(ID)"| q264
-    q254 -->|"tok(&quot;.&quot;)"| q255
-    q255 -->|"tok(ID)"| q260
-    q256 -->|"tok(&quot;+=&quot;)"| q257
-    q257 --> q261
-    q258 -->|"tok(&quot;=&quot;)"| q259
-    q259 --> q261
-    q260 --> q256
-    q260 --> q258
-    q261 --> q262
-    q262 -->|"tok(&quot;current&quot;)"| q263
-    q263 --> q265
-    q264 --> q254
-    q264 --> q263
-    q265 -->|"tok(&quot;}&quot;)"| q266
-    q266 --> q43
+    q42 --> q260
+    q260 -->|"tok(&quot;{&quot;)"| q261
+    q261 -->|"tok(ID)"| q272
+    q262 -->|"tok(&quot;.&quot;)"| q263
+    q263 -->|"tok(ID)"| q268
+    q264 -->|"tok(&quot;+=&quot;)"| q265
+    q265 --> q269
+    q266 -->|"tok(&quot;=&quot;)"| q267
+    q267 --> q269
+    q268 --> q264
+    q268 --> q266
+    q269 --> q270
+    q270 -->|"tok(&quot;current&quot;)"| q271
+    q271 --> q273
+    q272 --> q262
+    q272 --> q271
+    q273 -->|"tok(&quot;}&quot;)"| q274
+    q274 --> q43
 ```
 
 ## CompositeRule
@@ -702,23 +707,23 @@ flowchart TD
 flowchart TD
     q44(["CompositeRule__Start (44)<br/>RuleStart"])
     q45(["CompositeRule__Stop (45)<br/>RuleStop"])
-    q267["CompositeRule_composite (267)<br/>Basic<br/>"]
-    q268["CompositeRule_Name_ID (268)<br/>Basic<br/>"]
-    q269["CompositeRule_Colon (269)<br/>Basic<br/>"]
-    q270["CompositeRule__Basic_0 (270)<br/>Basic<br/>"]
-    q271["CompositeRule_Semicolon (271)<br/>Basic<br/>"]
-    q272["CompositeRule__Basic_1 (272)<br/>Basic<br/>"]
-    q273{"CompositeRule__Basic_2 (273)<br/>Basic<br/><br/>dec=31"}
+    q275["CompositeRule_composite (275)<br/>Basic<br/>"]
+    q276["CompositeRule_Name_ID (276)<br/>Basic<br/>"]
+    q277["CompositeRule_Colon (277)<br/>Basic<br/>"]
+    q278["CompositeRule__Basic_0 (278)<br/>Basic<br/>"]
+    q279["CompositeRule_Semicolon (279)<br/>Basic<br/>"]
+    q280["CompositeRule__Basic_1 (280)<br/>Basic<br/>"]
+    q281{"CompositeRule__Basic_2 (281)<br/>Basic<br/><br/>dec=31"}
 
-    q44 --> q267
-    q267 -->|"tok(&quot;composite&quot;)"| q268
-    q268 -->|"tok(ID)"| q269
-    q269 -->|"tok(&quot;:&quot;)"| q270
-    q270 -.->|"[CompositeAlternatives]"| q273
-    q271 -->|"tok(&quot;;&quot;)"| q272
-    q272 --> q45
-    q273 --> q271
-    q273 --> q272
+    q44 --> q275
+    q275 -->|"tok(&quot;composite&quot;)"| q276
+    q276 -->|"tok(ID)"| q277
+    q277 -->|"tok(&quot;:&quot;)"| q278
+    q278 -.->|"[CompositeAlternatives]"| q281
+    q279 -->|"tok(&quot;;&quot;)"| q280
+    q280 --> q45
+    q281 --> q279
+    q281 --> q280
 ```
 
 ## CompositeAlternatives
@@ -727,24 +732,24 @@ flowchart TD
 flowchart TD
     q46(["CompositeAlternatives__Start (46)<br/>RuleStart"])
     q47(["CompositeAlternatives__Stop (47)<br/>RuleStop"])
-    q274["CompositeAlternatives__Basic_0 (274)<br/>Basic<br/>"]
-    q275["CompositeAlternatives_Pipe (275)<br/>Basic<br/>"]
-    q276["CompositeAlternatives__Basic_1 (276)<br/>Basic<br/>"]
-    q277["CompositeAlternatives__Basic_2 (277)<br/>Basic<br/>"]
-    q278{"CompositeAlternatives__LoopBack (278)<br/>LoopBack<br/><br/>dec=32"}
-    q279["CompositeAlternatives__LoopEnd (279)<br/>LoopEnd<br/>"]
-    q280{"CompositeAlternatives__Basic_3 (280)<br/>Basic<br/><br/>dec=33"}
+    q282["CompositeAlternatives__Basic_0 (282)<br/>Basic<br/>"]
+    q283["CompositeAlternatives_Pipe (283)<br/>Basic<br/>"]
+    q284["CompositeAlternatives__Basic_1 (284)<br/>Basic<br/>"]
+    q285["CompositeAlternatives__Basic_2 (285)<br/>Basic<br/>"]
+    q286{"CompositeAlternatives__LoopBack (286)<br/>LoopBack<br/><br/>dec=32"}
+    q287["CompositeAlternatives__LoopEnd (287)<br/>LoopEnd<br/>"]
+    q288{"CompositeAlternatives__Basic_3 (288)<br/>Basic<br/><br/>dec=33"}
 
-    q46 --> q274
-    q274 -.->|"[CompositeGroup]"| q280
-    q275 -->|"tok(&quot;|&quot;)"| q276
-    q276 -.->|"[CompositeGroup]"| q277
-    q277 --> q278
-    q278 --> q275
-    q278 --> q279
-    q279 --> q47
-    q280 --> q275
-    q280 --> q279
+    q46 --> q282
+    q282 -.->|"[CompositeGroup]"| q288
+    q283 -->|"tok(&quot;|&quot;)"| q284
+    q284 -.->|"[CompositeGroup]"| q285
+    q285 --> q286
+    q286 --> q283
+    q286 --> q287
+    q287 --> q47
+    q288 --> q283
+    q288 --> q287
 ```
 
 ## CompositeGroup
@@ -753,22 +758,22 @@ flowchart TD
 flowchart TD
     q48(["CompositeGroup__Start (48)<br/>RuleStart"])
     q49(["CompositeGroup__Stop (49)<br/>RuleStop"])
-    q281["CompositeGroup__Basic_0 (281)<br/>Basic<br/>"]
-    q282["CompositeGroup__Basic_1 (282)<br/>Basic<br/>"]
-    q283["CompositeGroup__Basic_2 (283)<br/>Basic<br/>"]
-    q284{"CompositeGroup__LoopBack (284)<br/>LoopBack<br/><br/>dec=34"}
-    q285["CompositeGroup__LoopEnd (285)<br/>LoopEnd<br/>"]
-    q286{"CompositeGroup__Basic_3 (286)<br/>Basic<br/><br/>dec=35"}
+    q289["CompositeGroup__Basic_0 (289)<br/>Basic<br/>"]
+    q290["CompositeGroup__Basic_1 (290)<br/>Basic<br/>"]
+    q291["CompositeGroup__Basic_2 (291)<br/>Basic<br/>"]
+    q292{"CompositeGroup__LoopBack (292)<br/>LoopBack<br/><br/>dec=34"}
+    q293["CompositeGroup__LoopEnd (293)<br/>LoopEnd<br/>"]
+    q294{"CompositeGroup__Basic_3 (294)<br/>Basic<br/><br/>dec=35"}
 
-    q48 --> q281
-    q281 -.->|"[CompositeElement]"| q286
-    q282 -.->|"[CompositeElement]"| q283
-    q283 --> q284
-    q284 --> q282
-    q284 --> q285
-    q285 --> q49
-    q286 --> q282
-    q286 --> q285
+    q48 --> q289
+    q289 -.->|"[CompositeElement]"| q294
+    q290 -.->|"[CompositeElement]"| q291
+    q291 --> q292
+    q292 --> q290
+    q292 --> q293
+    q293 --> q49
+    q294 --> q290
+    q294 --> q293
 ```
 
 ## CompositeElement
@@ -777,50 +782,169 @@ flowchart TD
 flowchart TD
     q50(["CompositeElement__Start (50)<br/>RuleStart"])
     q51(["CompositeElement__Stop (51)<br/>RuleStop"])
-    q287["CompositeElement__Basic_0 (287)<br/>Basic<br/>"]
-    q288["CompositeElement__Basic_1 (288)<br/>Basic<br/>"]
-    q289["CompositeElement__Basic_2 (289)<br/>Basic<br/>"]
-    q290["CompositeElement__Basic_3 (290)<br/>Basic<br/>"]
-    q291["CompositeElement_LeftParen (291)<br/>Basic<br/>"]
-    q292["CompositeElement__Basic_4 (292)<br/>Basic<br/>"]
-    q293["CompositeElement_RightParen (293)<br/>Basic<br/>"]
-    q294["CompositeElement__Basic_5 (294)<br/>Basic<br/>"]
-    q295{"CompositeElement__Basic_6 (295)<br/>Basic<br/><br/>dec=36"}
-    q296["CompositeElement__BlockEnd_0 (296)<br/>BlockEnd<br/>"]
-    q297["CompositeElement_Cardinality_Asterisk (297)<br/>Basic<br/>"]
-    q298["CompositeElement__Basic_7 (298)<br/>Basic<br/>"]
-    q299["CompositeElement_Cardinality_Plus (299)<br/>Basic<br/>"]
-    q300["CompositeElement__Basic_8 (300)<br/>Basic<br/>"]
-    q301["CompositeElement_Cardinality_Question (301)<br/>Basic<br/>"]
-    q302["CompositeElement__Basic_9 (302)<br/>Basic<br/>"]
-    q303{"CompositeElement__Basic_10 (303)<br/>Basic<br/><br/>dec=37"}
-    q304["CompositeElement__BlockEnd_1 (304)<br/>BlockEnd<br/>"]
-    q305{"CompositeElement__Basic_11 (305)<br/>Basic<br/><br/>dec=38"}
+    q295["CompositeElement__Basic_0 (295)<br/>Basic<br/>"]
+    q296["CompositeElement__Basic_1 (296)<br/>Basic<br/>"]
+    q297["CompositeElement__Basic_2 (297)<br/>Basic<br/>"]
+    q298["CompositeElement__Basic_3 (298)<br/>Basic<br/>"]
+    q299["CompositeElement_LeftParen (299)<br/>Basic<br/>"]
+    q300["CompositeElement__Basic_4 (300)<br/>Basic<br/>"]
+    q301["CompositeElement_RightParen (301)<br/>Basic<br/>"]
+    q302["CompositeElement__Basic_5 (302)<br/>Basic<br/>"]
+    q303{"CompositeElement__Basic_6 (303)<br/>Basic<br/><br/>dec=36"}
+    q304["CompositeElement__BlockEnd_0 (304)<br/>BlockEnd<br/>"]
+    q305["CompositeElement_Cardinality_Asterisk (305)<br/>Basic<br/>"]
+    q306["CompositeElement__Basic_7 (306)<br/>Basic<br/>"]
+    q307["CompositeElement_Cardinality_Plus (307)<br/>Basic<br/>"]
+    q308["CompositeElement__Basic_8 (308)<br/>Basic<br/>"]
+    q309["CompositeElement_Cardinality_Question (309)<br/>Basic<br/>"]
+    q310["CompositeElement__Basic_9 (310)<br/>Basic<br/>"]
+    q311{"CompositeElement__Basic_10 (311)<br/>Basic<br/><br/>dec=37"}
+    q312["CompositeElement__BlockEnd_1 (312)<br/>BlockEnd<br/>"]
+    q313{"CompositeElement__Basic_11 (313)<br/>Basic<br/><br/>dec=38"}
 
-    q50 --> q295
-    q287 -.->|"[Keyword]"| q288
-    q288 --> q296
-    q289 -.->|"[RuleCall]"| q290
-    q290 --> q296
-    q291 -->|"tok(&quot;(&quot;)"| q292
-    q292 -.->|"[CompositeAlternatives]"| q293
-    q293 -->|"tok(&quot;)&quot;)"| q294
-    q294 --> q296
-    q295 --> q287
-    q295 --> q289
-    q295 --> q291
-    q296 --> q305
-    q297 -->|"tok(&quot;*&quot;)"| q298
+    q50 --> q303
+    q295 -.->|"[Keyword]"| q296
+    q296 --> q304
+    q297 -.->|"[RuleCall]"| q298
     q298 --> q304
-    q299 -->|"tok(&quot;+&quot;)"| q300
-    q300 --> q304
-    q301 -->|"tok(&quot;?&quot;)"| q302
+    q299 -->|"tok(&quot;(&quot;)"| q300
+    q300 -.->|"[CompositeAlternatives]"| q301
+    q301 -->|"tok(&quot;)&quot;)"| q302
     q302 --> q304
+    q303 --> q295
     q303 --> q297
     q303 --> q299
-    q303 --> q301
-    q304 --> q51
-    q305 --> q303
-    q305 --> q304
+    q304 --> q313
+    q305 -->|"tok(&quot;*&quot;)"| q306
+    q306 --> q312
+    q307 -->|"tok(&quot;+&quot;)"| q308
+    q308 --> q312
+    q309 -->|"tok(&quot;?&quot;)"| q310
+    q310 --> q312
+    q311 --> q305
+    q311 --> q307
+    q311 --> q309
+    q312 --> q51
+    q313 --> q311
+    q313 --> q312
+```
+
+## InfixRule
+
+```mermaid
+flowchart TD
+    q52(["InfixRule__Start (52)<br/>RuleStart"])
+    q53(["InfixRule__Stop (53)<br/>RuleStop"])
+    q314["InfixRule_infix (314)<br/>Basic<br/>"]
+    q315["InfixRule_Name_ID (315)<br/>Basic<br/>"]
+    q316["InfixRule_on (316)<br/>Basic<br/>"]
+    q317["InfixRule__Basic_0 (317)<br/>Basic<br/>"]
+    q318["InfixRule_returns (318)<br/>Basic<br/>"]
+    q319["InfixRule_ReturnType_ID (319)<br/>Basic<br/>"]
+    q320["InfixRule__Basic_1 (320)<br/>Basic<br/>"]
+    q321{"InfixRule__Basic_2 (321)<br/>Basic<br/><br/>dec=39"}
+    q322["InfixRule_Colon (322)<br/>Basic<br/>"]
+    q323["InfixRule__Basic_3 (323)<br/>Basic<br/>"]
+    q324["InfixRule_GreaterThan (324)<br/>Basic<br/>"]
+    q325["InfixRule__Basic_4 (325)<br/>Basic<br/>"]
+    q326["InfixRule__Basic_5 (326)<br/>Basic<br/>"]
+    q327{"InfixRule__LoopEntry (327)<br/>LoopEntry<br/><br/>dec=40"}
+    q328["InfixRule__LoopEnd (328)<br/>LoopEnd<br/>"]
+    q329["InfixRule__LoopBack (329)<br/>LoopBack<br/>"]
+    q330["InfixRule_Semicolon (330)<br/>Basic<br/>"]
+    q331["InfixRule__Basic_6 (331)<br/>Basic<br/>"]
+    q332{"InfixRule__Basic_7 (332)<br/>Basic<br/><br/>dec=41"}
+
+    q52 --> q314
+    q314 -->|"tok(&quot;infix&quot;)"| q315
+    q315 -->|"tok(ID)"| q316
+    q316 -->|"tok(&quot;on&quot;)"| q317
+    q317 -.->|"[RuleCall]"| q321
+    q318 -->|"tok(&quot;returns&quot;)"| q319
+    q319 -->|"tok(ID)"| q320
+    q320 --> q322
+    q321 --> q318
+    q321 --> q320
+    q322 -->|"tok(&quot;:&quot;)"| q323
+    q323 -.->|"[PrecedenceGroup]"| q327
+    q324 -->|"tok(&quot;>&quot;)"| q325
+    q325 -.->|"[PrecedenceGroup]"| q326
+    q326 --> q329
+    q327 --> q324
+    q327 --> q328
+    q328 --> q332
+    q329 --> q327
+    q330 -->|"tok(&quot;;&quot;)"| q331
+    q331 --> q53
+    q332 --> q330
+    q332 --> q331
+```
+
+## PrecedenceGroup
+
+```mermaid
+flowchart TD
+    q54(["PrecedenceGroup__Start (54)<br/>RuleStart"])
+    q55(["PrecedenceGroup__Stop (55)<br/>RuleStop"])
+    q333["PrecedenceGroup_Associativity_left (333)<br/>Basic<br/>"]
+    q334["PrecedenceGroup__Basic_0 (334)<br/>Basic<br/>"]
+    q335["PrecedenceGroup_Associativity_right (335)<br/>Basic<br/>"]
+    q336["PrecedenceGroup__Basic_1 (336)<br/>Basic<br/>"]
+    q337{"PrecedenceGroup__Basic_2 (337)<br/>Basic<br/><br/>dec=42"}
+    q338["PrecedenceGroup__BlockEnd (338)<br/>BlockEnd<br/>"]
+    q339["PrecedenceGroup_assoc (339)<br/>Basic<br/>"]
+    q340["PrecedenceGroup__Basic_3 (340)<br/>Basic<br/>"]
+    q341{"PrecedenceGroup__Basic_4 (341)<br/>Basic<br/><br/>dec=43"}
+    q342["PrecedenceGroup__Basic_5 (342)<br/>Basic<br/>"]
+    q343["PrecedenceGroup_Pipe (343)<br/>Basic<br/>"]
+    q344["PrecedenceGroup__Basic_6 (344)<br/>Basic<br/>"]
+    q345["PrecedenceGroup__Basic_7 (345)<br/>Basic<br/>"]
+    q346{"PrecedenceGroup__LoopEntry (346)<br/>LoopEntry<br/><br/>dec=44"}
+    q347["PrecedenceGroup__LoopEnd (347)<br/>LoopEnd<br/>"]
+    q348["PrecedenceGroup__LoopBack (348)<br/>LoopBack<br/>"]
+
+    q54 --> q341
+    q333 -->|"tok(&quot;left&quot;)"| q334
+    q334 --> q338
+    q335 -->|"tok(&quot;right&quot;)"| q336
+    q336 --> q338
+    q337 --> q333
+    q337 --> q335
+    q338 --> q339
+    q339 -->|"tok(&quot;assoc&quot;)"| q340
+    q340 --> q342
+    q341 --> q337
+    q341 --> q340
+    q342 -.->|"[InfixOperator]"| q346
+    q343 -->|"tok(&quot;|&quot;)"| q344
+    q344 -.->|"[InfixOperator]"| q345
+    q345 --> q348
+    q346 --> q343
+    q346 --> q347
+    q347 --> q55
+    q348 --> q346
+```
+
+## InfixOperator
+
+```mermaid
+flowchart TD
+    q56(["InfixOperator__Start (56)<br/>RuleStart"])
+    q57(["InfixOperator__Stop (57)<br/>RuleStop"])
+    q349["InfixOperator__Basic_0 (349)<br/>Basic<br/>"]
+    q350["InfixOperator__Basic_1 (350)<br/>Basic<br/>"]
+    q351["InfixOperator__Basic_2 (351)<br/>Basic<br/>"]
+    q352["InfixOperator__Basic_3 (352)<br/>Basic<br/>"]
+    q353{"InfixOperator__Basic_4 (353)<br/>Basic<br/><br/>dec=45"}
+    q354["InfixOperator__BlockEnd (354)<br/>BlockEnd<br/>"]
+
+    q56 --> q353
+    q349 -.->|"[Keyword]"| q350
+    q350 --> q354
+    q351 -.->|"[RuleCall]"| q352
+    q352 --> q354
+    q353 --> q349
+    q353 --> q351
+    q354 --> q57
 ```
 

--- a/internal/grammar/atn_gen.go
+++ b/internal/grammar/atn_gen.go
@@ -60,6 +60,12 @@ const (
 	CompositeGroup__Stop
 	CompositeElement__Start
 	CompositeElement__Stop
+	InfixRule__Start
+	InfixRule__Stop
+	PrecedenceGroup__Start
+	PrecedenceGroup__Stop
+	InfixOperator__Start
+	InfixOperator__Stop
 	Grammar_grammar
 	Grammar_Name_ID
 	Grammar_Semicolon
@@ -76,6 +82,8 @@ const (
 	Grammar__Basic_10
 	Grammar__Basic_11
 	Grammar__Basic_12
+	Grammar__Basic_13
+	Grammar__Basic_14
 	Grammar__BlockEnd
 	Grammar__LoopEntry
 	Grammar__LoopEnd
@@ -314,6 +322,47 @@ const (
 	CompositeElement__Basic_10
 	CompositeElement__BlockEnd_1
 	CompositeElement__Basic_11
+	InfixRule_infix
+	InfixRule_Name_ID
+	InfixRule_on
+	InfixRule__Basic_0
+	InfixRule_returns
+	InfixRule_ReturnType_ID
+	InfixRule__Basic_1
+	InfixRule__Basic_2
+	InfixRule_Colon
+	InfixRule__Basic_3
+	InfixRule_GreaterThan
+	InfixRule__Basic_4
+	InfixRule__Basic_5
+	InfixRule__LoopEntry
+	InfixRule__LoopEnd
+	InfixRule__LoopBack
+	InfixRule_Semicolon
+	InfixRule__Basic_6
+	InfixRule__Basic_7
+	PrecedenceGroup_Associativity_left
+	PrecedenceGroup__Basic_0
+	PrecedenceGroup_Associativity_right
+	PrecedenceGroup__Basic_1
+	PrecedenceGroup__Basic_2
+	PrecedenceGroup__BlockEnd
+	PrecedenceGroup_assoc
+	PrecedenceGroup__Basic_3
+	PrecedenceGroup__Basic_4
+	PrecedenceGroup__Basic_5
+	PrecedenceGroup_Pipe
+	PrecedenceGroup__Basic_6
+	PrecedenceGroup__Basic_7
+	PrecedenceGroup__LoopEntry
+	PrecedenceGroup__LoopEnd
+	PrecedenceGroup__LoopBack
+	InfixOperator__Basic_0
+	InfixOperator__Basic_1
+	InfixOperator__Basic_2
+	InfixOperator__Basic_3
+	InfixOperator__Basic_4
+	InfixOperator__BlockEnd
 )
 
 var once sync.Once
@@ -326,7 +375,7 @@ func ATN() *parser.RuntimeATN {
 	return atn
 }
 func BuildATN() *parser.RuntimeATN {
-	states := make([]*parser.RuntimeATNState, 306)
+	states := make([]*parser.RuntimeATNState, 355)
 	states[Grammar__Start] = parser.NewATNState(Grammar__Start, parser.ATNRuleStart, true)
 	states[Grammar__Stop] = parser.NewATNState(Grammar__Stop, parser.ATNRuleStop, false)
 	states[Interface__Start] = parser.NewATNState(Interface__Start, parser.ATNRuleStart, true)
@@ -379,6 +428,12 @@ func BuildATN() *parser.RuntimeATN {
 	states[CompositeGroup__Stop] = parser.NewATNState(CompositeGroup__Stop, parser.ATNRuleStop, false)
 	states[CompositeElement__Start] = parser.NewATNState(CompositeElement__Start, parser.ATNRuleStart, true)
 	states[CompositeElement__Stop] = parser.NewATNState(CompositeElement__Stop, parser.ATNRuleStop, false)
+	states[InfixRule__Start] = parser.NewATNState(InfixRule__Start, parser.ATNRuleStart, true)
+	states[InfixRule__Stop] = parser.NewATNState(InfixRule__Stop, parser.ATNRuleStop, false)
+	states[PrecedenceGroup__Start] = parser.NewATNState(PrecedenceGroup__Start, parser.ATNRuleStart, true)
+	states[PrecedenceGroup__Stop] = parser.NewATNState(PrecedenceGroup__Stop, parser.ATNRuleStop, false)
+	states[InfixOperator__Start] = parser.NewATNState(InfixOperator__Start, parser.ATNRuleStart, true)
+	states[InfixOperator__Stop] = parser.NewATNState(InfixOperator__Stop, parser.ATNRuleStop, false)
 	states[Grammar_grammar] = parser.NewATNState(Grammar_grammar, parser.ATNBasic, false)
 	states[Grammar_Name_ID] = parser.NewATNState(Grammar_Name_ID, parser.ATNBasic, false)
 	states[Grammar_Semicolon] = parser.NewATNState(Grammar_Semicolon, parser.ATNBasic, false)
@@ -394,7 +449,9 @@ func BuildATN() *parser.RuntimeATN {
 	states[Grammar__Basic_9] = parser.NewATNState(Grammar__Basic_9, parser.ATNBasic, true)
 	states[Grammar__Basic_10] = parser.NewATNState(Grammar__Basic_10, parser.ATNBasic, true)
 	states[Grammar__Basic_11] = parser.NewATNState(Grammar__Basic_11, parser.ATNBasic, true)
-	states[Grammar__Basic_12] = parser.NewATNState(Grammar__Basic_12, parser.ATNBasic, true).SetDecision(1)
+	states[Grammar__Basic_12] = parser.NewATNState(Grammar__Basic_12, parser.ATNBasic, true)
+	states[Grammar__Basic_13] = parser.NewATNState(Grammar__Basic_13, parser.ATNBasic, true)
+	states[Grammar__Basic_14] = parser.NewATNState(Grammar__Basic_14, parser.ATNBasic, true).SetDecision(1)
 	states[Grammar__BlockEnd] = parser.NewATNState(Grammar__BlockEnd, parser.ATNBlockEnd, true)
 	states[Grammar__LoopEntry] = parser.NewATNState(Grammar__LoopEntry, parser.ATNLoopEntry, true).SetDecision(2)
 	states[Grammar__LoopEnd] = parser.NewATNState(Grammar__LoopEnd, parser.ATNLoopEnd, true)
@@ -633,6 +690,47 @@ func BuildATN() *parser.RuntimeATN {
 	states[CompositeElement__Basic_10] = parser.NewATNState(CompositeElement__Basic_10, parser.ATNBasic, true).SetDecision(37)
 	states[CompositeElement__BlockEnd_1] = parser.NewATNState(CompositeElement__BlockEnd_1, parser.ATNBlockEnd, true)
 	states[CompositeElement__Basic_11] = parser.NewATNState(CompositeElement__Basic_11, parser.ATNBasic, true).SetDecision(38)
+	states[InfixRule_infix] = parser.NewATNState(InfixRule_infix, parser.ATNBasic, false)
+	states[InfixRule_Name_ID] = parser.NewATNState(InfixRule_Name_ID, parser.ATNBasic, false)
+	states[InfixRule_on] = parser.NewATNState(InfixRule_on, parser.ATNBasic, false)
+	states[InfixRule__Basic_0] = parser.NewATNState(InfixRule__Basic_0, parser.ATNBasic, true)
+	states[InfixRule_returns] = parser.NewATNState(InfixRule_returns, parser.ATNBasic, false)
+	states[InfixRule_ReturnType_ID] = parser.NewATNState(InfixRule_ReturnType_ID, parser.ATNBasic, false)
+	states[InfixRule__Basic_1] = parser.NewATNState(InfixRule__Basic_1, parser.ATNBasic, true)
+	states[InfixRule__Basic_2] = parser.NewATNState(InfixRule__Basic_2, parser.ATNBasic, true).SetDecision(39)
+	states[InfixRule_Colon] = parser.NewATNState(InfixRule_Colon, parser.ATNBasic, false)
+	states[InfixRule__Basic_3] = parser.NewATNState(InfixRule__Basic_3, parser.ATNBasic, true)
+	states[InfixRule_GreaterThan] = parser.NewATNState(InfixRule_GreaterThan, parser.ATNBasic, false)
+	states[InfixRule__Basic_4] = parser.NewATNState(InfixRule__Basic_4, parser.ATNBasic, true)
+	states[InfixRule__Basic_5] = parser.NewATNState(InfixRule__Basic_5, parser.ATNBasic, true)
+	states[InfixRule__LoopEntry] = parser.NewATNState(InfixRule__LoopEntry, parser.ATNLoopEntry, true).SetDecision(40)
+	states[InfixRule__LoopEnd] = parser.NewATNState(InfixRule__LoopEnd, parser.ATNLoopEnd, true)
+	states[InfixRule__LoopBack] = parser.NewATNState(InfixRule__LoopBack, parser.ATNLoopBack, true)
+	states[InfixRule_Semicolon] = parser.NewATNState(InfixRule_Semicolon, parser.ATNBasic, false)
+	states[InfixRule__Basic_6] = parser.NewATNState(InfixRule__Basic_6, parser.ATNBasic, true)
+	states[InfixRule__Basic_7] = parser.NewATNState(InfixRule__Basic_7, parser.ATNBasic, true).SetDecision(41)
+	states[PrecedenceGroup_Associativity_left] = parser.NewATNState(PrecedenceGroup_Associativity_left, parser.ATNBasic, false)
+	states[PrecedenceGroup__Basic_0] = parser.NewATNState(PrecedenceGroup__Basic_0, parser.ATNBasic, true)
+	states[PrecedenceGroup_Associativity_right] = parser.NewATNState(PrecedenceGroup_Associativity_right, parser.ATNBasic, false)
+	states[PrecedenceGroup__Basic_1] = parser.NewATNState(PrecedenceGroup__Basic_1, parser.ATNBasic, true)
+	states[PrecedenceGroup__Basic_2] = parser.NewATNState(PrecedenceGroup__Basic_2, parser.ATNBasic, true).SetDecision(42)
+	states[PrecedenceGroup__BlockEnd] = parser.NewATNState(PrecedenceGroup__BlockEnd, parser.ATNBlockEnd, true)
+	states[PrecedenceGroup_assoc] = parser.NewATNState(PrecedenceGroup_assoc, parser.ATNBasic, false)
+	states[PrecedenceGroup__Basic_3] = parser.NewATNState(PrecedenceGroup__Basic_3, parser.ATNBasic, true)
+	states[PrecedenceGroup__Basic_4] = parser.NewATNState(PrecedenceGroup__Basic_4, parser.ATNBasic, true).SetDecision(43)
+	states[PrecedenceGroup__Basic_5] = parser.NewATNState(PrecedenceGroup__Basic_5, parser.ATNBasic, true)
+	states[PrecedenceGroup_Pipe] = parser.NewATNState(PrecedenceGroup_Pipe, parser.ATNBasic, false)
+	states[PrecedenceGroup__Basic_6] = parser.NewATNState(PrecedenceGroup__Basic_6, parser.ATNBasic, true)
+	states[PrecedenceGroup__Basic_7] = parser.NewATNState(PrecedenceGroup__Basic_7, parser.ATNBasic, true)
+	states[PrecedenceGroup__LoopEntry] = parser.NewATNState(PrecedenceGroup__LoopEntry, parser.ATNLoopEntry, true).SetDecision(44)
+	states[PrecedenceGroup__LoopEnd] = parser.NewATNState(PrecedenceGroup__LoopEnd, parser.ATNLoopEnd, true)
+	states[PrecedenceGroup__LoopBack] = parser.NewATNState(PrecedenceGroup__LoopBack, parser.ATNLoopBack, true)
+	states[InfixOperator__Basic_0] = parser.NewATNState(InfixOperator__Basic_0, parser.ATNBasic, true)
+	states[InfixOperator__Basic_1] = parser.NewATNState(InfixOperator__Basic_1, parser.ATNBasic, true)
+	states[InfixOperator__Basic_2] = parser.NewATNState(InfixOperator__Basic_2, parser.ATNBasic, true)
+	states[InfixOperator__Basic_3] = parser.NewATNState(InfixOperator__Basic_3, parser.ATNBasic, true)
+	states[InfixOperator__Basic_4] = parser.NewATNState(InfixOperator__Basic_4, parser.ATNBasic, true).SetDecision(45)
+	states[InfixOperator__BlockEnd] = parser.NewATNState(InfixOperator__BlockEnd, parser.ATNBlockEnd, true)
 	states[Grammar__Start].AppendTransitions(
 		parser.NewEpsilonTransition(states[Grammar_grammar]),
 	)
@@ -711,6 +809,15 @@ func BuildATN() *parser.RuntimeATN {
 	states[CompositeElement__Start].AppendTransitions(
 		parser.NewEpsilonTransition(states[CompositeElement__Basic_6]),
 	)
+	states[InfixRule__Start].AppendTransitions(
+		parser.NewEpsilonTransition(states[InfixRule_infix]),
+	)
+	states[PrecedenceGroup__Start].AppendTransitions(
+		parser.NewEpsilonTransition(states[PrecedenceGroup__Basic_4]),
+	)
+	states[InfixOperator__Start].AppendTransitions(
+		parser.NewEpsilonTransition(states[InfixOperator__Basic_4]),
+	)
 	states[Grammar_grammar].AppendTransitions(
 		parser.NewAtomTransition(states[Grammar_Name_ID], Keyword_grammar, nil),
 	)
@@ -758,17 +865,24 @@ func BuildATN() *parser.RuntimeATN {
 		parser.NewEpsilonTransition(states[Grammar__BlockEnd]),
 	)
 	states[Grammar__Basic_12].AppendTransitions(
+		parser.NewRuleTransition(states[InfixRule__Start], states[Grammar__Basic_13], nil),
+	)
+	states[Grammar__Basic_13].AppendTransitions(
+		parser.NewEpsilonTransition(states[Grammar__BlockEnd]),
+	)
+	states[Grammar__Basic_14].AppendTransitions(
 		parser.NewEpsilonTransition(states[Grammar__Basic_2]),
 		parser.NewEpsilonTransition(states[Grammar__Basic_4]),
 		parser.NewEpsilonTransition(states[Grammar__Basic_6]),
 		parser.NewEpsilonTransition(states[Grammar__Basic_8]),
 		parser.NewEpsilonTransition(states[Grammar__Basic_10]),
+		parser.NewEpsilonTransition(states[Grammar__Basic_12]),
 	)
 	states[Grammar__BlockEnd].AppendTransitions(
 		parser.NewEpsilonTransition(states[Grammar__LoopBack]),
 	)
 	states[Grammar__LoopEntry].AppendTransitions(
-		parser.NewEpsilonTransition(states[Grammar__Basic_12]),
+		parser.NewEpsilonTransition(states[Grammar__Basic_14]),
 		parser.NewEpsilonTransition(states[Grammar__LoopEnd]),
 	)
 	states[Grammar__LoopEnd].AppendTransitions(
@@ -1529,9 +1643,139 @@ func BuildATN() *parser.RuntimeATN {
 		parser.NewEpsilonTransition(states[CompositeElement__Basic_10]),
 		parser.NewEpsilonTransition(states[CompositeElement__BlockEnd_1]),
 	)
-	decisionStates := make([]*parser.RuntimeATNState, 39)
+	states[InfixRule_infix].AppendTransitions(
+		parser.NewAtomTransition(states[InfixRule_Name_ID], Keyword_infix, nil),
+	)
+	states[InfixRule_Name_ID].AppendTransitions(
+		parser.NewAtomTransition(states[InfixRule_on], Token_ID, nil),
+	)
+	states[InfixRule_on].AppendTransitions(
+		parser.NewAtomTransition(states[InfixRule__Basic_0], Keyword_on, nil),
+	)
+	states[InfixRule__Basic_0].AppendTransitions(
+		parser.NewRuleTransition(states[RuleCall__Start], states[InfixRule__Basic_2], nil),
+	)
+	states[InfixRule_returns].AppendTransitions(
+		parser.NewAtomTransition(states[InfixRule_ReturnType_ID], Keyword_returns, nil),
+	)
+	states[InfixRule_ReturnType_ID].AppendTransitions(
+		parser.NewAtomTransition(states[InfixRule__Basic_1], Token_ID, &parser.CompletionHint{Field: "InfixRule.ReturnType"}),
+	)
+	states[InfixRule__Basic_1].AppendTransitions(
+		parser.NewEpsilonTransition(states[InfixRule_Colon]),
+	)
+	states[InfixRule__Basic_2].AppendTransitions(
+		parser.NewEpsilonTransition(states[InfixRule_returns]),
+		parser.NewEpsilonTransition(states[InfixRule__Basic_1]),
+	)
+	states[InfixRule_Colon].AppendTransitions(
+		parser.NewAtomTransition(states[InfixRule__Basic_3], Keyword_Colon, nil),
+	)
+	states[InfixRule__Basic_3].AppendTransitions(
+		parser.NewRuleTransition(states[PrecedenceGroup__Start], states[InfixRule__LoopEntry], nil),
+	)
+	states[InfixRule_GreaterThan].AppendTransitions(
+		parser.NewAtomTransition(states[InfixRule__Basic_4], Keyword_GreaterThan, nil),
+	)
+	states[InfixRule__Basic_4].AppendTransitions(
+		parser.NewRuleTransition(states[PrecedenceGroup__Start], states[InfixRule__Basic_5], nil),
+	)
+	states[InfixRule__Basic_5].AppendTransitions(
+		parser.NewEpsilonTransition(states[InfixRule__LoopBack]),
+	)
+	states[InfixRule__LoopEntry].AppendTransitions(
+		parser.NewEpsilonTransition(states[InfixRule_GreaterThan]),
+		parser.NewEpsilonTransition(states[InfixRule__LoopEnd]),
+	)
+	states[InfixRule__LoopEnd].AppendTransitions(
+		parser.NewEpsilonTransition(states[InfixRule__Basic_7]),
+	)
+	states[InfixRule__LoopBack].AppendTransitions(
+		parser.NewEpsilonTransition(states[InfixRule__LoopEntry]),
+	)
+	states[InfixRule_Semicolon].AppendTransitions(
+		parser.NewAtomTransition(states[InfixRule__Basic_6], Keyword_Semicolon, nil),
+	)
+	states[InfixRule__Basic_6].AppendTransitions(
+		parser.NewEpsilonTransition(states[InfixRule__Stop]),
+	)
+	states[InfixRule__Basic_7].AppendTransitions(
+		parser.NewEpsilonTransition(states[InfixRule_Semicolon]),
+		parser.NewEpsilonTransition(states[InfixRule__Basic_6]),
+	)
+	states[PrecedenceGroup_Associativity_left].AppendTransitions(
+		parser.NewAtomTransition(states[PrecedenceGroup__Basic_0], Keyword_left, nil),
+	)
+	states[PrecedenceGroup__Basic_0].AppendTransitions(
+		parser.NewEpsilonTransition(states[PrecedenceGroup__BlockEnd]),
+	)
+	states[PrecedenceGroup_Associativity_right].AppendTransitions(
+		parser.NewAtomTransition(states[PrecedenceGroup__Basic_1], Keyword_right, nil),
+	)
+	states[PrecedenceGroup__Basic_1].AppendTransitions(
+		parser.NewEpsilonTransition(states[PrecedenceGroup__BlockEnd]),
+	)
+	states[PrecedenceGroup__Basic_2].AppendTransitions(
+		parser.NewEpsilonTransition(states[PrecedenceGroup_Associativity_left]),
+		parser.NewEpsilonTransition(states[PrecedenceGroup_Associativity_right]),
+	)
+	states[PrecedenceGroup__BlockEnd].AppendTransitions(
+		parser.NewEpsilonTransition(states[PrecedenceGroup_assoc]),
+	)
+	states[PrecedenceGroup_assoc].AppendTransitions(
+		parser.NewAtomTransition(states[PrecedenceGroup__Basic_3], Keyword_assoc, nil),
+	)
+	states[PrecedenceGroup__Basic_3].AppendTransitions(
+		parser.NewEpsilonTransition(states[PrecedenceGroup__Basic_5]),
+	)
+	states[PrecedenceGroup__Basic_4].AppendTransitions(
+		parser.NewEpsilonTransition(states[PrecedenceGroup__Basic_2]),
+		parser.NewEpsilonTransition(states[PrecedenceGroup__Basic_3]),
+	)
+	states[PrecedenceGroup__Basic_5].AppendTransitions(
+		parser.NewRuleTransition(states[InfixOperator__Start], states[PrecedenceGroup__LoopEntry], nil),
+	)
+	states[PrecedenceGroup_Pipe].AppendTransitions(
+		parser.NewAtomTransition(states[PrecedenceGroup__Basic_6], Keyword_Pipe, nil),
+	)
+	states[PrecedenceGroup__Basic_6].AppendTransitions(
+		parser.NewRuleTransition(states[InfixOperator__Start], states[PrecedenceGroup__Basic_7], nil),
+	)
+	states[PrecedenceGroup__Basic_7].AppendTransitions(
+		parser.NewEpsilonTransition(states[PrecedenceGroup__LoopBack]),
+	)
+	states[PrecedenceGroup__LoopEntry].AppendTransitions(
+		parser.NewEpsilonTransition(states[PrecedenceGroup_Pipe]),
+		parser.NewEpsilonTransition(states[PrecedenceGroup__LoopEnd]),
+	)
+	states[PrecedenceGroup__LoopEnd].AppendTransitions(
+		parser.NewEpsilonTransition(states[PrecedenceGroup__Stop]),
+	)
+	states[PrecedenceGroup__LoopBack].AppendTransitions(
+		parser.NewEpsilonTransition(states[PrecedenceGroup__LoopEntry]),
+	)
+	states[InfixOperator__Basic_0].AppendTransitions(
+		parser.NewRuleTransition(states[Keyword__Start], states[InfixOperator__Basic_1], nil),
+	)
+	states[InfixOperator__Basic_1].AppendTransitions(
+		parser.NewEpsilonTransition(states[InfixOperator__BlockEnd]),
+	)
+	states[InfixOperator__Basic_2].AppendTransitions(
+		parser.NewRuleTransition(states[RuleCall__Start], states[InfixOperator__Basic_3], nil),
+	)
+	states[InfixOperator__Basic_3].AppendTransitions(
+		parser.NewEpsilonTransition(states[InfixOperator__BlockEnd]),
+	)
+	states[InfixOperator__Basic_4].AppendTransitions(
+		parser.NewEpsilonTransition(states[InfixOperator__Basic_0]),
+		parser.NewEpsilonTransition(states[InfixOperator__Basic_2]),
+	)
+	states[InfixOperator__BlockEnd].AppendTransitions(
+		parser.NewEpsilonTransition(states[InfixOperator__Stop]),
+	)
+	decisionStates := make([]*parser.RuntimeATNState, 46)
 	decisionStates[0] = states[Grammar__Basic_1]
-	decisionStates[1] = states[Grammar__Basic_12]
+	decisionStates[1] = states[Grammar__Basic_14]
 	decisionStates[2] = states[Grammar__LoopEntry]
 	decisionStates[3] = states[Interface__LoopEntry_0]
 	decisionStates[4] = states[Interface__Basic_1]
@@ -1569,9 +1813,16 @@ func BuildATN() *parser.RuntimeATN {
 	decisionStates[36] = states[CompositeElement__Basic_6]
 	decisionStates[37] = states[CompositeElement__Basic_10]
 	decisionStates[38] = states[CompositeElement__Basic_11]
-	decisionMap := make([]*parser.RuntimeATNState, 39)
+	decisionStates[39] = states[InfixRule__Basic_2]
+	decisionStates[40] = states[InfixRule__LoopEntry]
+	decisionStates[41] = states[InfixRule__Basic_7]
+	decisionStates[42] = states[PrecedenceGroup__Basic_2]
+	decisionStates[43] = states[PrecedenceGroup__Basic_4]
+	decisionStates[44] = states[PrecedenceGroup__LoopEntry]
+	decisionStates[45] = states[InfixOperator__Basic_4]
+	decisionMap := make([]*parser.RuntimeATNState, 46)
 	decisionMap[0] = states[Grammar__Basic_1]
-	decisionMap[1] = states[Grammar__Basic_12]
+	decisionMap[1] = states[Grammar__Basic_14]
 	decisionMap[2] = states[Grammar__LoopEntry]
 	decisionMap[3] = states[Interface__LoopEntry_0]
 	decisionMap[4] = states[Interface__Basic_1]
@@ -1609,5 +1860,12 @@ func BuildATN() *parser.RuntimeATN {
 	decisionMap[36] = states[CompositeElement__Basic_6]
 	decisionMap[37] = states[CompositeElement__Basic_10]
 	decisionMap[38] = states[CompositeElement__Basic_11]
+	decisionMap[39] = states[InfixRule__Basic_2]
+	decisionMap[40] = states[InfixRule__LoopEntry]
+	decisionMap[41] = states[InfixRule__Basic_7]
+	decisionMap[42] = states[PrecedenceGroup__Basic_2]
+	decisionMap[43] = states[PrecedenceGroup__Basic_4]
+	decisionMap[44] = states[PrecedenceGroup__LoopEntry]
+	decisionMap[45] = states[InfixOperator__Basic_4]
 	return parser.NewRuntimeATN(states, decisionStates, decisionMap)
 }

--- a/internal/grammar/atn_gen.go
+++ b/internal/grammar/atn_gen.go
@@ -347,13 +347,11 @@ const (
 	PrecedenceGroup__Basic_1
 	PrecedenceGroup__Basic_2
 	PrecedenceGroup__BlockEnd
-	PrecedenceGroup_assoc
 	PrecedenceGroup__Basic_3
 	PrecedenceGroup__Basic_4
-	PrecedenceGroup__Basic_5
 	PrecedenceGroup_Pipe
+	PrecedenceGroup__Basic_5
 	PrecedenceGroup__Basic_6
-	PrecedenceGroup__Basic_7
 	PrecedenceGroup__LoopEntry
 	PrecedenceGroup__LoopEnd
 	PrecedenceGroup__LoopBack
@@ -375,7 +373,7 @@ func ATN() *parser.RuntimeATN {
 	return atn
 }
 func BuildATN() *parser.RuntimeATN {
-	states := make([]*parser.RuntimeATNState, 355)
+	states := make([]*parser.RuntimeATNState, 353)
 	states[Grammar__Start] = parser.NewATNState(Grammar__Start, parser.ATNRuleStart, true)
 	states[Grammar__Stop] = parser.NewATNState(Grammar__Stop, parser.ATNRuleStop, false)
 	states[Interface__Start] = parser.NewATNState(Interface__Start, parser.ATNRuleStart, true)
@@ -715,13 +713,11 @@ func BuildATN() *parser.RuntimeATN {
 	states[PrecedenceGroup__Basic_1] = parser.NewATNState(PrecedenceGroup__Basic_1, parser.ATNBasic, true)
 	states[PrecedenceGroup__Basic_2] = parser.NewATNState(PrecedenceGroup__Basic_2, parser.ATNBasic, true).SetDecision(42)
 	states[PrecedenceGroup__BlockEnd] = parser.NewATNState(PrecedenceGroup__BlockEnd, parser.ATNBlockEnd, true)
-	states[PrecedenceGroup_assoc] = parser.NewATNState(PrecedenceGroup_assoc, parser.ATNBasic, false)
-	states[PrecedenceGroup__Basic_3] = parser.NewATNState(PrecedenceGroup__Basic_3, parser.ATNBasic, true)
-	states[PrecedenceGroup__Basic_4] = parser.NewATNState(PrecedenceGroup__Basic_4, parser.ATNBasic, true).SetDecision(43)
-	states[PrecedenceGroup__Basic_5] = parser.NewATNState(PrecedenceGroup__Basic_5, parser.ATNBasic, true)
+	states[PrecedenceGroup__Basic_3] = parser.NewATNState(PrecedenceGroup__Basic_3, parser.ATNBasic, true).SetDecision(43)
+	states[PrecedenceGroup__Basic_4] = parser.NewATNState(PrecedenceGroup__Basic_4, parser.ATNBasic, true)
 	states[PrecedenceGroup_Pipe] = parser.NewATNState(PrecedenceGroup_Pipe, parser.ATNBasic, false)
+	states[PrecedenceGroup__Basic_5] = parser.NewATNState(PrecedenceGroup__Basic_5, parser.ATNBasic, true)
 	states[PrecedenceGroup__Basic_6] = parser.NewATNState(PrecedenceGroup__Basic_6, parser.ATNBasic, true)
-	states[PrecedenceGroup__Basic_7] = parser.NewATNState(PrecedenceGroup__Basic_7, parser.ATNBasic, true)
 	states[PrecedenceGroup__LoopEntry] = parser.NewATNState(PrecedenceGroup__LoopEntry, parser.ATNLoopEntry, true).SetDecision(44)
 	states[PrecedenceGroup__LoopEnd] = parser.NewATNState(PrecedenceGroup__LoopEnd, parser.ATNLoopEnd, true)
 	states[PrecedenceGroup__LoopBack] = parser.NewATNState(PrecedenceGroup__LoopBack, parser.ATNLoopBack, true)
@@ -813,7 +809,7 @@ func BuildATN() *parser.RuntimeATN {
 		parser.NewEpsilonTransition(states[InfixRule_infix]),
 	)
 	states[PrecedenceGroup__Start].AppendTransitions(
-		parser.NewEpsilonTransition(states[PrecedenceGroup__Basic_4]),
+		parser.NewEpsilonTransition(states[PrecedenceGroup__Basic_3]),
 	)
 	states[InfixOperator__Start].AppendTransitions(
 		parser.NewEpsilonTransition(states[InfixOperator__Basic_4]),
@@ -1063,7 +1059,7 @@ func BuildATN() *parser.RuntimeATN {
 		parser.NewAtomTransition(states[ParserRule_ReturnType_ID], Keyword_returns, nil),
 	)
 	states[ParserRule_ReturnType_ID].AppendTransitions(
-		parser.NewAtomTransition(states[ParserRule__Basic_2], Token_ID, &parser.CompletionHint{Field: "ParserRule.ReturnType"}),
+		parser.NewAtomTransition(states[ParserRule__Basic_2], Token_ID, &parser.CompletionHint{Field: "AbstractRuleWithReturnType.ReturnType"}),
 	)
 	states[ParserRule__Basic_2].AppendTransitions(
 		parser.NewEpsilonTransition(states[ParserRule_Colon]),
@@ -1659,7 +1655,7 @@ func BuildATN() *parser.RuntimeATN {
 		parser.NewAtomTransition(states[InfixRule_ReturnType_ID], Keyword_returns, nil),
 	)
 	states[InfixRule_ReturnType_ID].AppendTransitions(
-		parser.NewAtomTransition(states[InfixRule__Basic_1], Token_ID, &parser.CompletionHint{Field: "InfixRule.ReturnType"}),
+		parser.NewAtomTransition(states[InfixRule__Basic_1], Token_ID, &parser.CompletionHint{Field: "AbstractRuleWithReturnType.ReturnType"}),
 	)
 	states[InfixRule__Basic_1].AppendTransitions(
 		parser.NewEpsilonTransition(states[InfixRule_Colon]),
@@ -1720,28 +1716,22 @@ func BuildATN() *parser.RuntimeATN {
 		parser.NewEpsilonTransition(states[PrecedenceGroup_Associativity_right]),
 	)
 	states[PrecedenceGroup__BlockEnd].AppendTransitions(
-		parser.NewEpsilonTransition(states[PrecedenceGroup_assoc]),
-	)
-	states[PrecedenceGroup_assoc].AppendTransitions(
-		parser.NewAtomTransition(states[PrecedenceGroup__Basic_3], Keyword_assoc, nil),
+		parser.NewEpsilonTransition(states[PrecedenceGroup__Basic_4]),
 	)
 	states[PrecedenceGroup__Basic_3].AppendTransitions(
-		parser.NewEpsilonTransition(states[PrecedenceGroup__Basic_5]),
+		parser.NewEpsilonTransition(states[PrecedenceGroup__Basic_2]),
+		parser.NewEpsilonTransition(states[PrecedenceGroup__BlockEnd]),
 	)
 	states[PrecedenceGroup__Basic_4].AppendTransitions(
-		parser.NewEpsilonTransition(states[PrecedenceGroup__Basic_2]),
-		parser.NewEpsilonTransition(states[PrecedenceGroup__Basic_3]),
-	)
-	states[PrecedenceGroup__Basic_5].AppendTransitions(
 		parser.NewRuleTransition(states[InfixOperator__Start], states[PrecedenceGroup__LoopEntry], nil),
 	)
 	states[PrecedenceGroup_Pipe].AppendTransitions(
-		parser.NewAtomTransition(states[PrecedenceGroup__Basic_6], Keyword_Pipe, nil),
+		parser.NewAtomTransition(states[PrecedenceGroup__Basic_5], Keyword_Pipe, nil),
+	)
+	states[PrecedenceGroup__Basic_5].AppendTransitions(
+		parser.NewRuleTransition(states[InfixOperator__Start], states[PrecedenceGroup__Basic_6], nil),
 	)
 	states[PrecedenceGroup__Basic_6].AppendTransitions(
-		parser.NewRuleTransition(states[InfixOperator__Start], states[PrecedenceGroup__Basic_7], nil),
-	)
-	states[PrecedenceGroup__Basic_7].AppendTransitions(
 		parser.NewEpsilonTransition(states[PrecedenceGroup__LoopBack]),
 	)
 	states[PrecedenceGroup__LoopEntry].AppendTransitions(
@@ -1817,7 +1807,7 @@ func BuildATN() *parser.RuntimeATN {
 	decisionStates[40] = states[InfixRule__LoopEntry]
 	decisionStates[41] = states[InfixRule__Basic_7]
 	decisionStates[42] = states[PrecedenceGroup__Basic_2]
-	decisionStates[43] = states[PrecedenceGroup__Basic_4]
+	decisionStates[43] = states[PrecedenceGroup__Basic_3]
 	decisionStates[44] = states[PrecedenceGroup__LoopEntry]
 	decisionStates[45] = states[InfixOperator__Basic_4]
 	decisionMap := make([]*parser.RuntimeATNState, 46)
@@ -1864,7 +1854,7 @@ func BuildATN() *parser.RuntimeATN {
 	decisionMap[40] = states[InfixRule__LoopEntry]
 	decisionMap[41] = states[InfixRule__Basic_7]
 	decisionMap[42] = states[PrecedenceGroup__Basic_2]
-	decisionMap[43] = states[PrecedenceGroup__Basic_4]
+	decisionMap[43] = states[PrecedenceGroup__Basic_3]
 	decisionMap[44] = states[PrecedenceGroup__LoopEntry]
 	decisionMap[45] = states[InfixOperator__Basic_4]
 	return parser.NewRuntimeATN(states, decisionStates, decisionMap)

--- a/internal/grammar/completion_gen.go
+++ b/internal/grammar/completion_gen.go
@@ -24,6 +24,7 @@ type FastbeltCompletionFilter interface {
 	FilterRuleCallRule(ctx context.Context, reference *core.Reference[AbstractRule], in iter.Seq[*core.SymbolDescription]) iter.Seq[*core.SymbolDescription]
 	FilterActionType(ctx context.Context, reference *core.Reference[Interface], in iter.Seq[*core.SymbolDescription]) iter.Seq[*core.SymbolDescription]
 	FilterActionProperty(ctx context.Context, reference *core.Reference[Field], in iter.Seq[*core.SymbolDescription]) iter.Seq[*core.SymbolDescription]
+	FilterInfixRuleReturnType(ctx context.Context, reference *core.Reference[Interface], in iter.Seq[*core.SymbolDescription]) iter.Seq[*core.SymbolDescription]
 }
 
 type DefaultFastbeltCompletionFilter struct{}
@@ -69,6 +70,10 @@ func (*DefaultFastbeltCompletionFilter) FilterActionType(_ context.Context, _ *c
 }
 
 func (*DefaultFastbeltCompletionFilter) FilterActionProperty(_ context.Context, _ *core.Reference[Field], in iter.Seq[*core.SymbolDescription]) iter.Seq[*core.SymbolDescription] {
+	return in
+}
+
+func (*DefaultFastbeltCompletionFilter) FilterInfixRuleReturnType(_ context.Context, _ *core.Reference[Interface], in iter.Seq[*core.SymbolDescription]) iter.Seq[*core.SymbolDescription] {
 	return in
 }
 
@@ -199,6 +204,18 @@ var FastbeltCompletionDispatch = map[string]FastbeltCompletionDispatchFunc{
 		candidates := scopes.ScopeActionProperty(ctx, ref).AllElements()
 		return filter.FilterActionProperty(ctx, ref, candidates)
 	},
+	"InfixRule.ReturnType": func(ctx context.Context, sc *service.Container, owner core.AstNode) iter.Seq[*core.SymbolDescription] {
+		typedOwner, ok := owner.(InfixRule)
+		if !ok {
+			return func(yield func(*core.SymbolDescription) bool) {}
+		}
+		refs := service.MustGet[FastbeltReferencesConstructor](sc)
+		scopes := service.MustGet[FastbeltScopeProvider](sc)
+		filter := service.MustGet[FastbeltCompletionFilter](sc)
+		ref := refs.InfixRuleReturnType(typedOwner, nil)
+		candidates := scopes.ScopeInfixRuleReturnType(ctx, ref).AllElements()
+		return filter.FilterInfixRuleReturnType(ctx, ref, candidates)
+	},
 }
 
 type FastbeltCompletionAdapter struct {
@@ -251,6 +268,11 @@ func (a *FastbeltCompletionAdapter) HasAssignment(node core.AstNode, property st
 		switch property {
 		case "Type":
 			return n.Type() != nil
+		}
+	case InfixRule:
+		switch property {
+		case "ReturnType":
+			return n.ReturnType() != nil
 		}
 	case Interface:
 		switch property {

--- a/internal/grammar/completion_gen.go
+++ b/internal/grammar/completion_gen.go
@@ -17,14 +17,13 @@ type FastbeltCompletionFilter interface {
 	FilterInterfaceExtends(ctx context.Context, reference *core.Reference[Interface], in iter.Seq[*core.SymbolDescription]) iter.Seq[*core.SymbolDescription]
 	FilterReferenceTypeType(ctx context.Context, reference *core.Reference[Interface], in iter.Seq[*core.SymbolDescription]) iter.Seq[*core.SymbolDescription]
 	FilterSimpleTypeType(ctx context.Context, reference *core.Reference[Interface], in iter.Seq[*core.SymbolDescription]) iter.Seq[*core.SymbolDescription]
-	FilterParserRuleReturnType(ctx context.Context, reference *core.Reference[Interface], in iter.Seq[*core.SymbolDescription]) iter.Seq[*core.SymbolDescription]
+	FilterAbstractRuleWithReturnTypeReturnType(ctx context.Context, reference *core.Reference[Interface], in iter.Seq[*core.SymbolDescription]) iter.Seq[*core.SymbolDescription]
 	FilterTokenGroupTokenRefs(ctx context.Context, reference *core.Reference[AbstractTokenRule], in iter.Seq[*core.SymbolDescription]) iter.Seq[*core.SymbolDescription]
 	FilterAssignmentProperty(ctx context.Context, reference *core.Reference[Field], in iter.Seq[*core.SymbolDescription]) iter.Seq[*core.SymbolDescription]
 	FilterCrossRefType(ctx context.Context, reference *core.Reference[Interface], in iter.Seq[*core.SymbolDescription]) iter.Seq[*core.SymbolDescription]
 	FilterRuleCallRule(ctx context.Context, reference *core.Reference[AbstractRule], in iter.Seq[*core.SymbolDescription]) iter.Seq[*core.SymbolDescription]
 	FilterActionType(ctx context.Context, reference *core.Reference[Interface], in iter.Seq[*core.SymbolDescription]) iter.Seq[*core.SymbolDescription]
 	FilterActionProperty(ctx context.Context, reference *core.Reference[Field], in iter.Seq[*core.SymbolDescription]) iter.Seq[*core.SymbolDescription]
-	FilterInfixRuleReturnType(ctx context.Context, reference *core.Reference[Interface], in iter.Seq[*core.SymbolDescription]) iter.Seq[*core.SymbolDescription]
 }
 
 type DefaultFastbeltCompletionFilter struct{}
@@ -45,7 +44,7 @@ func (*DefaultFastbeltCompletionFilter) FilterSimpleTypeType(_ context.Context, 
 	return in
 }
 
-func (*DefaultFastbeltCompletionFilter) FilterParserRuleReturnType(_ context.Context, _ *core.Reference[Interface], in iter.Seq[*core.SymbolDescription]) iter.Seq[*core.SymbolDescription] {
+func (*DefaultFastbeltCompletionFilter) FilterAbstractRuleWithReturnTypeReturnType(_ context.Context, _ *core.Reference[Interface], in iter.Seq[*core.SymbolDescription]) iter.Seq[*core.SymbolDescription] {
 	return in
 }
 
@@ -70,10 +69,6 @@ func (*DefaultFastbeltCompletionFilter) FilterActionType(_ context.Context, _ *c
 }
 
 func (*DefaultFastbeltCompletionFilter) FilterActionProperty(_ context.Context, _ *core.Reference[Field], in iter.Seq[*core.SymbolDescription]) iter.Seq[*core.SymbolDescription] {
-	return in
-}
-
-func (*DefaultFastbeltCompletionFilter) FilterInfixRuleReturnType(_ context.Context, _ *core.Reference[Interface], in iter.Seq[*core.SymbolDescription]) iter.Seq[*core.SymbolDescription] {
 	return in
 }
 
@@ -120,17 +115,17 @@ var FastbeltCompletionDispatch = map[string]FastbeltCompletionDispatchFunc{
 		candidates := scopes.ScopeSimpleTypeType(ctx, ref).AllElements()
 		return filter.FilterSimpleTypeType(ctx, ref, candidates)
 	},
-	"ParserRule.ReturnType": func(ctx context.Context, sc *service.Container, owner core.AstNode) iter.Seq[*core.SymbolDescription] {
-		typedOwner, ok := owner.(ParserRule)
+	"AbstractRuleWithReturnType.ReturnType": func(ctx context.Context, sc *service.Container, owner core.AstNode) iter.Seq[*core.SymbolDescription] {
+		typedOwner, ok := owner.(AbstractRuleWithReturnType)
 		if !ok {
 			return func(yield func(*core.SymbolDescription) bool) {}
 		}
 		refs := service.MustGet[FastbeltReferencesConstructor](sc)
 		scopes := service.MustGet[FastbeltScopeProvider](sc)
 		filter := service.MustGet[FastbeltCompletionFilter](sc)
-		ref := refs.ParserRuleReturnType(typedOwner, nil)
-		candidates := scopes.ScopeParserRuleReturnType(ctx, ref).AllElements()
-		return filter.FilterParserRuleReturnType(ctx, ref, candidates)
+		ref := refs.AbstractRuleWithReturnTypeReturnType(typedOwner, nil)
+		candidates := scopes.ScopeAbstractRuleWithReturnTypeReturnType(ctx, ref).AllElements()
+		return filter.FilterAbstractRuleWithReturnTypeReturnType(ctx, ref, candidates)
 	},
 	"TokenGroup.TokenRefs": func(ctx context.Context, sc *service.Container, owner core.AstNode) iter.Seq[*core.SymbolDescription] {
 		typedOwner, ok := owner.(TokenGroup)
@@ -204,18 +199,6 @@ var FastbeltCompletionDispatch = map[string]FastbeltCompletionDispatchFunc{
 		candidates := scopes.ScopeActionProperty(ctx, ref).AllElements()
 		return filter.FilterActionProperty(ctx, ref, candidates)
 	},
-	"InfixRule.ReturnType": func(ctx context.Context, sc *service.Container, owner core.AstNode) iter.Seq[*core.SymbolDescription] {
-		typedOwner, ok := owner.(InfixRule)
-		if !ok {
-			return func(yield func(*core.SymbolDescription) bool) {}
-		}
-		refs := service.MustGet[FastbeltReferencesConstructor](sc)
-		scopes := service.MustGet[FastbeltScopeProvider](sc)
-		filter := service.MustGet[FastbeltCompletionFilter](sc)
-		ref := refs.InfixRuleReturnType(typedOwner, nil)
-		candidates := scopes.ScopeInfixRuleReturnType(ctx, ref).AllElements()
-		return filter.FilterInfixRuleReturnType(ctx, ref, candidates)
-	},
 }
 
 type FastbeltCompletionAdapter struct {
@@ -252,6 +235,11 @@ func (a *FastbeltCompletionAdapter) DispatchCompletion(ctx context.Context, fiel
 
 func (a *FastbeltCompletionAdapter) HasAssignment(node core.AstNode, property string) bool {
 	switch n := node.(type) {
+	case AbstractRuleWithReturnType:
+		switch property {
+		case "ReturnType":
+			return n.ReturnType() != nil
+		}
 	case Action:
 		switch property {
 		case "Property":
@@ -269,20 +257,10 @@ func (a *FastbeltCompletionAdapter) HasAssignment(node core.AstNode, property st
 		case "Type":
 			return n.Type() != nil
 		}
-	case InfixRule:
-		switch property {
-		case "ReturnType":
-			return n.ReturnType() != nil
-		}
 	case Interface:
 		switch property {
 		case "Extends":
 			return n.Extends() != nil
-		}
-	case ParserRule:
-		switch property {
-		case "ReturnType":
-			return n.ReturnType() != nil
 		}
 	case ReferenceType:
 		switch property {

--- a/internal/grammar/completion_parser_gen.go
+++ b/internal/grammar/completion_parser_gen.go
@@ -956,21 +956,18 @@ func (p *CompletionParser) ParseInfixRule() {
 func (p *CompletionParser) ParsePrecedenceGroup() {
 	p.cp.EnterRule("PrecedenceGroup", PrecedenceGroup__Start)
 	defer p.cp.ExitRule()
-	p.cp.RecordSnapshot(PrecedenceGroup__Basic_4)
-	p.state.Sync(PrecedenceGroup__Basic_4)
-	if p.lookahead.PrecedenceGroupOptional(p.state) {
-		{
+	{
+		p.cp.RecordSnapshot(PrecedenceGroup__Basic_3)
+		p.state.Sync(PrecedenceGroup__Basic_3)
+		switch prediction, _ := p.lookahead.PrecedenceGroupAssociativityAlternatives(p.state); prediction {
+		case 0:
 			p.cp.MarkAssignment("Associativity")
-			switch prediction, _ := p.lookahead.PrecedenceGroupAssociativityAlternatives(p.state); prediction {
-			case 0:
-				p.state.Consume(Keyword_left)
-			case 1:
-				p.state.Consume(Keyword_right)
-			}
+			p.state.Consume(Keyword_left)
 			p.cp.ClearAssignment()
-		}
-		{
-			p.state.Consume(Keyword_assoc)
+		case 1:
+			p.cp.MarkAssignment("Associativity")
+			p.state.Consume(Keyword_right)
+			p.cp.ClearAssignment()
 		}
 	}
 	{
@@ -988,7 +985,7 @@ func (p *CompletionParser) ParsePrecedenceGroup() {
 		}
 		{
 			p.cp.MarkAssignment("Operators")
-			p.state.EnterRule(PrecedenceGroup__Basic_7)
+			p.state.EnterRule(PrecedenceGroup__Basic_6)
 			p.ParseInfixOperator()
 			p.state.ExitRule()
 			p.cp.ClearAssignment()

--- a/internal/grammar/completion_parser_gen.go
+++ b/internal/grammar/completion_parser_gen.go
@@ -99,6 +99,14 @@ func (p *CompletionParser) ParseGrammar() {
 				p.state.ExitRule()
 				p.cp.ClearAssignment()
 			}
+		case 5:
+			{
+				p.cp.MarkAssignment("InfixRules")
+				p.state.EnterRule(Grammar__Basic_13)
+				p.ParseInfixRule()
+				p.state.ExitRule()
+				p.cp.ClearAssignment()
+			}
 		default:
 			p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 		}
@@ -876,5 +884,137 @@ func (p *CompletionParser) ParseCompositeElement() {
 			p.state.Consume(Keyword_Question)
 			p.cp.ClearAssignment()
 		}
+	}
+}
+
+func (p *CompletionParser) ParseInfixRule() {
+	p.cp.EnterRule("InfixRule", InfixRule__Start)
+	defer p.cp.ExitRule()
+	{
+		p.state.Consume(Keyword_infix)
+	}
+	{
+		p.cp.MarkAssignment("Name")
+		p.state.Consume(Token_ID)
+		p.cp.ClearAssignment()
+	}
+	{
+		p.state.Consume(Keyword_on)
+	}
+	{
+		p.cp.MarkAssignment("Call")
+		p.state.EnterRule(InfixRule__Basic_2)
+		p.ParseRuleCall()
+		p.state.ExitRule()
+		p.cp.ClearAssignment()
+	}
+	p.cp.RecordSnapshot(InfixRule__Basic_2)
+	p.state.Sync(InfixRule__Basic_2)
+	if p.lookahead.InfixRuleOptional(p.state) {
+		{
+			p.state.Consume(Keyword_returns)
+		}
+		{
+			p.cp.MarkAssignment("ReturnType")
+			p.state.Consume(Token_ID)
+			p.cp.ClearAssignment()
+		}
+	}
+	{
+		p.state.Consume(Keyword_Colon)
+	}
+	{
+		p.cp.MarkAssignment("Groups")
+		p.state.EnterRule(InfixRule__LoopEntry)
+		p.ParsePrecedenceGroup()
+		p.state.ExitRule()
+		p.cp.ClearAssignment()
+	}
+	p.cp.RecordSnapshot(InfixRule__LoopEntry)
+	p.state.Sync(InfixRule__LoopEntry)
+	for p.lookahead.InfixRuleLoop(p.state) {
+		{
+			p.state.Consume(Keyword_GreaterThan)
+		}
+		{
+			p.cp.MarkAssignment("Groups")
+			p.state.EnterRule(InfixRule__Basic_5)
+			p.ParsePrecedenceGroup()
+			p.state.ExitRule()
+			p.cp.ClearAssignment()
+		}
+		p.cp.RecordSnapshot(InfixRule__LoopEntry)
+		p.state.Sync(InfixRule__LoopEntry)
+	}
+	{
+		if p.lookahead.InfixRuleSemicolonOptional(p.state) {
+			p.state.Consume(Keyword_Semicolon)
+		}
+	}
+}
+
+func (p *CompletionParser) ParsePrecedenceGroup() {
+	p.cp.EnterRule("PrecedenceGroup", PrecedenceGroup__Start)
+	defer p.cp.ExitRule()
+	p.cp.RecordSnapshot(PrecedenceGroup__Basic_4)
+	p.state.Sync(PrecedenceGroup__Basic_4)
+	if p.lookahead.PrecedenceGroupOptional(p.state) {
+		{
+			p.cp.MarkAssignment("Associativity")
+			switch prediction, _ := p.lookahead.PrecedenceGroupAssociativityAlternatives(p.state); prediction {
+			case 0:
+				p.state.Consume(Keyword_left)
+			case 1:
+				p.state.Consume(Keyword_right)
+			}
+			p.cp.ClearAssignment()
+		}
+		{
+			p.state.Consume(Keyword_assoc)
+		}
+	}
+	{
+		p.cp.MarkAssignment("Operators")
+		p.state.EnterRule(PrecedenceGroup__LoopEntry)
+		p.ParseInfixOperator()
+		p.state.ExitRule()
+		p.cp.ClearAssignment()
+	}
+	p.cp.RecordSnapshot(PrecedenceGroup__LoopEntry)
+	p.state.Sync(PrecedenceGroup__LoopEntry)
+	for p.lookahead.PrecedenceGroupLoop(p.state) {
+		{
+			p.state.Consume(Keyword_Pipe)
+		}
+		{
+			p.cp.MarkAssignment("Operators")
+			p.state.EnterRule(PrecedenceGroup__Basic_7)
+			p.ParseInfixOperator()
+			p.state.ExitRule()
+			p.cp.ClearAssignment()
+		}
+		p.cp.RecordSnapshot(PrecedenceGroup__LoopEntry)
+		p.state.Sync(PrecedenceGroup__LoopEntry)
+	}
+}
+
+func (p *CompletionParser) ParseInfixOperator() {
+	p.cp.EnterRule("InfixOperator", InfixOperator__Start)
+	defer p.cp.ExitRule()
+	switch prediction, failure := p.lookahead.InfixOperatorAlternatives(p.state); prediction {
+	case 0:
+		{
+			p.state.EnterRule(InfixOperator__Basic_1)
+			p.ParseKeyword()
+			p.state.ExitRule()
+		}
+	case 1:
+		{
+			p.state.EnterRule(InfixOperator__Basic_3)
+			p.ParseRuleCall()
+			p.state.ExitRule()
+		}
+	default:
+		p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 	}
 }

--- a/internal/grammar/grammar.fb
+++ b/internal/grammar/grammar.fb
@@ -4,6 +4,7 @@ interface Grammar {
     Name        string
     Rules       []ParserRule
     Composites  []CompositeRule
+    InfixRules  []InfixRule
     Terminals   []Token
     TokenGroups []TokenGroup
     Interfaces  []Interface
@@ -16,6 +17,7 @@ entry Grammar: "grammar" Name=ID ";"?
         | TokenGroups+=TokenGroup
         | Interfaces+=Interface
         | Composites+=CompositeRule
+        | InfixRules+=InfixRule
     )*
 
 interface Interface {
@@ -170,6 +172,26 @@ CompositeAlternatives returns Element: CompositeGroup ({Alternatives.Alts+=curre
 CompositeGroup returns Element: CompositeElement ({Group.Elements+=current} Elements+=CompositeElement+)?
 
 CompositeElement returns Element: (Keyword | RuleCall | "(" CompositeAlternatives ")") Cardinality=("*" | "+" | "?")?
+
+interface InfixRule extends AbstractRuleWithBody {
+    Call       RuleCall
+    ReturnType *Interface
+    Groups     []PrecedenceGroup
+}
+
+InfixRule: "infix" Name=ID "on" Call=RuleCall ("returns" ReturnType=[Interface:ID])? ":"
+    Groups+=PrecedenceGroup (">" Groups+=PrecedenceGroup)* ";"?
+
+interface PrecedenceGroup {
+    Associativity string
+    Operators     []Assignable
+}
+
+PrecedenceGroup:
+    (Associativity=("left" | "right") "assoc")?
+    Operators+=InfixOperator ("|" Operators+=InfixOperator)*
+
+InfixOperator returns Assignable: Keyword | RuleCall
 
 // Move comments in front of RegexLiteral
 comment token SL_COMMENT: /\/\/[^\r\n]*/

--- a/internal/grammar/grammar.fb
+++ b/internal/grammar/grammar.fb
@@ -74,12 +74,15 @@ interface AbstractRuleWithBody extends AbstractRule {
     Body Element
 }
 
+interface AbstractRuleWithReturnType extends AbstractRuleWithBody {
+    ReturnType *Interface
+}
+
 // Base type for Token and TokenGroup
 interface AbstractTokenRule extends AbstractRule{}
 
-interface ParserRule extends AbstractRuleWithBody {
+interface ParserRule extends AbstractRuleWithReturnType {
     Entry      bool
-    ReturnType *Interface
 }
 
 ParserRule: (Entry?="entry")? Name=ID ("returns" ReturnType=[Interface:ID])? ":" Body=Alternatives ";"?
@@ -173,9 +176,8 @@ CompositeGroup returns Element: CompositeElement ({Group.Elements+=current} Elem
 
 CompositeElement returns Element: (Keyword | RuleCall | "(" CompositeAlternatives ")") Cardinality=("*" | "+" | "?")?
 
-interface InfixRule extends AbstractRuleWithBody {
+interface InfixRule extends AbstractRuleWithReturnType {
     Call       RuleCall
-    ReturnType *Interface
     Groups     []PrecedenceGroup
 }
 
@@ -188,7 +190,7 @@ interface PrecedenceGroup {
 }
 
 PrecedenceGroup:
-    (Associativity=("left" | "right") "assoc")?
+    Associativity=("left" | "right")?
     Operators+=InfixOperator ("|" Operators+=InfixOperator)*
 
 InfixOperator returns Assignable: Keyword | RuleCall

--- a/internal/grammar/infix.go
+++ b/internal/grammar/infix.go
@@ -1,0 +1,218 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+package grammar
+
+import (
+	"context"
+	"fmt"
+
+	core "typefox.dev/fastbelt"
+)
+
+// InfixOperatorGroupName returns the name of the token group synthesized by
+// [ExpandInfixRules] to unify all operator tokens of the given infix rule.
+func InfixOperatorGroupName(rule InfixRule) string {
+	return rule.Name() + "Operator"
+}
+
+// FindInfixReturnType returns the effective return type of an infix rule:
+// the explicit "returns" type if present, otherwise the return type of the
+// operand rule (a lone operand is returned unchanged, so the static type must
+// cover both the operand and the binary node type).
+func FindInfixReturnType(rule InfixRule, ctx context.Context) Interface {
+	if rule == nil {
+		return nil
+	}
+	if typeRef := rule.ReturnType(); typeRef != nil {
+		return typeRef.Ref(ctx)
+	}
+	if rule.Call() == nil {
+		return nil
+	}
+	operand, _ := rule.Call().Rule().Ref(ctx).(ParserRule)
+	return FindReturnType(operand, ctx)
+}
+
+// FindInfixNodeType returns the interface the binary nodes of an infix rule
+// are instances of. It is always the interface named like the rule itself.
+func FindInfixNodeType(rule InfixRule) Interface {
+	grammar, ok := rule.Container().(Grammar)
+	if !ok || grammar == nil {
+		return nil
+	}
+	return FindInterfaceByName(grammar, rule.Name())
+}
+
+// ExpandInfixRules desugars every infix rule of the grammar in place:
+//
+//  1. A token group named "<RuleName>Operator" is appended to the grammar,
+//     containing all operator keywords and token references of the rule. The
+//     generated parser consumes any operator with a single bitset check
+//     against this group, without an alternatives decision.
+//
+//  2. The rule's body is set to the flat form the ATN, lookahead, and
+//     completion machinery operate on:
+//
+//     [ RuleCall(operand), [ RuleCall(operator), RuleCall(operand) ]* ]
+//
+// The expansion is idempotent (rules with a non-nil body are skipped) and is
+// only invoked by the code generator; documents managed by the language
+// server are never expanded.
+func ExpandInfixRules(g Grammar) error {
+	ctx := context.Background()
+	for _, rule := range g.InfixRules() {
+		if rule.Body() != nil {
+			continue
+		}
+		groupName := InfixOperatorGroupName(rule)
+		if findRuleByName(g, groupName) != nil {
+			return fmt.Errorf("cannot generate operator token group for infix rule '%s': the name '%s' is already taken", rule.Name(), groupName)
+		}
+		operand := resolveOperandRule(rule, ctx)
+		if operand == nil {
+			return fmt.Errorf("could not resolve the operand rule of infix rule '%s'", rule.Name())
+		}
+
+		tokenGroup, err := synthesizeOperatorGroup(g, rule, groupName, ctx)
+		if err != nil {
+			return err
+		}
+		synthesizeInfixBody(rule, operand, tokenGroup)
+	}
+	return nil
+}
+
+func findRuleByName(g Grammar, name string) AbstractRule {
+	for _, rule := range g.Rules() {
+		if rule.Name() == name {
+			return rule
+		}
+	}
+	for _, rule := range g.Composites() {
+		if rule.Name() == name {
+			return rule
+		}
+	}
+	for _, rule := range g.InfixRules() {
+		if rule.Name() == name {
+			return rule
+		}
+	}
+	for _, token := range g.Terminals() {
+		if token.Name() == name {
+			return token
+		}
+	}
+	for _, tokenGroup := range g.TokenGroups() {
+		if tokenGroup.Name() == name {
+			return tokenGroup
+		}
+	}
+	return nil
+}
+
+func resolveOperandRule(rule InfixRule, ctx context.Context) ParserRule {
+	call := rule.Call()
+	if call == nil {
+		return nil
+	}
+	operand, _ := call.Rule().Ref(ctx).(ParserRule)
+	return operand
+}
+
+// synthesizeOperatorGroup builds the unified operator token group of an infix
+// rule and appends it to the grammar.
+func synthesizeOperatorGroup(g Grammar, rule InfixRule, groupName string, ctx context.Context) (TokenGroup, error) {
+	tokenGroup := NewTokenGroup()
+	tokenGroup.SetName(&core.Token{Image: groupName, Range: rule.NameToken().Range})
+	tokenGroup.SetTextRange(rule.TextRange())
+	tokenGroup.SetDocument(rule.Document())
+	keywordIndex := 0
+	for _, precedence := range rule.Groups() {
+		for _, operator := range precedence.Operators() {
+			switch op := operator.(type) {
+			case Keyword:
+				// A fresh node sharing the original value token: the original
+				// keyword stays in place below the infix rule, and keyword
+				// deduplication works on the (quoted) token value.
+				keyword := NewKeyword()
+				keyword.SetValue(op.ValueToken())
+				keyword.SetTextRange(op.TextRange())
+				keyword.SetDocument(rule.Document())
+				keyword.SetContainer(tokenGroup, fieldNameKeywords, keywordIndex)
+				tokenGroup.SetKeywordsItem(keyword)
+				keywordIndex++
+			case RuleCall:
+				target, ok := op.Rule().Ref(ctx).(AbstractTokenRule)
+				if !ok {
+					return nil, fmt.Errorf("operator '%s' of infix rule '%s' does not reference a token rule", op.Rule().Text(), rule.Name())
+				}
+				tokenGroup.SetTokenRefsItem(resolvedReference(tokenGroup, op.Rule().Unit(), target))
+			default:
+				return nil, fmt.Errorf("unsupported operator element in infix rule '%s'", rule.Name())
+			}
+		}
+	}
+	tokenGroup.SetContainer(g, fieldNameTokenGroups, len(g.TokenGroups()))
+	g.SetTokenGroupsItem(tokenGroup)
+	return tokenGroup, nil
+}
+
+// synthesizeInfixBody attaches the flat "operand (operator operand)*" body to
+// the infix rule.
+func synthesizeInfixBody(rule InfixRule, operand ParserRule, operatorGroup TokenGroup) {
+	nameUnit := rule.Call().Rule().Unit()
+
+	operandCall := func() RuleCall {
+		call := NewRuleCall()
+		call.SetRule(resolvedReference[AbstractRule](call, nameUnit, operand))
+		call.SetTextRange(rule.Call().TextRange())
+		call.SetDocument(rule.Document())
+		return call
+	}
+
+	operatorCall := NewRuleCall()
+	operatorCall.SetRule(resolvedReference[AbstractRule](operatorCall, operatorGroup.NameToken(), operatorGroup))
+	operatorCall.SetTextRange(rule.TextRange())
+	operatorCall.SetDocument(rule.Document())
+
+	inner := NewGroup()
+	inner.SetCardinality(&core.Token{Image: "*", Range: rule.TextRange()})
+	inner.SetTextRange(rule.TextRange())
+	inner.SetDocument(rule.Document())
+	first := operandCall()
+	second := operandCall()
+
+	outer := NewGroup()
+	outer.SetTextRange(rule.TextRange())
+	outer.SetDocument(rule.Document())
+
+	first.SetContainer(outer, fieldNameElements, 0)
+	outer.SetElementsItem(first)
+	inner.SetContainer(outer, fieldNameElements, 1)
+	outer.SetElementsItem(inner)
+	operatorCall.SetContainer(inner, fieldNameElements, 0)
+	inner.SetElementsItem(operatorCall)
+	second.SetContainer(inner, fieldNameElements, 1)
+	inner.SetElementsItem(second)
+
+	outer.SetContainer(rule, fieldNameBody, -1)
+	rule.SetBody(outer)
+}
+
+// resolvedReference creates a reference that resolves to an already known
+// target node, bypassing scoping and linking.
+func resolvedReference[T core.AstNode](owner core.AstNode, unit core.StringUnit, target T) *core.Reference[T] {
+	description := &core.SymbolDescription{
+		Node: target,
+		Name: any(target).(core.NamedTokenNode).NameToken(),
+	}
+	if doc := target.Document(); doc != nil {
+		description.URI = doc.URI
+	}
+	return core.NewReference(owner, unit, func(context.Context, *core.Reference[T]) (*core.SymbolDescription, *core.ReferenceError) {
+		return description, nil
+	})
+}

--- a/internal/grammar/infix.go
+++ b/internal/grammar/infix.go
@@ -17,24 +17,6 @@ func InfixOperatorGroupName(rule InfixRule) string {
 	return rule.Name() + "Operator"
 }
 
-// FindInfixReturnType returns the effective return type of an infix rule:
-// the explicit "returns" type if present, otherwise the return type of the
-// operand rule (a lone operand is returned unchanged, so the static type must
-// cover both the operand and the binary node type).
-func FindInfixReturnType(rule InfixRule, ctx context.Context) Interface {
-	if rule == nil {
-		return nil
-	}
-	if typeRef := rule.ReturnType(); typeRef != nil {
-		return typeRef.Ref(ctx)
-	}
-	if rule.Call() == nil {
-		return nil
-	}
-	operand, _ := rule.Call().Rule().Ref(ctx).(ParserRule)
-	return FindReturnType(operand, ctx)
-}
-
 // FindInfixNodeType returns the interface the binary nodes of an infix rule
 // are instances of. It is always the interface named like the rule itself.
 func FindInfixNodeType(rule InfixRule) Interface {

--- a/internal/grammar/infix_validator_test.go
+++ b/internal/grammar/infix_validator_test.go
@@ -1,0 +1,144 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+package grammar
+
+import (
+	"testing"
+
+	core "typefox.dev/fastbelt"
+	"typefox.dev/fastbelt/test"
+)
+
+func TestInfixRuleValid(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+	` + infixInterfaces + `
+		infix BinaryExpression on PrimaryExpression:
+			"*" | "/"
+			> "+" | "-"
+			> right assoc "="
+	` + commonTokens)
+	doc.AssertNoDiagnostics()
+}
+
+func TestInfixRuleMissingNodeType(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+	` + infixInterfaces + `
+		infix <|1:Binary|> on PrimaryExpression returns Expression: "+"
+	` + commonTokens)
+	doc.ExpectDiagnostic("1").WithSeverity(core.SeverityError).WithCode(ValidateInfixNodeType)
+}
+
+func TestInfixRuleMissingProperty(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+		interface Expression { Value string }
+		interface Binary extends Expression {
+			Left Expression
+			Operator string
+		}
+		PrimaryExpression returns Expression: Value=ID
+		infix <|1:Binary|> on PrimaryExpression returns Expression: "+"
+	` + commonTokens)
+	// Missing 'Right' field.
+	doc.ExpectDiagnostic("1").WithSeverity(core.SeverityError).WithCode(ValidateInfixProperty)
+}
+
+func TestInfixRuleOperatorFieldNotString(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+		interface Expression { Value string }
+		interface Binary extends Expression {
+			Left Expression
+			Operator Expression
+			Right Expression
+		}
+		PrimaryExpression returns Expression: Value=ID
+		infix <|1:Binary|> on PrimaryExpression returns Expression: "+"
+	` + commonTokens)
+	doc.ExpectDiagnostic("1").WithSeverity(core.SeverityError).WithCode(ValidateInfixProperty)
+}
+
+func TestInfixRuleOperandNotParserRule(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+	` + infixInterfaces + `
+		infix BinaryExpression on <|1:ID|>: "+"
+	` + commonTokens)
+	doc.ExpectDiagnostic("1").WithSeverity(core.SeverityError).WithCode(ValidateInfixOperandRule)
+}
+
+func TestInfixRuleIncompatibleReturnType(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+		interface Expression { Value string }
+		interface Other {}
+		interface BinaryExpression extends Expression {
+			Left Expression
+			Operator string
+			Right Expression
+		}
+		PrimaryExpression returns Expression: Value=ID
+		infix <|1:BinaryExpression|> on PrimaryExpression returns Other: "+"
+	` + commonTokens)
+	diag := doc.ExpectDiagnostic("1")
+	diag.WithSeverity(core.SeverityError)
+	diag.WithCode(ValidateInfixReturnType)
+}
+
+func TestInfixRuleDuplicateOperator(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+	` + infixInterfaces + `
+		infix BinaryExpression on PrimaryExpression:
+			"+" | "*"
+			> <|1:"+"|> | "-"
+	` + commonTokens)
+	doc.ExpectDiagnostic("1").WithSeverity(core.SeverityError).WithCode(ValidateInfixDuplicateOperator)
+}
+
+func TestInfixRuleDuplicateOperatorViaTokenGroup(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+	` + infixInterfaces + `
+		token group MulOp { "*" "/" }
+		infix BinaryExpression on PrimaryExpression:
+			"*"
+			> <|1:MulOp|>
+	` + commonTokens)
+	doc.ExpectDiagnostic("1").WithSeverity(core.SeverityError).WithCode(ValidateInfixDuplicateOperator)
+}
+
+func TestInfixRuleHiddenTokenOperator(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+	` + infixInterfaces + `
+		hidden token COMMENT: /#[^\n]*/;
+		infix BinaryExpression on PrimaryExpression:
+			"+" | <|1:COMMENT|>
+	` + commonTokens)
+	doc.ExpectDiagnostic("1").WithSeverity(core.SeverityError).WithCode(ValidateInfixOperator)
+}
+
+func TestInfixRuleOperatorGroupNameTaken(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+	` + infixInterfaces + `
+		token BinaryExpressionOperator: /@+/;
+		infix <|1:BinaryExpression|> on PrimaryExpression: "+"
+	` + commonTokens)
+	doc.ExpectDiagnostic("1").WithSeverity(core.SeverityError).WithCode(ValidateInfixOperatorGroupName)
+}

--- a/internal/grammar/infix_validator_test.go
+++ b/internal/grammar/infix_validator_test.go
@@ -19,7 +19,7 @@ func TestInfixRuleValid(t *testing.T) {
 		infix BinaryExpression on PrimaryExpression:
 			"*" | "/"
 			> "+" | "-"
-			> right assoc "="
+			> right "="
 	` + commonTokens)
 	doc.AssertNoDiagnostics()
 }

--- a/internal/grammar/infix_validator_test.go
+++ b/internal/grammar/infix_validator_test.go
@@ -90,9 +90,7 @@ func TestInfixRuleIncompatibleReturnType(t *testing.T) {
 		PrimaryExpression returns Expression: Value=ID
 		infix <|1:BinaryExpression|> on PrimaryExpression returns Other: "+"
 	` + commonTokens)
-	diag := doc.ExpectDiagnostic("1")
-	diag.WithSeverity(core.SeverityError)
-	diag.WithCode(ValidateInfixReturnType)
+	doc.ExpectDiagnostic("1").WithSeverity(core.SeverityError).WithCode(ValidateInfixReturnType)
 }
 
 func TestInfixRuleDuplicateOperator(t *testing.T) {

--- a/internal/grammar/lexer_gen.go
+++ b/internal/grammar/lexer_gen.go
@@ -294,26 +294,7 @@ var Keyword_RightBracket = core.NewTokenType(
 	[]rune{']'},
 )
 
-const Keyword_assoc_Idx = 16
-
-var Keyword_assoc = core.NewTokenType(
-	Keyword_assoc_Idx,
-	"assoc",
-	"assoc",
-	0,
-	core.TokenKindKeyword,
-	0,
-	false,
-	func(text string, offset int) int {
-		if strings.HasPrefix(text[offset:], "assoc") {
-			return 5
-		}
-		return 0
-	},
-	[]rune{'a'},
-)
-
-const Keyword_bool_Idx = 17
+const Keyword_bool_Idx = 16
 
 var Keyword_bool = core.NewTokenType(
 	Keyword_bool_Idx,
@@ -332,7 +313,7 @@ var Keyword_bool = core.NewTokenType(
 	[]rune{'b'},
 )
 
-const Keyword_comment_Idx = 18
+const Keyword_comment_Idx = 17
 
 var Keyword_comment = core.NewTokenType(
 	Keyword_comment_Idx,
@@ -351,7 +332,7 @@ var Keyword_comment = core.NewTokenType(
 	[]rune{'c'},
 )
 
-const Keyword_composite_Idx = 19
+const Keyword_composite_Idx = 18
 
 var Keyword_composite = core.NewTokenType(
 	Keyword_composite_Idx,
@@ -370,7 +351,7 @@ var Keyword_composite = core.NewTokenType(
 	[]rune{'c'},
 )
 
-const Keyword_current_Idx = 20
+const Keyword_current_Idx = 19
 
 var Keyword_current = core.NewTokenType(
 	Keyword_current_Idx,
@@ -389,7 +370,7 @@ var Keyword_current = core.NewTokenType(
 	[]rune{'c'},
 )
 
-const Keyword_entry_Idx = 21
+const Keyword_entry_Idx = 20
 
 var Keyword_entry = core.NewTokenType(
 	Keyword_entry_Idx,
@@ -408,7 +389,7 @@ var Keyword_entry = core.NewTokenType(
 	[]rune{'e'},
 )
 
-const Keyword_extends_Idx = 22
+const Keyword_extends_Idx = 21
 
 var Keyword_extends = core.NewTokenType(
 	Keyword_extends_Idx,
@@ -427,7 +408,7 @@ var Keyword_extends = core.NewTokenType(
 	[]rune{'e'},
 )
 
-const Keyword_grammar_Idx = 23
+const Keyword_grammar_Idx = 22
 
 var Keyword_grammar = core.NewTokenType(
 	Keyword_grammar_Idx,
@@ -446,7 +427,7 @@ var Keyword_grammar = core.NewTokenType(
 	[]rune{'g'},
 )
 
-const Keyword_group_Idx = 24
+const Keyword_group_Idx = 23
 
 var Keyword_group = core.NewTokenType(
 	Keyword_group_Idx,
@@ -465,7 +446,7 @@ var Keyword_group = core.NewTokenType(
 	[]rune{'g'},
 )
 
-const Keyword_hidden_Idx = 25
+const Keyword_hidden_Idx = 24
 
 var Keyword_hidden = core.NewTokenType(
 	Keyword_hidden_Idx,
@@ -484,7 +465,7 @@ var Keyword_hidden = core.NewTokenType(
 	[]rune{'h'},
 )
 
-const Keyword_infix_Idx = 26
+const Keyword_infix_Idx = 25
 
 var Keyword_infix = core.NewTokenType(
 	Keyword_infix_Idx,
@@ -503,7 +484,7 @@ var Keyword_infix = core.NewTokenType(
 	[]rune{'i'},
 )
 
-const Keyword_interface_Idx = 27
+const Keyword_interface_Idx = 26
 
 var Keyword_interface = core.NewTokenType(
 	Keyword_interface_Idx,
@@ -522,7 +503,7 @@ var Keyword_interface = core.NewTokenType(
 	[]rune{'i'},
 )
 
-const Keyword_keywords_Idx = 28
+const Keyword_keywords_Idx = 27
 
 var Keyword_keywords = core.NewTokenType(
 	Keyword_keywords_Idx,
@@ -541,7 +522,7 @@ var Keyword_keywords = core.NewTokenType(
 	[]rune{'k'},
 )
 
-const Keyword_left_Idx = 29
+const Keyword_left_Idx = 28
 
 var Keyword_left = core.NewTokenType(
 	Keyword_left_Idx,
@@ -560,7 +541,7 @@ var Keyword_left = core.NewTokenType(
 	[]rune{'l'},
 )
 
-const Keyword_on_Idx = 30
+const Keyword_on_Idx = 29
 
 var Keyword_on = core.NewTokenType(
 	Keyword_on_Idx,
@@ -579,7 +560,7 @@ var Keyword_on = core.NewTokenType(
 	[]rune{'o'},
 )
 
-const Keyword_returns_Idx = 31
+const Keyword_returns_Idx = 30
 
 var Keyword_returns = core.NewTokenType(
 	Keyword_returns_Idx,
@@ -598,7 +579,7 @@ var Keyword_returns = core.NewTokenType(
 	[]rune{'r'},
 )
 
-const Keyword_right_Idx = 32
+const Keyword_right_Idx = 31
 
 var Keyword_right = core.NewTokenType(
 	Keyword_right_Idx,
@@ -617,7 +598,7 @@ var Keyword_right = core.NewTokenType(
 	[]rune{'r'},
 )
 
-const Keyword_string_Idx = 33
+const Keyword_string_Idx = 32
 
 var Keyword_string = core.NewTokenType(
 	Keyword_string_Idx,
@@ -636,7 +617,7 @@ var Keyword_string = core.NewTokenType(
 	[]rune{'s'},
 )
 
-const Keyword_token_Idx = 34
+const Keyword_token_Idx = 33
 
 var Keyword_token = core.NewTokenType(
 	Keyword_token_Idx,
@@ -655,7 +636,7 @@ var Keyword_token = core.NewTokenType(
 	[]rune{'t'},
 )
 
-const Keyword_LeftBrace_Idx = 35
+const Keyword_LeftBrace_Idx = 34
 
 var Keyword_LeftBrace = core.NewTokenType(
 	Keyword_LeftBrace_Idx,
@@ -674,7 +655,7 @@ var Keyword_LeftBrace = core.NewTokenType(
 	[]rune{'{'},
 )
 
-const Keyword_Pipe_Idx = 36
+const Keyword_Pipe_Idx = 35
 
 var Keyword_Pipe = core.NewTokenType(
 	Keyword_Pipe_Idx,
@@ -693,7 +674,7 @@ var Keyword_Pipe = core.NewTokenType(
 	[]rune{'|'},
 )
 
-const Keyword_RightBrace_Idx = 37
+const Keyword_RightBrace_Idx = 36
 
 var Keyword_RightBrace = core.NewTokenType(
 	Keyword_RightBrace_Idx,
@@ -712,7 +693,7 @@ var Keyword_RightBrace = core.NewTokenType(
 	[]rune{'}'},
 )
 
-const Token_SL_COMMENT_Idx = 38
+const Token_SL_COMMENT_Idx = 37
 
 var Token_SL_COMMENT = core.NewTokenType(
 	Token_SL_COMMENT_Idx,
@@ -803,7 +784,7 @@ var Token_SL_COMMENT_Accepting = [3]bool{
 	2: true,
 }
 
-const Token_ML_COMMENT_Idx = 39
+const Token_ML_COMMENT_Idx = 38
 
 var Token_ML_COMMENT = core.NewTokenType(
 	Token_ML_COMMENT_Idx,
@@ -928,7 +909,7 @@ var Token_ML_COMMENT_Accepting = [5]bool{
 	4: true,
 }
 
-const Token_StringLiteral_Idx = 40
+const Token_StringLiteral_Idx = 39
 
 var Token_StringLiteral = core.NewTokenType(
 	Token_StringLiteral_Idx,
@@ -1019,7 +1000,7 @@ var Token_StringLiteral_Accepting = [3]bool{
 	2: true,
 }
 
-const Token_ID_Idx = 41
+const Token_ID_Idx = 40
 
 var Token_ID = core.NewTokenType(
 	Token_ID_Idx,
@@ -1093,7 +1074,7 @@ var Token_ID_Accepting = [2]bool{
 	1: true,
 }
 
-const Token_RegexLiteral_Idx = 42
+const Token_RegexLiteral_Idx = 41
 
 var Token_RegexLiteral = core.NewTokenType(
 	Token_RegexLiteral_Idx,
@@ -1252,7 +1233,7 @@ var Token_RegexLiteral_Accepting = [7]bool{
 	5: true,
 }
 
-const Token_WS_Idx = 43
+const Token_WS_Idx = 42
 
 var Token_WS = core.NewTokenType(
 	Token_WS_Idx,
@@ -1343,7 +1324,6 @@ func NewLexer() lexer.Lexer {
 		Keyword_QuestionEquals,
 		Keyword_LeftBracket,
 		Keyword_RightBracket,
-		Keyword_assoc,
 		Keyword_bool,
 		Keyword_comment,
 		Keyword_composite,

--- a/internal/grammar/lexer_gen.go
+++ b/internal/grammar/lexer_gen.go
@@ -199,7 +199,26 @@ var Keyword_Equals = core.NewTokenType(
 	[]rune{'='},
 )
 
-const Keyword_Question_Idx = 11
+const Keyword_GreaterThan_Idx = 11
+
+var Keyword_GreaterThan = core.NewTokenType(
+	Keyword_GreaterThan_Idx,
+	">",
+	">",
+	0,
+	core.TokenKindKeyword,
+	0,
+	false,
+	func(text string, offset int) int {
+		if strings.HasPrefix(text[offset:], ">") {
+			return 1
+		}
+		return 0
+	},
+	[]rune{'>'},
+)
+
+const Keyword_Question_Idx = 12
 
 var Keyword_Question = core.NewTokenType(
 	Keyword_Question_Idx,
@@ -218,7 +237,7 @@ var Keyword_Question = core.NewTokenType(
 	[]rune{'?'},
 )
 
-const Keyword_QuestionEquals_Idx = 12
+const Keyword_QuestionEquals_Idx = 13
 
 var Keyword_QuestionEquals = core.NewTokenType(
 	Keyword_QuestionEquals_Idx,
@@ -237,7 +256,7 @@ var Keyword_QuestionEquals = core.NewTokenType(
 	[]rune{'?'},
 )
 
-const Keyword_LeftBracket_Idx = 13
+const Keyword_LeftBracket_Idx = 14
 
 var Keyword_LeftBracket = core.NewTokenType(
 	Keyword_LeftBracket_Idx,
@@ -256,7 +275,7 @@ var Keyword_LeftBracket = core.NewTokenType(
 	[]rune{'['},
 )
 
-const Keyword_RightBracket_Idx = 14
+const Keyword_RightBracket_Idx = 15
 
 var Keyword_RightBracket = core.NewTokenType(
 	Keyword_RightBracket_Idx,
@@ -275,7 +294,26 @@ var Keyword_RightBracket = core.NewTokenType(
 	[]rune{']'},
 )
 
-const Keyword_bool_Idx = 15
+const Keyword_assoc_Idx = 16
+
+var Keyword_assoc = core.NewTokenType(
+	Keyword_assoc_Idx,
+	"assoc",
+	"assoc",
+	0,
+	core.TokenKindKeyword,
+	0,
+	false,
+	func(text string, offset int) int {
+		if strings.HasPrefix(text[offset:], "assoc") {
+			return 5
+		}
+		return 0
+	},
+	[]rune{'a'},
+)
+
+const Keyword_bool_Idx = 17
 
 var Keyword_bool = core.NewTokenType(
 	Keyword_bool_Idx,
@@ -294,7 +332,7 @@ var Keyword_bool = core.NewTokenType(
 	[]rune{'b'},
 )
 
-const Keyword_comment_Idx = 16
+const Keyword_comment_Idx = 18
 
 var Keyword_comment = core.NewTokenType(
 	Keyword_comment_Idx,
@@ -313,7 +351,7 @@ var Keyword_comment = core.NewTokenType(
 	[]rune{'c'},
 )
 
-const Keyword_composite_Idx = 17
+const Keyword_composite_Idx = 19
 
 var Keyword_composite = core.NewTokenType(
 	Keyword_composite_Idx,
@@ -332,7 +370,7 @@ var Keyword_composite = core.NewTokenType(
 	[]rune{'c'},
 )
 
-const Keyword_current_Idx = 18
+const Keyword_current_Idx = 20
 
 var Keyword_current = core.NewTokenType(
 	Keyword_current_Idx,
@@ -351,7 +389,7 @@ var Keyword_current = core.NewTokenType(
 	[]rune{'c'},
 )
 
-const Keyword_entry_Idx = 19
+const Keyword_entry_Idx = 21
 
 var Keyword_entry = core.NewTokenType(
 	Keyword_entry_Idx,
@@ -370,7 +408,7 @@ var Keyword_entry = core.NewTokenType(
 	[]rune{'e'},
 )
 
-const Keyword_extends_Idx = 20
+const Keyword_extends_Idx = 22
 
 var Keyword_extends = core.NewTokenType(
 	Keyword_extends_Idx,
@@ -389,7 +427,7 @@ var Keyword_extends = core.NewTokenType(
 	[]rune{'e'},
 )
 
-const Keyword_grammar_Idx = 21
+const Keyword_grammar_Idx = 23
 
 var Keyword_grammar = core.NewTokenType(
 	Keyword_grammar_Idx,
@@ -408,7 +446,7 @@ var Keyword_grammar = core.NewTokenType(
 	[]rune{'g'},
 )
 
-const Keyword_group_Idx = 22
+const Keyword_group_Idx = 24
 
 var Keyword_group = core.NewTokenType(
 	Keyword_group_Idx,
@@ -427,7 +465,7 @@ var Keyword_group = core.NewTokenType(
 	[]rune{'g'},
 )
 
-const Keyword_hidden_Idx = 23
+const Keyword_hidden_Idx = 25
 
 var Keyword_hidden = core.NewTokenType(
 	Keyword_hidden_Idx,
@@ -446,7 +484,26 @@ var Keyword_hidden = core.NewTokenType(
 	[]rune{'h'},
 )
 
-const Keyword_interface_Idx = 24
+const Keyword_infix_Idx = 26
+
+var Keyword_infix = core.NewTokenType(
+	Keyword_infix_Idx,
+	"infix",
+	"infix",
+	0,
+	core.TokenKindKeyword,
+	0,
+	false,
+	func(text string, offset int) int {
+		if strings.HasPrefix(text[offset:], "infix") {
+			return 5
+		}
+		return 0
+	},
+	[]rune{'i'},
+)
+
+const Keyword_interface_Idx = 27
 
 var Keyword_interface = core.NewTokenType(
 	Keyword_interface_Idx,
@@ -465,7 +522,7 @@ var Keyword_interface = core.NewTokenType(
 	[]rune{'i'},
 )
 
-const Keyword_keywords_Idx = 25
+const Keyword_keywords_Idx = 28
 
 var Keyword_keywords = core.NewTokenType(
 	Keyword_keywords_Idx,
@@ -484,7 +541,45 @@ var Keyword_keywords = core.NewTokenType(
 	[]rune{'k'},
 )
 
-const Keyword_returns_Idx = 26
+const Keyword_left_Idx = 29
+
+var Keyword_left = core.NewTokenType(
+	Keyword_left_Idx,
+	"left",
+	"left",
+	0,
+	core.TokenKindKeyword,
+	0,
+	false,
+	func(text string, offset int) int {
+		if strings.HasPrefix(text[offset:], "left") {
+			return 4
+		}
+		return 0
+	},
+	[]rune{'l'},
+)
+
+const Keyword_on_Idx = 30
+
+var Keyword_on = core.NewTokenType(
+	Keyword_on_Idx,
+	"on",
+	"on",
+	0,
+	core.TokenKindKeyword,
+	0,
+	false,
+	func(text string, offset int) int {
+		if strings.HasPrefix(text[offset:], "on") {
+			return 2
+		}
+		return 0
+	},
+	[]rune{'o'},
+)
+
+const Keyword_returns_Idx = 31
 
 var Keyword_returns = core.NewTokenType(
 	Keyword_returns_Idx,
@@ -503,7 +598,26 @@ var Keyword_returns = core.NewTokenType(
 	[]rune{'r'},
 )
 
-const Keyword_string_Idx = 27
+const Keyword_right_Idx = 32
+
+var Keyword_right = core.NewTokenType(
+	Keyword_right_Idx,
+	"right",
+	"right",
+	0,
+	core.TokenKindKeyword,
+	0,
+	false,
+	func(text string, offset int) int {
+		if strings.HasPrefix(text[offset:], "right") {
+			return 5
+		}
+		return 0
+	},
+	[]rune{'r'},
+)
+
+const Keyword_string_Idx = 33
 
 var Keyword_string = core.NewTokenType(
 	Keyword_string_Idx,
@@ -522,7 +636,7 @@ var Keyword_string = core.NewTokenType(
 	[]rune{'s'},
 )
 
-const Keyword_token_Idx = 28
+const Keyword_token_Idx = 34
 
 var Keyword_token = core.NewTokenType(
 	Keyword_token_Idx,
@@ -541,7 +655,7 @@ var Keyword_token = core.NewTokenType(
 	[]rune{'t'},
 )
 
-const Keyword_LeftBrace_Idx = 29
+const Keyword_LeftBrace_Idx = 35
 
 var Keyword_LeftBrace = core.NewTokenType(
 	Keyword_LeftBrace_Idx,
@@ -560,7 +674,7 @@ var Keyword_LeftBrace = core.NewTokenType(
 	[]rune{'{'},
 )
 
-const Keyword_Pipe_Idx = 30
+const Keyword_Pipe_Idx = 36
 
 var Keyword_Pipe = core.NewTokenType(
 	Keyword_Pipe_Idx,
@@ -579,7 +693,7 @@ var Keyword_Pipe = core.NewTokenType(
 	[]rune{'|'},
 )
 
-const Keyword_RightBrace_Idx = 31
+const Keyword_RightBrace_Idx = 37
 
 var Keyword_RightBrace = core.NewTokenType(
 	Keyword_RightBrace_Idx,
@@ -598,7 +712,7 @@ var Keyword_RightBrace = core.NewTokenType(
 	[]rune{'}'},
 )
 
-const Token_SL_COMMENT_Idx = 32
+const Token_SL_COMMENT_Idx = 38
 
 var Token_SL_COMMENT = core.NewTokenType(
 	Token_SL_COMMENT_Idx,
@@ -689,7 +803,7 @@ var Token_SL_COMMENT_Accepting = [3]bool{
 	2: true,
 }
 
-const Token_ML_COMMENT_Idx = 33
+const Token_ML_COMMENT_Idx = 39
 
 var Token_ML_COMMENT = core.NewTokenType(
 	Token_ML_COMMENT_Idx,
@@ -814,7 +928,7 @@ var Token_ML_COMMENT_Accepting = [5]bool{
 	4: true,
 }
 
-const Token_StringLiteral_Idx = 34
+const Token_StringLiteral_Idx = 40
 
 var Token_StringLiteral = core.NewTokenType(
 	Token_StringLiteral_Idx,
@@ -905,7 +1019,7 @@ var Token_StringLiteral_Accepting = [3]bool{
 	2: true,
 }
 
-const Token_ID_Idx = 35
+const Token_ID_Idx = 41
 
 var Token_ID = core.NewTokenType(
 	Token_ID_Idx,
@@ -979,7 +1093,7 @@ var Token_ID_Accepting = [2]bool{
 	1: true,
 }
 
-const Token_RegexLiteral_Idx = 36
+const Token_RegexLiteral_Idx = 42
 
 var Token_RegexLiteral = core.NewTokenType(
 	Token_RegexLiteral_Idx,
@@ -1138,7 +1252,7 @@ var Token_RegexLiteral_Accepting = [7]bool{
 	5: true,
 }
 
-const Token_WS_Idx = 37
+const Token_WS_Idx = 43
 
 var Token_WS = core.NewTokenType(
 	Token_WS_Idx,
@@ -1224,10 +1338,12 @@ func NewLexer() lexer.Lexer {
 		Keyword_Colon,
 		Keyword_Semicolon,
 		Keyword_Equals,
+		Keyword_GreaterThan,
 		Keyword_Question,
 		Keyword_QuestionEquals,
 		Keyword_LeftBracket,
 		Keyword_RightBracket,
+		Keyword_assoc,
 		Keyword_bool,
 		Keyword_comment,
 		Keyword_composite,
@@ -1237,9 +1353,13 @@ func NewLexer() lexer.Lexer {
 		Keyword_grammar,
 		Keyword_group,
 		Keyword_hidden,
+		Keyword_infix,
 		Keyword_interface,
 		Keyword_keywords,
+		Keyword_left,
+		Keyword_on,
 		Keyword_returns,
+		Keyword_right,
 		Keyword_string,
 		Keyword_token,
 		Keyword_LeftBrace,

--- a/internal/grammar/linker_gen.go
+++ b/internal/grammar/linker_gen.go
@@ -25,6 +25,7 @@ type FastbeltScopeProvider interface {
 	ScopeRuleCallRule(ctx context.Context, reference *core.Reference[AbstractRule]) core.Scope
 	ScopeActionType(ctx context.Context, reference *core.Reference[Interface]) core.Scope
 	ScopeActionProperty(ctx context.Context, reference *core.Reference[Field]) core.Scope
+	ScopeInfixRuleReturnType(ctx context.Context, reference *core.Reference[Interface]) core.Scope
 }
 
 type DefaultFastbeltScopeProvider struct {
@@ -75,6 +76,10 @@ func (s *DefaultFastbeltScopeProvider) ScopeActionProperty(ctx context.Context, 
 	return linking.DefaultScopeOfType[Field](reference.Owner())
 }
 
+func (s *DefaultFastbeltScopeProvider) ScopeInfixRuleReturnType(ctx context.Context, reference *core.Reference[Interface]) core.Scope {
+	return linking.DefaultScopeOfType[Interface](reference.Owner())
+}
+
 type FastbeltReferenceLinker interface {
 	LinkInterfaceExtends(ctx context.Context, reference *core.Reference[Interface]) (*core.SymbolDescription, *core.ReferenceError)
 	LinkReferenceTypeType(ctx context.Context, reference *core.Reference[Interface]) (*core.SymbolDescription, *core.ReferenceError)
@@ -86,6 +91,7 @@ type FastbeltReferenceLinker interface {
 	LinkRuleCallRule(ctx context.Context, reference *core.Reference[AbstractRule]) (*core.SymbolDescription, *core.ReferenceError)
 	LinkActionType(ctx context.Context, reference *core.Reference[Interface]) (*core.SymbolDescription, *core.ReferenceError)
 	LinkActionProperty(ctx context.Context, reference *core.Reference[Field]) (*core.SymbolDescription, *core.ReferenceError)
+	LinkInfixRuleReturnType(ctx context.Context, reference *core.Reference[Interface]) (*core.SymbolDescription, *core.ReferenceError)
 }
 
 type DefaultFastbeltReferenceLinker struct {
@@ -152,6 +158,11 @@ func (s *DefaultFastbeltReferenceLinker) LinkActionProperty(ctx context.Context,
 	return core.DefaultLink(scope, reference.Text())
 }
 
+func (s *DefaultFastbeltReferenceLinker) LinkInfixRuleReturnType(ctx context.Context, reference *core.Reference[Interface]) (*core.SymbolDescription, *core.ReferenceError) {
+	scope := s.scopeProvider().ScopeInfixRuleReturnType(ctx, reference)
+	return core.DefaultLink(scope, reference.Text())
+}
+
 type FastbeltReferencesConstructor interface {
 	InterfaceExtends(owner core.AstNode, unit core.StringUnit) *core.Reference[Interface]
 	ReferenceTypeType(owner core.AstNode, unit core.StringUnit) *core.Reference[Interface]
@@ -163,6 +174,7 @@ type FastbeltReferencesConstructor interface {
 	RuleCallRule(owner core.AstNode, unit core.StringUnit) *core.Reference[AbstractRule]
 	ActionType(owner core.AstNode, unit core.StringUnit) *core.Reference[Interface]
 	ActionProperty(owner core.AstNode, unit core.StringUnit) *core.Reference[Field]
+	InfixRuleReturnType(owner core.AstNode, unit core.StringUnit) *core.Reference[Interface]
 }
 
 type DefaultFastbeltReferencesConstructor struct {
@@ -226,6 +238,11 @@ func (s *DefaultFastbeltReferencesConstructor) ActionType(owner core.AstNode, un
 
 func (s *DefaultFastbeltReferencesConstructor) ActionProperty(owner core.AstNode, unit core.StringUnit) *core.Reference[Field] {
 	fn := s.referenceLinker().LinkActionProperty
+	return core.NewReference(owner, unit, fn)
+}
+
+func (s *DefaultFastbeltReferencesConstructor) InfixRuleReturnType(owner core.AstNode, unit core.StringUnit) *core.Reference[Interface] {
+	fn := s.referenceLinker().LinkInfixRuleReturnType
 	return core.NewReference(owner, unit, fn)
 }
 

--- a/internal/grammar/linker_gen.go
+++ b/internal/grammar/linker_gen.go
@@ -18,14 +18,13 @@ type FastbeltScopeProvider interface {
 	ScopeInterfaceExtends(ctx context.Context, reference *core.Reference[Interface]) core.Scope
 	ScopeReferenceTypeType(ctx context.Context, reference *core.Reference[Interface]) core.Scope
 	ScopeSimpleTypeType(ctx context.Context, reference *core.Reference[Interface]) core.Scope
-	ScopeParserRuleReturnType(ctx context.Context, reference *core.Reference[Interface]) core.Scope
+	ScopeAbstractRuleWithReturnTypeReturnType(ctx context.Context, reference *core.Reference[Interface]) core.Scope
 	ScopeTokenGroupTokenRefs(ctx context.Context, reference *core.Reference[AbstractTokenRule]) core.Scope
 	ScopeAssignmentProperty(ctx context.Context, reference *core.Reference[Field]) core.Scope
 	ScopeCrossRefType(ctx context.Context, reference *core.Reference[Interface]) core.Scope
 	ScopeRuleCallRule(ctx context.Context, reference *core.Reference[AbstractRule]) core.Scope
 	ScopeActionType(ctx context.Context, reference *core.Reference[Interface]) core.Scope
 	ScopeActionProperty(ctx context.Context, reference *core.Reference[Field]) core.Scope
-	ScopeInfixRuleReturnType(ctx context.Context, reference *core.Reference[Interface]) core.Scope
 }
 
 type DefaultFastbeltScopeProvider struct {
@@ -48,7 +47,7 @@ func (s *DefaultFastbeltScopeProvider) ScopeSimpleTypeType(ctx context.Context, 
 	return linking.DefaultScopeOfType[Interface](reference.Owner())
 }
 
-func (s *DefaultFastbeltScopeProvider) ScopeParserRuleReturnType(ctx context.Context, reference *core.Reference[Interface]) core.Scope {
+func (s *DefaultFastbeltScopeProvider) ScopeAbstractRuleWithReturnTypeReturnType(ctx context.Context, reference *core.Reference[Interface]) core.Scope {
 	return linking.DefaultScopeOfType[Interface](reference.Owner())
 }
 
@@ -76,22 +75,17 @@ func (s *DefaultFastbeltScopeProvider) ScopeActionProperty(ctx context.Context, 
 	return linking.DefaultScopeOfType[Field](reference.Owner())
 }
 
-func (s *DefaultFastbeltScopeProvider) ScopeInfixRuleReturnType(ctx context.Context, reference *core.Reference[Interface]) core.Scope {
-	return linking.DefaultScopeOfType[Interface](reference.Owner())
-}
-
 type FastbeltReferenceLinker interface {
 	LinkInterfaceExtends(ctx context.Context, reference *core.Reference[Interface]) (*core.SymbolDescription, *core.ReferenceError)
 	LinkReferenceTypeType(ctx context.Context, reference *core.Reference[Interface]) (*core.SymbolDescription, *core.ReferenceError)
 	LinkSimpleTypeType(ctx context.Context, reference *core.Reference[Interface]) (*core.SymbolDescription, *core.ReferenceError)
-	LinkParserRuleReturnType(ctx context.Context, reference *core.Reference[Interface]) (*core.SymbolDescription, *core.ReferenceError)
+	LinkAbstractRuleWithReturnTypeReturnType(ctx context.Context, reference *core.Reference[Interface]) (*core.SymbolDescription, *core.ReferenceError)
 	LinkTokenGroupTokenRefs(ctx context.Context, reference *core.Reference[AbstractTokenRule]) (*core.SymbolDescription, *core.ReferenceError)
 	LinkAssignmentProperty(ctx context.Context, reference *core.Reference[Field]) (*core.SymbolDescription, *core.ReferenceError)
 	LinkCrossRefType(ctx context.Context, reference *core.Reference[Interface]) (*core.SymbolDescription, *core.ReferenceError)
 	LinkRuleCallRule(ctx context.Context, reference *core.Reference[AbstractRule]) (*core.SymbolDescription, *core.ReferenceError)
 	LinkActionType(ctx context.Context, reference *core.Reference[Interface]) (*core.SymbolDescription, *core.ReferenceError)
 	LinkActionProperty(ctx context.Context, reference *core.Reference[Field]) (*core.SymbolDescription, *core.ReferenceError)
-	LinkInfixRuleReturnType(ctx context.Context, reference *core.Reference[Interface]) (*core.SymbolDescription, *core.ReferenceError)
 }
 
 type DefaultFastbeltReferenceLinker struct {
@@ -123,8 +117,8 @@ func (s *DefaultFastbeltReferenceLinker) LinkSimpleTypeType(ctx context.Context,
 	return core.DefaultLink(scope, reference.Text())
 }
 
-func (s *DefaultFastbeltReferenceLinker) LinkParserRuleReturnType(ctx context.Context, reference *core.Reference[Interface]) (*core.SymbolDescription, *core.ReferenceError) {
-	scope := s.scopeProvider().ScopeParserRuleReturnType(ctx, reference)
+func (s *DefaultFastbeltReferenceLinker) LinkAbstractRuleWithReturnTypeReturnType(ctx context.Context, reference *core.Reference[Interface]) (*core.SymbolDescription, *core.ReferenceError) {
+	scope := s.scopeProvider().ScopeAbstractRuleWithReturnTypeReturnType(ctx, reference)
 	return core.DefaultLink(scope, reference.Text())
 }
 
@@ -158,23 +152,17 @@ func (s *DefaultFastbeltReferenceLinker) LinkActionProperty(ctx context.Context,
 	return core.DefaultLink(scope, reference.Text())
 }
 
-func (s *DefaultFastbeltReferenceLinker) LinkInfixRuleReturnType(ctx context.Context, reference *core.Reference[Interface]) (*core.SymbolDescription, *core.ReferenceError) {
-	scope := s.scopeProvider().ScopeInfixRuleReturnType(ctx, reference)
-	return core.DefaultLink(scope, reference.Text())
-}
-
 type FastbeltReferencesConstructor interface {
 	InterfaceExtends(owner core.AstNode, unit core.StringUnit) *core.Reference[Interface]
 	ReferenceTypeType(owner core.AstNode, unit core.StringUnit) *core.Reference[Interface]
 	SimpleTypeType(owner core.AstNode, unit core.StringUnit) *core.Reference[Interface]
-	ParserRuleReturnType(owner core.AstNode, unit core.StringUnit) *core.Reference[Interface]
+	AbstractRuleWithReturnTypeReturnType(owner core.AstNode, unit core.StringUnit) *core.Reference[Interface]
 	TokenGroupTokenRefs(owner core.AstNode, unit core.StringUnit) *core.Reference[AbstractTokenRule]
 	AssignmentProperty(owner core.AstNode, unit core.StringUnit) *core.Reference[Field]
 	CrossRefType(owner core.AstNode, unit core.StringUnit) *core.Reference[Interface]
 	RuleCallRule(owner core.AstNode, unit core.StringUnit) *core.Reference[AbstractRule]
 	ActionType(owner core.AstNode, unit core.StringUnit) *core.Reference[Interface]
 	ActionProperty(owner core.AstNode, unit core.StringUnit) *core.Reference[Field]
-	InfixRuleReturnType(owner core.AstNode, unit core.StringUnit) *core.Reference[Interface]
 }
 
 type DefaultFastbeltReferencesConstructor struct {
@@ -206,8 +194,8 @@ func (s *DefaultFastbeltReferencesConstructor) SimpleTypeType(owner core.AstNode
 	return core.NewReference(owner, unit, fn)
 }
 
-func (s *DefaultFastbeltReferencesConstructor) ParserRuleReturnType(owner core.AstNode, unit core.StringUnit) *core.Reference[Interface] {
-	fn := s.referenceLinker().LinkParserRuleReturnType
+func (s *DefaultFastbeltReferencesConstructor) AbstractRuleWithReturnTypeReturnType(owner core.AstNode, unit core.StringUnit) *core.Reference[Interface] {
+	fn := s.referenceLinker().LinkAbstractRuleWithReturnTypeReturnType
 	return core.NewReference(owner, unit, fn)
 }
 
@@ -238,11 +226,6 @@ func (s *DefaultFastbeltReferencesConstructor) ActionType(owner core.AstNode, un
 
 func (s *DefaultFastbeltReferencesConstructor) ActionProperty(owner core.AstNode, unit core.StringUnit) *core.Reference[Field] {
 	fn := s.referenceLinker().LinkActionProperty
-	return core.NewReference(owner, unit, fn)
-}
-
-func (s *DefaultFastbeltReferencesConstructor) InfixRuleReturnType(owner core.AstNode, unit core.StringUnit) *core.Reference[Interface] {
-	fn := s.referenceLinker().LinkInfixRuleReturnType
 	return core.NewReference(owner, unit, fn)
 }
 

--- a/internal/grammar/parser_gen.go
+++ b/internal/grammar/parser_gen.go
@@ -1322,8 +1322,8 @@ func (p *Parser) ParsePrecedenceGroup() PrecedenceGroup {
 }
 
 func (p *Parser) ParseInfixOperator() Assignable {
-	current := NewAssignable()
-	current.SetTextRangeStart(p.state.LA(1).Range.Start)
+	startPos := p.state.LA(1).Range.Start
+	var current Assignable
 	{
 		switch prediction, failure := p.lookahead.InfixOperatorAlternatives(p.state); prediction {
 		case 0:
@@ -1331,7 +1331,6 @@ func (p *Parser) ParseInfixOperator() Assignable {
 				p.state.EnterRule(InfixOperator__Basic_1)
 				result := p.ParseKeyword()
 				p.state.ExitRule()
-				core.MergeTokens(result, current.Tokens())
 				current = result
 			}
 		case 1:
@@ -1339,11 +1338,14 @@ func (p *Parser) ParseInfixOperator() Assignable {
 				p.state.EnterRule(InfixOperator__Basic_3)
 				result := p.ParseRuleCall()
 				p.state.ExitRule()
-				core.MergeTokens(result, current.Tokens())
 				current = result
 			}
 		default:
 			p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
+		}
+		if current == nil {
+			current = NewAssignable()
+			current.SetTextRangeStart(startPos)
 		}
 	}
 	current.SetTextRangeEnd(p.state.LA(0).Range.End)

--- a/internal/grammar/parser_gen.go
+++ b/internal/grammar/parser_gen.go
@@ -381,7 +381,7 @@ func (p *Parser) ParseParserRule() ParserRule {
 				token := p.state.Consume(Token_ID)
 				core.AssignToken(current, token, ParserRule_ReturnType_ID)
 				if token != nil {
-					current.SetReturnType(p.referencesConstructor.ParserRuleReturnType(current, token))
+					current.SetReturnType(p.referencesConstructor.AbstractRuleWithReturnTypeReturnType(current, token))
 				}
 			}
 		}
@@ -1228,7 +1228,7 @@ func (p *Parser) ParseInfixRule() InfixRule {
 				token := p.state.Consume(Token_ID)
 				core.AssignToken(current, token, InfixRule_ReturnType_ID)
 				if token != nil {
-					current.SetReturnType(p.referencesConstructor.InfixRuleReturnType(current, token))
+					current.SetReturnType(p.referencesConstructor.AbstractRuleWithReturnTypeReturnType(current, token))
 				}
 			}
 		}
@@ -1275,27 +1275,21 @@ func (p *Parser) ParsePrecedenceGroup() PrecedenceGroup {
 	current := NewPrecedenceGroup()
 	current.SetTextRangeStart(p.state.LA(1).Range.Start)
 	{
-		p.state.Sync(PrecedenceGroup__Basic_4)
-		if p.lookahead.PrecedenceGroupOptional(p.state) {
-			{
-				switch prediction, _ := p.lookahead.PrecedenceGroupAssociativityAlternatives(p.state); prediction {
-				case 0:
-					token := p.state.Consume(Keyword_left)
-					core.AssignToken(current, token, PrecedenceGroup_Associativity_left)
-					if token != nil {
-						current.SetAssociativity(token)
-					}
-				case 1:
-					token := p.state.Consume(Keyword_right)
-					core.AssignToken(current, token, PrecedenceGroup_Associativity_right)
-					if token != nil {
-						current.SetAssociativity(token)
-					}
+		{
+			p.state.Sync(PrecedenceGroup__Basic_3)
+			switch prediction, _ := p.lookahead.PrecedenceGroupAssociativityAlternatives(p.state); prediction {
+			case 0:
+				token := p.state.Consume(Keyword_left)
+				core.AssignToken(current, token, PrecedenceGroup_Associativity_left)
+				if token != nil {
+					current.SetAssociativity(token)
 				}
-			}
-			{
-				token := p.state.Consume(Keyword_assoc)
-				core.AssignToken(current, token, PrecedenceGroup_assoc)
+			case 1:
+				token := p.state.Consume(Keyword_right)
+				core.AssignToken(current, token, PrecedenceGroup_Associativity_right)
+				if token != nil {
+					current.SetAssociativity(token)
+				}
 			}
 		}
 		{
@@ -1313,7 +1307,7 @@ func (p *Parser) ParsePrecedenceGroup() PrecedenceGroup {
 				core.AssignToken(current, token, PrecedenceGroup_Pipe)
 			}
 			{
-				p.state.EnterRule(PrecedenceGroup__Basic_7)
+				p.state.EnterRule(PrecedenceGroup__Basic_6)
 				result := p.ParseInfixOperator()
 				p.state.ExitRule()
 				if result != nil {

--- a/internal/grammar/parser_gen.go
+++ b/internal/grammar/parser_gen.go
@@ -101,6 +101,15 @@ func (p *Parser) ParseGrammar() Grammar {
 						current.SetCompositesItem(result)
 					}
 				}
+			case 5:
+				{
+					p.state.EnterRule(Grammar__Basic_13)
+					result := p.ParseInfixRule()
+					p.state.ExitRule()
+					if result != nil {
+						current.SetInfixRulesItem(result)
+					}
+				}
 			default:
 				p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 			}
@@ -1176,6 +1185,171 @@ func (p *Parser) ParseCompositeElement() Element {
 					current.SetCardinality(token)
 				}
 			}
+		}
+	}
+	current.SetTextRangeEnd(p.state.LA(0).Range.End)
+	return current
+}
+
+func (p *Parser) ParseInfixRule() InfixRule {
+	current := NewInfixRule()
+	current.SetTextRangeStart(p.state.LA(1).Range.Start)
+	{
+		{
+			token := p.state.Consume(Keyword_infix)
+			core.AssignToken(current, token, InfixRule_infix)
+		}
+		{
+			token := p.state.Consume(Token_ID)
+			core.AssignToken(current, token, InfixRule_Name_ID)
+			if token != nil {
+				current.SetName(token)
+			}
+		}
+		{
+			token := p.state.Consume(Keyword_on)
+			core.AssignToken(current, token, InfixRule_on)
+		}
+		{
+			p.state.EnterRule(InfixRule__Basic_2)
+			result := p.ParseRuleCall()
+			p.state.ExitRule()
+			if result != nil {
+				current.SetCall(result)
+			}
+		}
+		p.state.Sync(InfixRule__Basic_2)
+		if p.lookahead.InfixRuleOptional(p.state) {
+			{
+				token := p.state.Consume(Keyword_returns)
+				core.AssignToken(current, token, InfixRule_returns)
+			}
+			{
+				token := p.state.Consume(Token_ID)
+				core.AssignToken(current, token, InfixRule_ReturnType_ID)
+				if token != nil {
+					current.SetReturnType(p.referencesConstructor.InfixRuleReturnType(current, token))
+				}
+			}
+		}
+		{
+			token := p.state.Consume(Keyword_Colon)
+			core.AssignToken(current, token, InfixRule_Colon)
+		}
+		{
+			p.state.EnterRule(InfixRule__LoopEntry)
+			result := p.ParsePrecedenceGroup()
+			p.state.ExitRule()
+			if result != nil {
+				current.SetGroupsItem(result)
+			}
+		}
+		p.state.Sync(InfixRule__LoopEntry)
+		for p.lookahead.InfixRuleLoop(p.state) {
+			{
+				token := p.state.Consume(Keyword_GreaterThan)
+				core.AssignToken(current, token, InfixRule_GreaterThan)
+			}
+			{
+				p.state.EnterRule(InfixRule__Basic_5)
+				result := p.ParsePrecedenceGroup()
+				p.state.ExitRule()
+				if result != nil {
+					current.SetGroupsItem(result)
+				}
+			}
+			p.state.Sync(InfixRule__LoopEntry)
+		}
+		{
+			if p.lookahead.InfixRuleSemicolonOptional(p.state) {
+				token := p.state.Consume(Keyword_Semicolon)
+				core.AssignToken(current, token, InfixRule_Semicolon)
+			}
+		}
+	}
+	current.SetTextRangeEnd(p.state.LA(0).Range.End)
+	return current
+}
+
+func (p *Parser) ParsePrecedenceGroup() PrecedenceGroup {
+	current := NewPrecedenceGroup()
+	current.SetTextRangeStart(p.state.LA(1).Range.Start)
+	{
+		p.state.Sync(PrecedenceGroup__Basic_4)
+		if p.lookahead.PrecedenceGroupOptional(p.state) {
+			{
+				switch prediction, _ := p.lookahead.PrecedenceGroupAssociativityAlternatives(p.state); prediction {
+				case 0:
+					token := p.state.Consume(Keyword_left)
+					core.AssignToken(current, token, PrecedenceGroup_Associativity_left)
+					if token != nil {
+						current.SetAssociativity(token)
+					}
+				case 1:
+					token := p.state.Consume(Keyword_right)
+					core.AssignToken(current, token, PrecedenceGroup_Associativity_right)
+					if token != nil {
+						current.SetAssociativity(token)
+					}
+				}
+			}
+			{
+				token := p.state.Consume(Keyword_assoc)
+				core.AssignToken(current, token, PrecedenceGroup_assoc)
+			}
+		}
+		{
+			p.state.EnterRule(PrecedenceGroup__LoopEntry)
+			result := p.ParseInfixOperator()
+			p.state.ExitRule()
+			if result != nil {
+				current.SetOperatorsItem(result)
+			}
+		}
+		p.state.Sync(PrecedenceGroup__LoopEntry)
+		for p.lookahead.PrecedenceGroupLoop(p.state) {
+			{
+				token := p.state.Consume(Keyword_Pipe)
+				core.AssignToken(current, token, PrecedenceGroup_Pipe)
+			}
+			{
+				p.state.EnterRule(PrecedenceGroup__Basic_7)
+				result := p.ParseInfixOperator()
+				p.state.ExitRule()
+				if result != nil {
+					current.SetOperatorsItem(result)
+				}
+			}
+			p.state.Sync(PrecedenceGroup__LoopEntry)
+		}
+	}
+	current.SetTextRangeEnd(p.state.LA(0).Range.End)
+	return current
+}
+
+func (p *Parser) ParseInfixOperator() Assignable {
+	current := NewAssignable()
+	current.SetTextRangeStart(p.state.LA(1).Range.Start)
+	{
+		switch prediction, failure := p.lookahead.InfixOperatorAlternatives(p.state); prediction {
+		case 0:
+			{
+				p.state.EnterRule(InfixOperator__Basic_1)
+				result := p.ParseKeyword()
+				p.state.ExitRule()
+				core.MergeTokens(result, current.Tokens())
+				current = result
+			}
+		case 1:
+			{
+				p.state.EnterRule(InfixOperator__Basic_3)
+				result := p.ParseRuleCall()
+				p.state.ExitRule()
+				core.MergeTokens(result, current.Tokens())
+				current = result
+			}
+		default:
+			p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 		}
 	}
 	current.SetTextRangeEnd(p.state.LA(0).Range.End)

--- a/internal/grammar/parser_lookahead_gen.go
+++ b/internal/grammar/parser_lookahead_gen.go
@@ -23,57 +23,72 @@ var ActionOperatorAlternatives = parser.LL1Lookahead{
 
 var AssignableAlternatives = parser.LL1Lookahead{
 	Types:  []*core.TokenType{Token_StringLiteral, Token_ID, Keyword_LeftBracket, Keyword_LeftParen},
-	Lookup: []int{1: 4, 13: 3, 34: 1, 35: 2},
+	Lookup: []int{1: 4, 14: 3, 40: 1, 41: 2},
 }
 
 var AssignableWithoutAltsAlternatives = parser.LL1Lookahead{
 	Types:  []*core.TokenType{Token_StringLiteral, Token_ID, Keyword_LeftBracket},
-	Lookup: []int{13: 3, 34: 1, 35: 2},
+	Lookup: []int{14: 3, 40: 1, 41: 2},
 }
 
 var AssignmentOperatorAlternatives = parser.LL1Lookahead{
 	Types:  []*core.TokenType{Keyword_PlusEquals, Keyword_Equals, Keyword_QuestionEquals},
-	Lookup: []int{5: 1, 10: 2, 12: 3},
+	Lookup: []int{5: 1, 10: 2, 13: 3},
 }
 
 var CompositeElementAlternatives = parser.LL1Lookahead{
 	Types:  []*core.TokenType{Token_StringLiteral, Token_ID, Keyword_LeftParen},
-	Lookup: []int{1: 3, 34: 1, 35: 2},
+	Lookup: []int{1: 3, 40: 1, 41: 2},
 }
 
 var CompositeElementCardinalityAlternatives = parser.LL1Lookahead{
 	Types:  []*core.TokenType{Keyword_Asterisk, Keyword_Plus, Keyword_Question},
-	Lookup: []int{3: 1, 4: 2, 11: 3},
+	Lookup: []int{3: 1, 4: 2, 12: 3},
 }
 
 var ElementCardinalityAlternatives = parser.LL1Lookahead{
 	Types:  []*core.TokenType{Keyword_Asterisk, Keyword_Plus, Keyword_Question},
-	Lookup: []int{3: 1, 4: 2, 11: 3},
+	Lookup: []int{3: 1, 4: 2, 12: 3},
 }
 
 var FieldTypeAlternatives = parser.LL1Lookahead{
 	Types:  []*core.TokenType{Token_ID, Keyword_Asterisk, Keyword_LeftBracket, Keyword_bool, Keyword_composite, Keyword_string},
-	Lookup: []int{3: 2, 13: 3, 15: 4, 17: 4, 27: 4, 35: 1},
+	Lookup: []int{3: 2, 14: 3, 17: 4, 19: 4, 33: 4, 41: 1},
 }
 
 var GrammarLoop = parser.LL1Lookahead{
-	Types:  []*core.TokenType{Keyword_comment, Keyword_composite, Keyword_entry, Keyword_hidden, Keyword_interface, Keyword_token, Token_ID},
-	Lookup: []int{16: 1, 17: 1, 19: 1, 23: 1, 24: 1, 28: 1, 35: 1},
+	Types:  []*core.TokenType{Keyword_comment, Keyword_composite, Keyword_entry, Keyword_hidden, Keyword_infix, Keyword_interface, Keyword_token, Token_ID},
+	Lookup: []int{18: 1, 19: 1, 21: 1, 25: 1, 26: 1, 27: 1, 34: 1, 41: 1},
+}
+
+var InfixOperatorAlternatives = parser.LL1Lookahead{
+	Types:  []*core.TokenType{Token_StringLiteral, Token_ID},
+	Lookup: []int{40: 1, 41: 2},
+}
+
+var PrecedenceGroupAssociativityAlternatives = parser.LL1Lookahead{
+	Types:  []*core.TokenType{Keyword_left, Keyword_right},
+	Lookup: []int{29: 1, 32: 2},
+}
+
+var PrecedenceGroupOptional = parser.LL1Lookahead{
+	Types:  []*core.TokenType{Keyword_left, Keyword_right},
+	Lookup: []int{29: 1, 32: 1},
 }
 
 var PrimitiveTypeTypeAlternatives = parser.LL1Lookahead{
 	Types:  []*core.TokenType{Keyword_string, Keyword_bool, Keyword_composite},
-	Lookup: []int{15: 2, 17: 3, 27: 1},
+	Lookup: []int{17: 2, 19: 3, 33: 1},
 }
 
 var TokenAlternatives = parser.LL1Lookahead{
 	Types:  []*core.TokenType{Keyword_hidden, Keyword_comment},
-	Lookup: []int{16: 2, 23: 1},
+	Lookup: []int{18: 2, 25: 1},
 }
 
 var TokenGroupAlternatives = parser.LL1Lookahead{
 	Types:  []*core.TokenType{Token_ID, Keyword_keywords, Token_StringLiteral},
-	Lookup: []int{25: 2, 34: 3, 35: 1},
+	Lookup: []int{28: 2, 40: 3, 41: 1},
 }
 
 // FastbeltParserLookahead abstracts every lookahead/prediction decision performed by
@@ -108,12 +123,19 @@ type FastbeltParserLookahead interface {
 	GrammarSemicolonOptional(state *parser.ParserState) bool
 	GroupElementsLoop(state *parser.ParserState) bool
 	GroupOptional(state *parser.ParserState) bool
+	InfixOperatorAlternatives(state *parser.ParserState) (int, *parser.PredictionFailure)
+	InfixRuleLoop(state *parser.ParserState) bool
+	InfixRuleOptional(state *parser.ParserState) bool
+	InfixRuleSemicolonOptional(state *parser.ParserState) bool
 	InterfaceFieldsLoop(state *parser.ParserState) bool
 	InterfaceLoop(state *parser.ParserState) bool
 	InterfaceOptional(state *parser.ParserState) bool
 	ParserRuleEntryOptional(state *parser.ParserState) bool
 	ParserRuleOptional(state *parser.ParserState) bool
 	ParserRuleSemicolonOptional(state *parser.ParserState) bool
+	PrecedenceGroupAssociativityAlternatives(state *parser.ParserState) (int, *parser.PredictionFailure)
+	PrecedenceGroupLoop(state *parser.ParserState) bool
+	PrecedenceGroupOptional(state *parser.ParserState) bool
 	PrimitiveTypeTypeAlternatives(state *parser.ParserState) (int, *parser.PredictionFailure)
 	TokenAlternatives(state *parser.ParserState) (int, *parser.PredictionFailure)
 	TokenGroupAlternatives(state *parser.ParserState) (int, *parser.PredictionFailure)
@@ -235,6 +257,22 @@ func (l *DefaultFastbeltParserLookahead) GroupOptional(state *parser.ParserState
 	return prediction == 0
 }
 
+func (l *DefaultFastbeltParserLookahead) InfixOperatorAlternatives(state *parser.ParserState) (int, *parser.PredictionFailure) {
+	return state.Lookahead(InfixOperatorAlternatives)
+}
+
+func (l *DefaultFastbeltParserLookahead) InfixRuleLoop(state *parser.ParserState) bool {
+	return state.LA(1).Type == Keyword_GreaterThan
+}
+
+func (l *DefaultFastbeltParserLookahead) InfixRuleOptional(state *parser.ParserState) bool {
+	return state.LA(1).Type == Keyword_returns
+}
+
+func (l *DefaultFastbeltParserLookahead) InfixRuleSemicolonOptional(state *parser.ParserState) bool {
+	return state.LA(1).Type == Keyword_Semicolon
+}
+
 func (l *DefaultFastbeltParserLookahead) InterfaceFieldsLoop(state *parser.ParserState) bool {
 	return state.LA(1).Type == Token_ID
 }
@@ -257,6 +295,19 @@ func (l *DefaultFastbeltParserLookahead) ParserRuleOptional(state *parser.Parser
 
 func (l *DefaultFastbeltParserLookahead) ParserRuleSemicolonOptional(state *parser.ParserState) bool {
 	return state.LA(1).Type == Keyword_Semicolon
+}
+
+func (l *DefaultFastbeltParserLookahead) PrecedenceGroupAssociativityAlternatives(state *parser.ParserState) (int, *parser.PredictionFailure) {
+	return state.Lookahead(PrecedenceGroupAssociativityAlternatives)
+}
+
+func (l *DefaultFastbeltParserLookahead) PrecedenceGroupLoop(state *parser.ParserState) bool {
+	return state.LA(1).Type == Keyword_Pipe
+}
+
+func (l *DefaultFastbeltParserLookahead) PrecedenceGroupOptional(state *parser.ParserState) bool {
+	prediction, _ := state.Lookahead(PrecedenceGroupOptional)
+	return prediction == 0
 }
 
 func (l *DefaultFastbeltParserLookahead) PrimitiveTypeTypeAlternatives(state *parser.ParserState) (int, *parser.PredictionFailure) {

--- a/internal/grammar/parser_lookahead_gen.go
+++ b/internal/grammar/parser_lookahead_gen.go
@@ -23,12 +23,12 @@ var ActionOperatorAlternatives = parser.LL1Lookahead{
 
 var AssignableAlternatives = parser.LL1Lookahead{
 	Types:  []*core.TokenType{Token_StringLiteral, Token_ID, Keyword_LeftBracket, Keyword_LeftParen},
-	Lookup: []int{1: 4, 14: 3, 40: 1, 41: 2},
+	Lookup: []int{1: 4, 14: 3, 39: 1, 40: 2},
 }
 
 var AssignableWithoutAltsAlternatives = parser.LL1Lookahead{
 	Types:  []*core.TokenType{Token_StringLiteral, Token_ID, Keyword_LeftBracket},
-	Lookup: []int{14: 3, 40: 1, 41: 2},
+	Lookup: []int{14: 3, 39: 1, 40: 2},
 }
 
 var AssignmentOperatorAlternatives = parser.LL1Lookahead{
@@ -38,7 +38,7 @@ var AssignmentOperatorAlternatives = parser.LL1Lookahead{
 
 var CompositeElementAlternatives = parser.LL1Lookahead{
 	Types:  []*core.TokenType{Token_StringLiteral, Token_ID, Keyword_LeftParen},
-	Lookup: []int{1: 3, 40: 1, 41: 2},
+	Lookup: []int{1: 3, 39: 1, 40: 2},
 }
 
 var CompositeElementCardinalityAlternatives = parser.LL1Lookahead{
@@ -53,42 +53,37 @@ var ElementCardinalityAlternatives = parser.LL1Lookahead{
 
 var FieldTypeAlternatives = parser.LL1Lookahead{
 	Types:  []*core.TokenType{Token_ID, Keyword_Asterisk, Keyword_LeftBracket, Keyword_bool, Keyword_composite, Keyword_string},
-	Lookup: []int{3: 2, 14: 3, 17: 4, 19: 4, 33: 4, 41: 1},
+	Lookup: []int{3: 2, 14: 3, 16: 4, 18: 4, 32: 4, 40: 1},
 }
 
 var GrammarLoop = parser.LL1Lookahead{
 	Types:  []*core.TokenType{Keyword_comment, Keyword_composite, Keyword_entry, Keyword_hidden, Keyword_infix, Keyword_interface, Keyword_token, Token_ID},
-	Lookup: []int{18: 1, 19: 1, 21: 1, 25: 1, 26: 1, 27: 1, 34: 1, 41: 1},
+	Lookup: []int{17: 1, 18: 1, 20: 1, 24: 1, 25: 1, 26: 1, 33: 1, 40: 1},
 }
 
 var InfixOperatorAlternatives = parser.LL1Lookahead{
 	Types:  []*core.TokenType{Token_StringLiteral, Token_ID},
-	Lookup: []int{40: 1, 41: 2},
+	Lookup: []int{39: 1, 40: 2},
 }
 
 var PrecedenceGroupAssociativityAlternatives = parser.LL1Lookahead{
 	Types:  []*core.TokenType{Keyword_left, Keyword_right},
-	Lookup: []int{29: 1, 32: 2},
-}
-
-var PrecedenceGroupOptional = parser.LL1Lookahead{
-	Types:  []*core.TokenType{Keyword_left, Keyword_right},
-	Lookup: []int{29: 1, 32: 1},
+	Lookup: []int{28: 1, 31: 2},
 }
 
 var PrimitiveTypeTypeAlternatives = parser.LL1Lookahead{
 	Types:  []*core.TokenType{Keyword_string, Keyword_bool, Keyword_composite},
-	Lookup: []int{17: 2, 19: 3, 33: 1},
+	Lookup: []int{16: 2, 18: 3, 32: 1},
 }
 
 var TokenAlternatives = parser.LL1Lookahead{
 	Types:  []*core.TokenType{Keyword_hidden, Keyword_comment},
-	Lookup: []int{18: 2, 25: 1},
+	Lookup: []int{17: 2, 24: 1},
 }
 
 var TokenGroupAlternatives = parser.LL1Lookahead{
 	Types:  []*core.TokenType{Token_ID, Keyword_keywords, Token_StringLiteral},
-	Lookup: []int{28: 2, 40: 3, 41: 1},
+	Lookup: []int{27: 2, 39: 3, 40: 1},
 }
 
 // FastbeltParserLookahead abstracts every lookahead/prediction decision performed by
@@ -135,7 +130,6 @@ type FastbeltParserLookahead interface {
 	ParserRuleSemicolonOptional(state *parser.ParserState) bool
 	PrecedenceGroupAssociativityAlternatives(state *parser.ParserState) (int, *parser.PredictionFailure)
 	PrecedenceGroupLoop(state *parser.ParserState) bool
-	PrecedenceGroupOptional(state *parser.ParserState) bool
 	PrimitiveTypeTypeAlternatives(state *parser.ParserState) (int, *parser.PredictionFailure)
 	TokenAlternatives(state *parser.ParserState) (int, *parser.PredictionFailure)
 	TokenGroupAlternatives(state *parser.ParserState) (int, *parser.PredictionFailure)
@@ -303,11 +297,6 @@ func (l *DefaultFastbeltParserLookahead) PrecedenceGroupAssociativityAlternative
 
 func (l *DefaultFastbeltParserLookahead) PrecedenceGroupLoop(state *parser.ParserState) bool {
 	return state.LA(1).Type == Keyword_Pipe
-}
-
-func (l *DefaultFastbeltParserLookahead) PrecedenceGroupOptional(state *parser.ParserState) bool {
-	prediction, _ := state.Lookahead(PrecedenceGroupOptional)
-	return prediction == 0
 }
 
 func (l *DefaultFastbeltParserLookahead) PrimitiveTypeTypeAlternatives(state *parser.ParserState) (int, *parser.PredictionFailure) {

--- a/internal/grammar/parser_test.go
+++ b/internal/grammar/parser_test.go
@@ -77,6 +77,89 @@ func TestOptionalSemicolonAfterStarBeforeReturnsRule(t *testing.T) {
 	assert.Equal(t, "Multiplication", g.Rules()[1].Name())
 }
 
+const infixInterfaces = `
+	interface Expression { Value string }
+	interface BinaryExpression extends Expression {
+		Left Expression
+		Operator string
+		Right Expression
+	}
+	PrimaryExpression returns Expression: Value=ID
+`
+
+func TestInfixRule(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+	`+infixInterfaces+`
+		infix BinaryExpression on PrimaryExpression:
+			"%"
+			> "^"
+			> "*" | "/"
+			> "+" | "-"
+	`+commonTokens)
+	doc.AssertNoParseErrors()
+	g := doc.Document.Root.(Grammar)
+	require.Len(t, g.InfixRules(), 1)
+	rule := g.InfixRules()[0]
+	assert.Equal(t, "BinaryExpression", rule.Name())
+	assert.Equal(t, "PrimaryExpression", rule.Call().Rule().Ref(doc.Ctx()).Name())
+	assert.Nil(t, rule.ReturnType())
+	require.Len(t, rule.Groups(), 4)
+	require.Len(t, rule.Groups()[2].Operators(), 2)
+	assert.Equal(t, "", rule.Groups()[2].Associativity())
+	assert.Equal(t, `"*"`, rule.Groups()[2].Operators()[0].(Keyword).Value())
+	assert.Equal(t, `"/"`, rule.Groups()[2].Operators()[1].(Keyword).Value())
+}
+
+func TestInfixRuleReturnsAndAssociativity(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+	`+infixInterfaces+`
+		infix BinaryExpression on PrimaryExpression returns Expression:
+			"*" | "/"
+			> "+" | "-"
+			> right assoc "="
+	`+commonTokens)
+	doc.AssertNoParseErrors()
+	g := doc.Document.Root.(Grammar)
+	require.Len(t, g.InfixRules(), 1)
+	rule := g.InfixRules()[0]
+	assert.Equal(t, "Expression", rule.ReturnType().Ref(doc.Ctx()).Name())
+	require.Len(t, rule.Groups(), 3)
+	assert.Equal(t, "", rule.Groups()[0].Associativity())
+	assert.Equal(t, "right", rule.Groups()[2].Associativity())
+	require.Len(t, rule.Groups()[2].Operators(), 1)
+	assert.Equal(t, `"="`, rule.Groups()[2].Operators()[0].(Keyword).Value())
+}
+
+func TestInfixRuleTokenOperators(t *testing.T) {
+	f := test.New(t, CreateServices())
+	doc := f.Parse(`
+		grammar Test;
+	`+infixInterfaces+`
+		token group MulOp { "*" "/" }
+		token POW: /\^+/;
+		infix BinaryExpression on PrimaryExpression:
+			POW
+			> MulOp
+			> left assoc "+" | "-"
+	`+commonTokens)
+	doc.AssertNoParseErrors()
+	doc.AssertNoLinkingErrors()
+	g := doc.Document.Root.(Grammar)
+	require.Len(t, g.InfixRules(), 1)
+	rule := g.InfixRules()[0]
+	require.Len(t, rule.Groups(), 3)
+	pow := rule.Groups()[0].Operators()[0].(RuleCall)
+	assert.Equal(t, "POW", pow.Rule().Ref(doc.Ctx()).Name())
+	mul := rule.Groups()[1].Operators()[0].(RuleCall)
+	assert.Equal(t, "MulOp", mul.Rule().Ref(doc.Ctx()).Name())
+	assert.Equal(t, "left", rule.Groups()[2].Associativity())
+	require.Len(t, rule.Groups()[2].Operators(), 2)
+}
+
 func TestOptionalSemicolonStarRuleBeforePlainRule(t *testing.T) {
 	f := test.New(t, CreateServices())
 	doc := f.Parse(`

--- a/internal/grammar/parser_test.go
+++ b/internal/grammar/parser_test.go
@@ -91,13 +91,13 @@ func TestInfixRule(t *testing.T) {
 	f := test.New(t, CreateServices())
 	doc := f.Parse(`
 		grammar Test;
-	`+infixInterfaces+`
+	` + infixInterfaces + `
 		infix BinaryExpression on PrimaryExpression:
 			"%"
 			> "^"
 			> "*" | "/"
 			> "+" | "-"
-	`+commonTokens)
+	` + commonTokens)
 	doc.AssertNoParseErrors()
 	g := doc.Document.Root.(Grammar)
 	require.Len(t, g.InfixRules(), 1)
@@ -116,12 +116,12 @@ func TestInfixRuleReturnsAndAssociativity(t *testing.T) {
 	f := test.New(t, CreateServices())
 	doc := f.Parse(`
 		grammar Test;
-	`+infixInterfaces+`
+	` + infixInterfaces + `
 		infix BinaryExpression on PrimaryExpression returns Expression:
 			"*" | "/"
 			> "+" | "-"
-			> right assoc "="
-	`+commonTokens)
+			> right "="
+	` + commonTokens)
 	doc.AssertNoParseErrors()
 	g := doc.Document.Root.(Grammar)
 	require.Len(t, g.InfixRules(), 1)
@@ -138,14 +138,14 @@ func TestInfixRuleTokenOperators(t *testing.T) {
 	f := test.New(t, CreateServices())
 	doc := f.Parse(`
 		grammar Test;
-	`+infixInterfaces+`
+	` + infixInterfaces + `
 		token group MulOp { "*" "/" }
 		token POW: /\^+/;
 		infix BinaryExpression on PrimaryExpression:
 			POW
 			> MulOp
-			> left assoc "+" | "-"
-	`+commonTokens)
+			> left "+" | "-"
+	` + commonTokens)
 	doc.AssertNoParseErrors()
 	doc.AssertNoLinkingErrors()
 	g := doc.Document.Root.(Grammar)

--- a/internal/grammar/symbol_kinds.go
+++ b/internal/grammar/symbol_kinds.go
@@ -31,3 +31,7 @@ func (f *FieldImpl) SymbolKind() lsp.SymbolKind {
 func (t *TokenImpl) SymbolKind() lsp.SymbolKind {
 	return lsp.Constant
 }
+
+func (r *InfixRuleImpl) SymbolKind() lsp.SymbolKind {
+	return lsp.Function
+}

--- a/internal/grammar/types_gen.go
+++ b/internal/grammar/types_gen.go
@@ -20,6 +20,8 @@ type Grammar interface {
 	SetRulesItem(item ParserRule)
 	Composites() []CompositeRule
 	SetCompositesItem(item CompositeRule)
+	InfixRules() []InfixRule
+	SetInfixRulesItem(item InfixRule)
 	Terminals() []Token
 	SetTerminalsItem(item Token)
 	TokenGroups() []TokenGroup
@@ -29,16 +31,31 @@ type Grammar interface {
 }
 
 func NewGrammar() Grammar {
-	return &GrammarImpl{}
+	return &GrammarImpl{
+		AstNodeBase: core.NewAstNode(),
+		GrammarData: NewGrammarData(),
+	}
 }
 
 type GrammarData struct {
 	name        *core.Token
 	rules       []ParserRule
 	composites  []CompositeRule
+	infixRules  []InfixRule
 	terminals   []Token
 	tokenGroups []TokenGroup
 	interfaces  []Interface
+}
+
+func NewGrammarData() GrammarData {
+	return GrammarData{
+		rules:       []ParserRule{},
+		composites:  []CompositeRule{},
+		infixRules:  []InfixRule{},
+		terminals:   []Token{},
+		tokenGroups: []TokenGroup{},
+		interfaces:  []Interface{},
+	}
 }
 
 func (i *GrammarData) IsGrammar() {}
@@ -49,6 +66,9 @@ func (i *GrammarData) ForEachNode(fn func(core.AstNode, unique.Handle[string], i
 	}
 	for j, item := range i.composites {
 		fn(item, fieldNameComposites, j)
+	}
+	for j, item := range i.infixRules {
+		fn(item, fieldNameInfixRules, j)
 	}
 	for j, item := range i.terminals {
 		fn(item, fieldNameTerminals, j)
@@ -94,6 +114,14 @@ func (i *GrammarData) Composites() []CompositeRule {
 
 func (i *GrammarData) SetCompositesItem(item CompositeRule) {
 	i.composites = append(i.composites, item)
+}
+
+func (i *GrammarData) InfixRules() []InfixRule {
+	return i.infixRules
+}
+
+func (i *GrammarData) SetInfixRulesItem(item InfixRule) {
+	i.infixRules = append(i.infixRules, item)
 }
 
 func (i *GrammarData) Terminals() []Token {
@@ -148,6 +176,17 @@ func (i *GrammarImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
 		if child == nil {
 			nodePath, _ := core.PathOf(i)
 			return nil, fmt.Errorf("GrammarImpl.Resolve: item %d of slice in field 'composites' is nil in node '%s'", index, nodePath)
+		}
+		return child.Resolve(path.Tail())
+	case fieldNameInfixRules:
+		if index >= len(i.InfixRules()) {
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("GrammarImpl.Resolve: index %d exceeds length of slice in 'infixRules' (length=%d) in node '%s'", index, len(i.InfixRules()), nodePath)
+		}
+		child := i.InfixRules()[index]
+		if child == nil {
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("GrammarImpl.Resolve: item %d of slice in field 'infixRules' is nil in node '%s'", index, nodePath)
 		}
 		return child.Resolve(path.Tail())
 	case fieldNameInterfaces:
@@ -216,13 +255,23 @@ type Interface interface {
 }
 
 func NewInterface() Interface {
-	return &InterfaceImpl{}
+	return &InterfaceImpl{
+		AstNodeBase:   core.NewAstNode(),
+		InterfaceData: NewInterfaceData(),
+	}
 }
 
 type InterfaceData struct {
 	name    *core.Token
 	extends []*core.Reference[Interface]
 	fields  []Field
+}
+
+func NewInterfaceData() InterfaceData {
+	return InterfaceData{
+		extends: []*core.Reference[Interface]{},
+		fields:  []Field{},
+	}
 }
 
 func (i *InterfaceData) IsInterface() {}
@@ -323,12 +372,19 @@ type Field interface {
 }
 
 func NewField() Field {
-	return &FieldImpl{}
+	return &FieldImpl{
+		AstNodeBase: core.NewAstNode(),
+		FieldData:   NewFieldData(),
+	}
 }
 
 type FieldData struct {
 	name  *core.Token
 	_Type FieldType
+}
+
+func NewFieldData() FieldData {
+	return FieldData{}
 }
 
 func (i *FieldData) IsField() {}
@@ -411,10 +467,17 @@ type FieldType interface {
 }
 
 func NewFieldType() FieldType {
-	return &FieldTypeImpl{}
+	return &FieldTypeImpl{
+		AstNodeBase:   core.NewAstNode(),
+		FieldTypeData: NewFieldTypeData(),
+	}
 }
 
 type FieldTypeData struct {
+}
+
+func NewFieldTypeData() FieldTypeData {
+	return FieldTypeData{}
 }
 
 func (i *FieldTypeData) IsFieldType() {}
@@ -457,11 +520,19 @@ type ArrayType interface {
 }
 
 func NewArrayType() ArrayType {
-	return &ArrayTypeImpl{}
+	return &ArrayTypeImpl{
+		AstNodeBase:   core.NewAstNode(),
+		FieldTypeData: NewFieldTypeData(),
+		ArrayTypeData: NewArrayTypeData(),
+	}
 }
 
 type ArrayTypeData struct {
 	internalType FieldType
+}
+
+func NewArrayTypeData() ArrayTypeData {
+	return ArrayTypeData{}
 }
 
 func (i *ArrayTypeData) IsArrayType() {}
@@ -532,11 +603,19 @@ type ReferenceType interface {
 }
 
 func NewReferenceType() ReferenceType {
-	return &ReferenceTypeImpl{}
+	return &ReferenceTypeImpl{
+		AstNodeBase:       core.NewAstNode(),
+		FieldTypeData:     NewFieldTypeData(),
+		ReferenceTypeData: NewReferenceTypeData(),
+	}
 }
 
 type ReferenceTypeData struct {
 	_Type *core.Reference[Interface]
+}
+
+func NewReferenceTypeData() ReferenceTypeData {
+	return ReferenceTypeData{}
 }
 
 func (i *ReferenceTypeData) IsReferenceType() {}
@@ -602,11 +681,19 @@ type SimpleType interface {
 }
 
 func NewSimpleType() SimpleType {
-	return &SimpleTypeImpl{}
+	return &SimpleTypeImpl{
+		AstNodeBase:    core.NewAstNode(),
+		FieldTypeData:  NewFieldTypeData(),
+		SimpleTypeData: NewSimpleTypeData(),
+	}
 }
 
 type SimpleTypeData struct {
 	_Type *core.Reference[Interface]
+}
+
+func NewSimpleTypeData() SimpleTypeData {
+	return SimpleTypeData{}
 }
 
 func (i *SimpleTypeData) IsSimpleType() {}
@@ -673,11 +760,19 @@ type PrimitiveType interface {
 }
 
 func NewPrimitiveType() PrimitiveType {
-	return &PrimitiveTypeImpl{}
+	return &PrimitiveTypeImpl{
+		AstNodeBase:       core.NewAstNode(),
+		FieldTypeData:     NewFieldTypeData(),
+		PrimitiveTypeData: NewPrimitiveTypeData(),
+	}
 }
 
 type PrimitiveTypeData struct {
 	_Type *core.Token
+}
+
+func NewPrimitiveTypeData() PrimitiveTypeData {
+	return PrimitiveTypeData{}
 }
 
 func (i *PrimitiveTypeData) IsPrimitiveType() {}
@@ -744,11 +839,18 @@ type AbstractRule interface {
 }
 
 func NewAbstractRule() AbstractRule {
-	return &AbstractRuleImpl{}
+	return &AbstractRuleImpl{
+		AstNodeBase:      core.NewAstNode(),
+		AbstractRuleData: NewAbstractRuleData(),
+	}
 }
 
 type AbstractRuleData struct {
 	name *core.Token
+}
+
+func NewAbstractRuleData() AbstractRuleData {
+	return AbstractRuleData{}
 }
 
 func (i *AbstractRuleData) IsAbstractRule() {}
@@ -812,11 +914,19 @@ type AbstractRuleWithBody interface {
 }
 
 func NewAbstractRuleWithBody() AbstractRuleWithBody {
-	return &AbstractRuleWithBodyImpl{}
+	return &AbstractRuleWithBodyImpl{
+		AstNodeBase:              core.NewAstNode(),
+		AbstractRuleData:         NewAbstractRuleData(),
+		AbstractRuleWithBodyData: NewAbstractRuleWithBodyData(),
+	}
 }
 
 type AbstractRuleWithBodyData struct {
 	body Element
+}
+
+func NewAbstractRuleWithBodyData() AbstractRuleWithBodyData {
+	return AbstractRuleWithBodyData{}
 }
 
 func (i *AbstractRuleWithBodyData) IsAbstractRuleWithBody() {}
@@ -887,10 +997,18 @@ type AbstractTokenRule interface {
 }
 
 func NewAbstractTokenRule() AbstractTokenRule {
-	return &AbstractTokenRuleImpl{}
+	return &AbstractTokenRuleImpl{
+		AstNodeBase:           core.NewAstNode(),
+		AbstractRuleData:      NewAbstractRuleData(),
+		AbstractTokenRuleData: NewAbstractTokenRuleData(),
+	}
 }
 
 type AbstractTokenRuleData struct {
+}
+
+func NewAbstractTokenRuleData() AbstractTokenRuleData {
+	return AbstractTokenRuleData{}
 }
 
 func (i *AbstractTokenRuleData) IsAbstractTokenRule() {}
@@ -944,12 +1062,21 @@ type ParserRule interface {
 }
 
 func NewParserRule() ParserRule {
-	return &ParserRuleImpl{}
+	return &ParserRuleImpl{
+		AstNodeBase:              core.NewAstNode(),
+		AbstractRuleWithBodyData: NewAbstractRuleWithBodyData(),
+		AbstractRuleData:         NewAbstractRuleData(),
+		ParserRuleData:           NewParserRuleData(),
+	}
 }
 
 type ParserRuleData struct {
 	entry      *core.Token
 	returnType *core.Reference[Interface]
+}
+
+func NewParserRuleData() ParserRuleData {
+	return ParserRuleData{}
 }
 
 func (i *ParserRuleData) IsParserRule() {}
@@ -1045,12 +1172,21 @@ type Token interface {
 }
 
 func NewToken() Token {
-	return &TokenImpl{}
+	return &TokenImpl{
+		AstNodeBase:           core.NewAstNode(),
+		AbstractTokenRuleData: NewAbstractTokenRuleData(),
+		AbstractRuleData:      NewAbstractRuleData(),
+		TokenData:             NewTokenData(),
+	}
 }
 
 type TokenData struct {
 	_Type  *core.Token
 	regexp *core.Token
+}
+
+func NewTokenData() TokenData {
+	return TokenData{}
 }
 
 func (i *TokenData) IsToken() {}
@@ -1144,13 +1280,26 @@ type TokenGroup interface {
 }
 
 func NewTokenGroup() TokenGroup {
-	return &TokenGroupImpl{}
+	return &TokenGroupImpl{
+		AstNodeBase:           core.NewAstNode(),
+		AbstractTokenRuleData: NewAbstractTokenRuleData(),
+		AbstractRuleData:      NewAbstractRuleData(),
+		TokenGroupData:        NewTokenGroupData(),
+	}
 }
 
 type TokenGroupData struct {
 	tokenRefs []*core.Reference[AbstractTokenRule]
 	regexps   []*core.Token
 	keywords  []Keyword
+}
+
+func NewTokenGroupData() TokenGroupData {
+	return TokenGroupData{
+		tokenRefs: []*core.Reference[AbstractTokenRule]{},
+		regexps:   []*core.Token{},
+		keywords:  []Keyword{},
+	}
 }
 
 func (i *TokenGroupData) IsTokenGroup() {}
@@ -1249,11 +1398,18 @@ type Element interface {
 }
 
 func NewElement() Element {
-	return &ElementImpl{}
+	return &ElementImpl{
+		AstNodeBase: core.NewAstNode(),
+		ElementData: NewElementData(),
+	}
 }
 
 type ElementData struct {
 	cardinality *core.Token
+}
+
+func NewElementData() ElementData {
+	return ElementData{}
 }
 
 func (i *ElementData) IsElement() {}
@@ -1317,11 +1473,22 @@ type Alternatives interface {
 }
 
 func NewAlternatives() Alternatives {
-	return &AlternativesImpl{}
+	return &AlternativesImpl{
+		AstNodeBase:      core.NewAstNode(),
+		AssignableData:   NewAssignableData(),
+		ElementData:      NewElementData(),
+		AlternativesData: NewAlternativesData(),
+	}
 }
 
 type AlternativesData struct {
 	alts []Element
+}
+
+func NewAlternativesData() AlternativesData {
+	return AlternativesData{
+		alts: []Element{},
+	}
 }
 
 func (i *AlternativesData) IsAlternatives() {}
@@ -1397,11 +1564,21 @@ type Group interface {
 }
 
 func NewGroup() Group {
-	return &GroupImpl{}
+	return &GroupImpl{
+		AstNodeBase: core.NewAstNode(),
+		ElementData: NewElementData(),
+		GroupData:   NewGroupData(),
+	}
 }
 
 type GroupData struct {
 	elements []Element
+}
+
+func NewGroupData() GroupData {
+	return GroupData{
+		elements: []Element{},
+	}
 }
 
 func (i *GroupData) IsGroup() {}
@@ -1475,11 +1652,20 @@ type Keyword interface {
 }
 
 func NewKeyword() Keyword {
-	return &KeywordImpl{}
+	return &KeywordImpl{
+		AstNodeBase:    core.NewAstNode(),
+		AssignableData: NewAssignableData(),
+		ElementData:    NewElementData(),
+		KeywordData:    NewKeywordData(),
+	}
 }
 
 type KeywordData struct {
 	value *core.Token
+}
+
+func NewKeywordData() KeywordData {
+	return KeywordData{}
 }
 
 func (i *KeywordData) IsKeyword() {}
@@ -1556,13 +1742,21 @@ type Assignment interface {
 }
 
 func NewAssignment() Assignment {
-	return &AssignmentImpl{}
+	return &AssignmentImpl{
+		AstNodeBase:    core.NewAstNode(),
+		ElementData:    NewElementData(),
+		AssignmentData: NewAssignmentData(),
+	}
 }
 
 type AssignmentData struct {
 	property *core.Reference[Field]
 	operator *core.Token
 	value    Assignable
+}
+
+func NewAssignmentData() AssignmentData {
+	return AssignmentData{}
 }
 
 func (i *AssignmentData) IsAssignment() {}
@@ -1668,10 +1862,18 @@ type Assignable interface {
 }
 
 func NewAssignable() Assignable {
-	return &AssignableImpl{}
+	return &AssignableImpl{
+		AstNodeBase:    core.NewAstNode(),
+		ElementData:    NewElementData(),
+		AssignableData: NewAssignableData(),
+	}
 }
 
 type AssignableData struct {
+}
+
+func NewAssignableData() AssignableData {
+	return AssignableData{}
 }
 
 func (i *AssignableData) IsAssignable() {}
@@ -1724,12 +1926,21 @@ type CrossRef interface {
 }
 
 func NewCrossRef() CrossRef {
-	return &CrossRefImpl{}
+	return &CrossRefImpl{
+		AstNodeBase:    core.NewAstNode(),
+		AssignableData: NewAssignableData(),
+		ElementData:    NewElementData(),
+		CrossRefData:   NewCrossRefData(),
+	}
 }
 
 type CrossRefData struct {
 	_Type *core.Reference[Interface]
 	rule  RuleCall
+}
+
+func NewCrossRefData() CrossRefData {
+	return CrossRefData{}
 }
 
 func (i *CrossRefData) IsCrossRef() {}
@@ -1822,11 +2033,20 @@ type RuleCall interface {
 }
 
 func NewRuleCall() RuleCall {
-	return &RuleCallImpl{}
+	return &RuleCallImpl{
+		AstNodeBase:    core.NewAstNode(),
+		AssignableData: NewAssignableData(),
+		ElementData:    NewElementData(),
+		RuleCallData:   NewRuleCallData(),
+	}
 }
 
 type RuleCallData struct {
 	rule *core.Reference[AbstractRule]
+}
+
+func NewRuleCallData() RuleCallData {
+	return RuleCallData{}
 }
 
 func (i *RuleCallData) IsRuleCall() {}
@@ -1902,13 +2122,21 @@ type Action interface {
 }
 
 func NewAction() Action {
-	return &ActionImpl{}
+	return &ActionImpl{
+		AstNodeBase: core.NewAstNode(),
+		ElementData: NewElementData(),
+		ActionData:  NewActionData(),
+	}
 }
 
 type ActionData struct {
 	_Type    *core.Reference[Interface]
 	operator *core.Token
 	property *core.Reference[Field]
+}
+
+func NewActionData() ActionData {
+	return ActionData{}
 }
 
 func (i *ActionData) IsAction() {}
@@ -2009,10 +2237,19 @@ type CompositeRule interface {
 }
 
 func NewCompositeRule() CompositeRule {
-	return &CompositeRuleImpl{}
+	return &CompositeRuleImpl{
+		AstNodeBase:              core.NewAstNode(),
+		AbstractRuleWithBodyData: NewAbstractRuleWithBodyData(),
+		AbstractRuleData:         NewAbstractRuleData(),
+		CompositeRuleData:        NewCompositeRuleData(),
+	}
 }
 
 type CompositeRuleData struct {
+}
+
+func NewCompositeRuleData() CompositeRuleData {
+	return CompositeRuleData{}
 }
 
 func (i *CompositeRuleData) IsCompositeRule() {}
@@ -2063,31 +2300,281 @@ func (i *CompositeRuleImpl) Resolve(path core.FragmentPath) (core.AstNode, error
 	}
 }
 
+type InfixRule interface {
+	core.AstNode
+	AbstractRuleWithBody
+
+	IsInfixRule()
+	Call() RuleCall
+	SetCall(value RuleCall)
+	ReturnType() *core.Reference[Interface]
+	SetReturnType(value *core.Reference[Interface])
+	Groups() []PrecedenceGroup
+	SetGroupsItem(item PrecedenceGroup)
+}
+
+func NewInfixRule() InfixRule {
+	return &InfixRuleImpl{
+		AstNodeBase:              core.NewAstNode(),
+		AbstractRuleWithBodyData: NewAbstractRuleWithBodyData(),
+		AbstractRuleData:         NewAbstractRuleData(),
+		InfixRuleData:            NewInfixRuleData(),
+	}
+}
+
+type InfixRuleData struct {
+	call       RuleCall
+	returnType *core.Reference[Interface]
+	groups     []PrecedenceGroup
+}
+
+func NewInfixRuleData() InfixRuleData {
+	return InfixRuleData{
+		groups: []PrecedenceGroup{},
+	}
+}
+
+func (i *InfixRuleData) IsInfixRule() {}
+
+func (i *InfixRuleData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
+	if i.call != nil {
+		fn(i.call, fieldNameCall, -1)
+	}
+	for j, item := range i.groups {
+		fn(item, fieldNameGroups, j)
+	}
+}
+
+func (i *InfixRuleData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
+	if i.returnType != nil {
+		fn(i.returnType, fieldNameReturnType, -1)
+	}
+}
+
+func (i *InfixRuleData) Call() RuleCall {
+	if i != nil && i.call != nil {
+		return i.call
+	} else {
+		return nil
+	}
+}
+
+func (i *InfixRuleData) SetCall(value RuleCall) {
+	i.call = value
+}
+
+func (i *InfixRuleData) ReturnType() *core.Reference[Interface] {
+	if i != nil && i.returnType != nil {
+		return i.returnType
+	} else {
+		return nil
+	}
+}
+
+func (i *InfixRuleData) SetReturnType(value *core.Reference[Interface]) {
+	i.returnType = value
+}
+
+func (i *InfixRuleData) Groups() []PrecedenceGroup {
+	return i.groups
+}
+
+func (i *InfixRuleData) SetGroupsItem(item PrecedenceGroup) {
+	i.groups = append(i.groups, item)
+}
+
+type InfixRuleImpl struct {
+	core.AstNodeBase
+	AbstractRuleWithBodyData
+	AbstractRuleData
+	InfixRuleData
+}
+
+func (i *InfixRuleImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
+	i.AbstractRuleWithBodyData.ForEachNode(fn)
+	i.AbstractRuleData.ForEachNode(fn)
+	i.InfixRuleData.ForEachNode(fn)
+}
+
+func (i *InfixRuleImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
+	i.AbstractRuleWithBodyData.ForEachReference(fn)
+	i.AbstractRuleData.ForEachReference(fn)
+	i.InfixRuleData.ForEachReference(fn)
+}
+
+func (i *InfixRuleImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
+	if path.Empty() {
+		return i, nil
+	}
+	field, index := path.Head()
+	switch field {
+	case fieldNameBody:
+		if i.Body() == nil {
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("InfixRuleImpl.Resolve: field 'body' is nil in node '%s'", nodePath)
+		}
+		child := i.Body()
+		return child.Resolve(path.Tail())
+	case fieldNameCall:
+		if i.Call() == nil {
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("InfixRuleImpl.Resolve: field 'call' is nil in node '%s'", nodePath)
+		}
+		child := i.Call()
+		return child.Resolve(path.Tail())
+	case fieldNameGroups:
+		if index >= len(i.Groups()) {
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("InfixRuleImpl.Resolve: index %d exceeds length of slice in 'groups' (length=%d) in node '%s'", index, len(i.Groups()), nodePath)
+		}
+		child := i.Groups()[index]
+		if child == nil {
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("InfixRuleImpl.Resolve: item %d of slice in field 'groups' is nil in node '%s'", index, nodePath)
+		}
+		return child.Resolve(path.Tail())
+	case fieldNameName:
+		return nil, fmt.Errorf("InfixRuleImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
+	case fieldNameReturnType:
+		return nil, fmt.Errorf("InfixRuleImpl.Resolve: field 'returnType' is a cross-reference instead of a container field")
+	default:
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("InfixRuleImpl.Resolve: field '%s' does not exist in node '%s' of type 'InfixRule'", field.Value(), nodePath)
+	}
+}
+
+type PrecedenceGroup interface {
+	core.AstNode
+
+	IsPrecedenceGroup()
+	Associativity() string
+	AssociativityToken() *core.Token
+	SetAssociativity(value *core.Token)
+	Operators() []Assignable
+	SetOperatorsItem(item Assignable)
+}
+
+func NewPrecedenceGroup() PrecedenceGroup {
+	return &PrecedenceGroupImpl{
+		AstNodeBase:         core.NewAstNode(),
+		PrecedenceGroupData: NewPrecedenceGroupData(),
+	}
+}
+
+type PrecedenceGroupData struct {
+	associativity *core.Token
+	operators     []Assignable
+}
+
+func NewPrecedenceGroupData() PrecedenceGroupData {
+	return PrecedenceGroupData{
+		operators: []Assignable{},
+	}
+}
+
+func (i *PrecedenceGroupData) IsPrecedenceGroup() {}
+
+func (i *PrecedenceGroupData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
+	for j, item := range i.operators {
+		fn(item, fieldNameOperators, j)
+	}
+}
+
+func (i *PrecedenceGroupData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
+}
+
+func (i *PrecedenceGroupData) Associativity() string {
+	if i != nil && i.associativity != nil {
+		return i.associativity.Image
+	} else {
+		return ""
+	}
+}
+
+func (i *PrecedenceGroupData) AssociativityToken() *core.Token {
+	return i.associativity
+}
+
+func (i *PrecedenceGroupData) SetAssociativity(value *core.Token) {
+	i.associativity = value
+}
+
+func (i *PrecedenceGroupData) Operators() []Assignable {
+	return i.operators
+}
+
+func (i *PrecedenceGroupData) SetOperatorsItem(item Assignable) {
+	i.operators = append(i.operators, item)
+}
+
+type PrecedenceGroupImpl struct {
+	core.AstNodeBase
+	PrecedenceGroupData
+}
+
+func (i *PrecedenceGroupImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
+	i.PrecedenceGroupData.ForEachNode(fn)
+}
+
+func (i *PrecedenceGroupImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
+	i.PrecedenceGroupData.ForEachReference(fn)
+}
+
+func (i *PrecedenceGroupImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
+	if path.Empty() {
+		return i, nil
+	}
+	field, index := path.Head()
+	switch field {
+	case fieldNameOperators:
+		if index >= len(i.Operators()) {
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("PrecedenceGroupImpl.Resolve: index %d exceeds length of slice in 'operators' (length=%d) in node '%s'", index, len(i.Operators()), nodePath)
+		}
+		child := i.Operators()[index]
+		if child == nil {
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("PrecedenceGroupImpl.Resolve: item %d of slice in field 'operators' is nil in node '%s'", index, nodePath)
+		}
+		return child.Resolve(path.Tail())
+	case fieldNameAssociativity:
+		return nil, fmt.Errorf("PrecedenceGroupImpl.Resolve: field 'associativity' holds a primitive value instead of an ast node")
+	default:
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("PrecedenceGroupImpl.Resolve: field '%s' does not exist in node '%s' of type 'PrecedenceGroup'", field.Value(), nodePath)
+	}
+}
+
 var (
-	fieldNameType         = unique.Make("_Type")
-	fieldNameAlts         = unique.Make("alts")
-	fieldNameBody         = unique.Make("body")
-	fieldNameCardinality  = unique.Make("cardinality")
-	fieldNameComposites   = unique.Make("composites")
-	fieldNameElements     = unique.Make("elements")
-	fieldNameEntry        = unique.Make("entry")
-	fieldNameExtends      = unique.Make("extends")
-	fieldNameFields       = unique.Make("fields")
-	fieldNameInterfaces   = unique.Make("interfaces")
-	fieldNameInternalType = unique.Make("internalType")
-	fieldNameKeywords     = unique.Make("keywords")
-	fieldNameName         = unique.Make("name")
-	fieldNameOperator     = unique.Make("operator")
-	fieldNameProperty     = unique.Make("property")
-	fieldNameRegexp       = unique.Make("regexp")
-	fieldNameRegexps      = unique.Make("regexps")
-	fieldNameReturnType   = unique.Make("returnType")
-	fieldNameRule         = unique.Make("rule")
-	fieldNameRules        = unique.Make("rules")
-	fieldNameTerminals    = unique.Make("terminals")
-	fieldNameTokenGroups  = unique.Make("tokenGroups")
-	fieldNameTokenRefs    = unique.Make("tokenRefs")
-	fieldNameValue        = unique.Make("value")
+	fieldNameType          = unique.Make("_Type")
+	fieldNameAlts          = unique.Make("alts")
+	fieldNameAssociativity = unique.Make("associativity")
+	fieldNameBody          = unique.Make("body")
+	fieldNameCall          = unique.Make("call")
+	fieldNameCardinality   = unique.Make("cardinality")
+	fieldNameComposites    = unique.Make("composites")
+	fieldNameElements      = unique.Make("elements")
+	fieldNameEntry         = unique.Make("entry")
+	fieldNameExtends       = unique.Make("extends")
+	fieldNameFields        = unique.Make("fields")
+	fieldNameGroups        = unique.Make("groups")
+	fieldNameInfixRules    = unique.Make("infixRules")
+	fieldNameInterfaces    = unique.Make("interfaces")
+	fieldNameInternalType  = unique.Make("internalType")
+	fieldNameKeywords      = unique.Make("keywords")
+	fieldNameName          = unique.Make("name")
+	fieldNameOperator      = unique.Make("operator")
+	fieldNameOperators     = unique.Make("operators")
+	fieldNameProperty      = unique.Make("property")
+	fieldNameRegexp        = unique.Make("regexp")
+	fieldNameRegexps       = unique.Make("regexps")
+	fieldNameReturnType    = unique.Make("returnType")
+	fieldNameRule          = unique.Make("rule")
+	fieldNameRules         = unique.Make("rules")
+	fieldNameTerminals     = unique.Make("terminals")
+	fieldNameTokenGroups   = unique.Make("tokenGroups")
+	fieldNameTokenRefs     = unique.Make("tokenRefs")
+	fieldNameValue         = unique.Make("value")
 )
 
 var FastbeltSyntheticFactories = map[string]func() core.AstNode{
@@ -2106,9 +2593,11 @@ var FastbeltSyntheticFactories = map[string]func() core.AstNode{
 	"FieldType":            func() core.AstNode { return NewFieldType() },
 	"Grammar":              func() core.AstNode { return NewGrammar() },
 	"Group":                func() core.AstNode { return NewGroup() },
+	"InfixRule":            func() core.AstNode { return NewInfixRule() },
 	"Interface":            func() core.AstNode { return NewInterface() },
 	"Keyword":              func() core.AstNode { return NewKeyword() },
 	"ParserRule":           func() core.AstNode { return NewParserRule() },
+	"PrecedenceGroup":      func() core.AstNode { return NewPrecedenceGroup() },
 	"PrimitiveType":        func() core.AstNode { return NewPrimitiveType() },
 	"ReferenceType":        func() core.AstNode { return NewReferenceType() },
 	"RuleCall":             func() core.AstNode { return NewRuleCall() },

--- a/internal/grammar/types_gen.go
+++ b/internal/grammar/types_gen.go
@@ -31,10 +31,7 @@ type Grammar interface {
 }
 
 func NewGrammar() Grammar {
-	return &GrammarImpl{
-		AstNodeBase: core.NewAstNode(),
-		GrammarData: NewGrammarData(),
-	}
+	return &GrammarImpl{}
 }
 
 type GrammarData struct {
@@ -45,17 +42,6 @@ type GrammarData struct {
 	terminals   []Token
 	tokenGroups []TokenGroup
 	interfaces  []Interface
-}
-
-func NewGrammarData() GrammarData {
-	return GrammarData{
-		rules:       []ParserRule{},
-		composites:  []CompositeRule{},
-		infixRules:  []InfixRule{},
-		terminals:   []Token{},
-		tokenGroups: []TokenGroup{},
-		interfaces:  []Interface{},
-	}
 }
 
 func (i *GrammarData) IsGrammar() {}
@@ -255,23 +241,13 @@ type Interface interface {
 }
 
 func NewInterface() Interface {
-	return &InterfaceImpl{
-		AstNodeBase:   core.NewAstNode(),
-		InterfaceData: NewInterfaceData(),
-	}
+	return &InterfaceImpl{}
 }
 
 type InterfaceData struct {
 	name    *core.Token
 	extends []*core.Reference[Interface]
 	fields  []Field
-}
-
-func NewInterfaceData() InterfaceData {
-	return InterfaceData{
-		extends: []*core.Reference[Interface]{},
-		fields:  []Field{},
-	}
 }
 
 func (i *InterfaceData) IsInterface() {}
@@ -372,19 +348,12 @@ type Field interface {
 }
 
 func NewField() Field {
-	return &FieldImpl{
-		AstNodeBase: core.NewAstNode(),
-		FieldData:   NewFieldData(),
-	}
+	return &FieldImpl{}
 }
 
 type FieldData struct {
 	name  *core.Token
 	_Type FieldType
-}
-
-func NewFieldData() FieldData {
-	return FieldData{}
 }
 
 func (i *FieldData) IsField() {}
@@ -467,17 +436,10 @@ type FieldType interface {
 }
 
 func NewFieldType() FieldType {
-	return &FieldTypeImpl{
-		AstNodeBase:   core.NewAstNode(),
-		FieldTypeData: NewFieldTypeData(),
-	}
+	return &FieldTypeImpl{}
 }
 
 type FieldTypeData struct {
-}
-
-func NewFieldTypeData() FieldTypeData {
-	return FieldTypeData{}
 }
 
 func (i *FieldTypeData) IsFieldType() {}
@@ -520,19 +482,11 @@ type ArrayType interface {
 }
 
 func NewArrayType() ArrayType {
-	return &ArrayTypeImpl{
-		AstNodeBase:   core.NewAstNode(),
-		FieldTypeData: NewFieldTypeData(),
-		ArrayTypeData: NewArrayTypeData(),
-	}
+	return &ArrayTypeImpl{}
 }
 
 type ArrayTypeData struct {
 	internalType FieldType
-}
-
-func NewArrayTypeData() ArrayTypeData {
-	return ArrayTypeData{}
 }
 
 func (i *ArrayTypeData) IsArrayType() {}
@@ -603,19 +557,11 @@ type ReferenceType interface {
 }
 
 func NewReferenceType() ReferenceType {
-	return &ReferenceTypeImpl{
-		AstNodeBase:       core.NewAstNode(),
-		FieldTypeData:     NewFieldTypeData(),
-		ReferenceTypeData: NewReferenceTypeData(),
-	}
+	return &ReferenceTypeImpl{}
 }
 
 type ReferenceTypeData struct {
 	_Type *core.Reference[Interface]
-}
-
-func NewReferenceTypeData() ReferenceTypeData {
-	return ReferenceTypeData{}
 }
 
 func (i *ReferenceTypeData) IsReferenceType() {}
@@ -681,19 +627,11 @@ type SimpleType interface {
 }
 
 func NewSimpleType() SimpleType {
-	return &SimpleTypeImpl{
-		AstNodeBase:    core.NewAstNode(),
-		FieldTypeData:  NewFieldTypeData(),
-		SimpleTypeData: NewSimpleTypeData(),
-	}
+	return &SimpleTypeImpl{}
 }
 
 type SimpleTypeData struct {
 	_Type *core.Reference[Interface]
-}
-
-func NewSimpleTypeData() SimpleTypeData {
-	return SimpleTypeData{}
 }
 
 func (i *SimpleTypeData) IsSimpleType() {}
@@ -760,19 +698,11 @@ type PrimitiveType interface {
 }
 
 func NewPrimitiveType() PrimitiveType {
-	return &PrimitiveTypeImpl{
-		AstNodeBase:       core.NewAstNode(),
-		FieldTypeData:     NewFieldTypeData(),
-		PrimitiveTypeData: NewPrimitiveTypeData(),
-	}
+	return &PrimitiveTypeImpl{}
 }
 
 type PrimitiveTypeData struct {
 	_Type *core.Token
-}
-
-func NewPrimitiveTypeData() PrimitiveTypeData {
-	return PrimitiveTypeData{}
 }
 
 func (i *PrimitiveTypeData) IsPrimitiveType() {}
@@ -839,18 +769,11 @@ type AbstractRule interface {
 }
 
 func NewAbstractRule() AbstractRule {
-	return &AbstractRuleImpl{
-		AstNodeBase:      core.NewAstNode(),
-		AbstractRuleData: NewAbstractRuleData(),
-	}
+	return &AbstractRuleImpl{}
 }
 
 type AbstractRuleData struct {
 	name *core.Token
-}
-
-func NewAbstractRuleData() AbstractRuleData {
-	return AbstractRuleData{}
 }
 
 func (i *AbstractRuleData) IsAbstractRule() {}
@@ -914,19 +837,11 @@ type AbstractRuleWithBody interface {
 }
 
 func NewAbstractRuleWithBody() AbstractRuleWithBody {
-	return &AbstractRuleWithBodyImpl{
-		AstNodeBase:              core.NewAstNode(),
-		AbstractRuleData:         NewAbstractRuleData(),
-		AbstractRuleWithBodyData: NewAbstractRuleWithBodyData(),
-	}
+	return &AbstractRuleWithBodyImpl{}
 }
 
 type AbstractRuleWithBodyData struct {
 	body Element
-}
-
-func NewAbstractRuleWithBodyData() AbstractRuleWithBodyData {
-	return AbstractRuleWithBodyData{}
 }
 
 func (i *AbstractRuleWithBodyData) IsAbstractRuleWithBody() {}
@@ -989,6 +904,88 @@ func (i *AbstractRuleWithBodyImpl) Resolve(path core.FragmentPath) (core.AstNode
 	}
 }
 
+type AbstractRuleWithReturnType interface {
+	core.AstNode
+	AbstractRuleWithBody
+
+	IsAbstractRuleWithReturnType()
+	ReturnType() *core.Reference[Interface]
+	SetReturnType(value *core.Reference[Interface])
+}
+
+func NewAbstractRuleWithReturnType() AbstractRuleWithReturnType {
+	return &AbstractRuleWithReturnTypeImpl{}
+}
+
+type AbstractRuleWithReturnTypeData struct {
+	returnType *core.Reference[Interface]
+}
+
+func (i *AbstractRuleWithReturnTypeData) IsAbstractRuleWithReturnType() {}
+
+func (i *AbstractRuleWithReturnTypeData) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
+}
+
+func (i *AbstractRuleWithReturnTypeData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
+	if i.returnType != nil {
+		fn(i.returnType, fieldNameReturnType, -1)
+	}
+}
+
+func (i *AbstractRuleWithReturnTypeData) ReturnType() *core.Reference[Interface] {
+	if i != nil && i.returnType != nil {
+		return i.returnType
+	} else {
+		return nil
+	}
+}
+
+func (i *AbstractRuleWithReturnTypeData) SetReturnType(value *core.Reference[Interface]) {
+	i.returnType = value
+}
+
+type AbstractRuleWithReturnTypeImpl struct {
+	core.AstNodeBase
+	AbstractRuleWithBodyData
+	AbstractRuleData
+	AbstractRuleWithReturnTypeData
+}
+
+func (i *AbstractRuleWithReturnTypeImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
+	i.AbstractRuleWithBodyData.ForEachNode(fn)
+	i.AbstractRuleData.ForEachNode(fn)
+	i.AbstractRuleWithReturnTypeData.ForEachNode(fn)
+}
+
+func (i *AbstractRuleWithReturnTypeImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
+	i.AbstractRuleWithBodyData.ForEachReference(fn)
+	i.AbstractRuleData.ForEachReference(fn)
+	i.AbstractRuleWithReturnTypeData.ForEachReference(fn)
+}
+
+func (i *AbstractRuleWithReturnTypeImpl) Resolve(path core.FragmentPath) (core.AstNode, error) {
+	if path.Empty() {
+		return i, nil
+	}
+	field, _ := path.Head()
+	switch field {
+	case fieldNameBody:
+		if i.Body() == nil {
+			nodePath, _ := core.PathOf(i)
+			return nil, fmt.Errorf("AbstractRuleWithReturnTypeImpl.Resolve: field 'body' is nil in node '%s'", nodePath)
+		}
+		child := i.Body()
+		return child.Resolve(path.Tail())
+	case fieldNameName:
+		return nil, fmt.Errorf("AbstractRuleWithReturnTypeImpl.Resolve: field 'name' holds a primitive value instead of an ast node")
+	case fieldNameReturnType:
+		return nil, fmt.Errorf("AbstractRuleWithReturnTypeImpl.Resolve: field 'returnType' is a cross-reference instead of a container field")
+	default:
+		nodePath, _ := core.PathOf(i)
+		return nil, fmt.Errorf("AbstractRuleWithReturnTypeImpl.Resolve: field '%s' does not exist in node '%s' of type 'AbstractRuleWithReturnType'", field.Value(), nodePath)
+	}
+}
+
 type AbstractTokenRule interface {
 	core.AstNode
 	AbstractRule
@@ -997,18 +994,10 @@ type AbstractTokenRule interface {
 }
 
 func NewAbstractTokenRule() AbstractTokenRule {
-	return &AbstractTokenRuleImpl{
-		AstNodeBase:           core.NewAstNode(),
-		AbstractRuleData:      NewAbstractRuleData(),
-		AbstractTokenRuleData: NewAbstractTokenRuleData(),
-	}
+	return &AbstractTokenRuleImpl{}
 }
 
 type AbstractTokenRuleData struct {
-}
-
-func NewAbstractTokenRuleData() AbstractTokenRuleData {
-	return AbstractTokenRuleData{}
 }
 
 func (i *AbstractTokenRuleData) IsAbstractTokenRule() {}
@@ -1051,32 +1040,20 @@ func (i *AbstractTokenRuleImpl) Resolve(path core.FragmentPath) (core.AstNode, e
 
 type ParserRule interface {
 	core.AstNode
-	AbstractRuleWithBody
+	AbstractRuleWithReturnType
 
 	IsParserRule()
 	IsEntry() bool
 	EntryToken() *core.Token
 	SetEntry(value *core.Token)
-	ReturnType() *core.Reference[Interface]
-	SetReturnType(value *core.Reference[Interface])
 }
 
 func NewParserRule() ParserRule {
-	return &ParserRuleImpl{
-		AstNodeBase:              core.NewAstNode(),
-		AbstractRuleWithBodyData: NewAbstractRuleWithBodyData(),
-		AbstractRuleData:         NewAbstractRuleData(),
-		ParserRuleData:           NewParserRuleData(),
-	}
+	return &ParserRuleImpl{}
 }
 
 type ParserRuleData struct {
-	entry      *core.Token
-	returnType *core.Reference[Interface]
-}
-
-func NewParserRuleData() ParserRuleData {
-	return ParserRuleData{}
+	entry *core.Token
 }
 
 func (i *ParserRuleData) IsParserRule() {}
@@ -1085,9 +1062,6 @@ func (i *ParserRuleData) ForEachNode(fn func(core.AstNode, unique.Handle[string]
 }
 
 func (i *ParserRuleData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
-	if i.returnType != nil {
-		fn(i.returnType, fieldNameReturnType, -1)
-	}
 }
 
 func (i *ParserRuleData) IsEntry() bool {
@@ -1102,32 +1076,23 @@ func (i *ParserRuleData) SetEntry(value *core.Token) {
 	i.entry = value
 }
 
-func (i *ParserRuleData) ReturnType() *core.Reference[Interface] {
-	if i != nil && i.returnType != nil {
-		return i.returnType
-	} else {
-		return nil
-	}
-}
-
-func (i *ParserRuleData) SetReturnType(value *core.Reference[Interface]) {
-	i.returnType = value
-}
-
 type ParserRuleImpl struct {
 	core.AstNodeBase
+	AbstractRuleWithReturnTypeData
 	AbstractRuleWithBodyData
 	AbstractRuleData
 	ParserRuleData
 }
 
 func (i *ParserRuleImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
+	i.AbstractRuleWithReturnTypeData.ForEachNode(fn)
 	i.AbstractRuleWithBodyData.ForEachNode(fn)
 	i.AbstractRuleData.ForEachNode(fn)
 	i.ParserRuleData.ForEachNode(fn)
 }
 
 func (i *ParserRuleImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
+	i.AbstractRuleWithReturnTypeData.ForEachReference(fn)
 	i.AbstractRuleWithBodyData.ForEachReference(fn)
 	i.AbstractRuleData.ForEachReference(fn)
 	i.ParserRuleData.ForEachReference(fn)
@@ -1172,21 +1137,12 @@ type Token interface {
 }
 
 func NewToken() Token {
-	return &TokenImpl{
-		AstNodeBase:           core.NewAstNode(),
-		AbstractTokenRuleData: NewAbstractTokenRuleData(),
-		AbstractRuleData:      NewAbstractRuleData(),
-		TokenData:             NewTokenData(),
-	}
+	return &TokenImpl{}
 }
 
 type TokenData struct {
 	_Type  *core.Token
 	regexp *core.Token
-}
-
-func NewTokenData() TokenData {
-	return TokenData{}
 }
 
 func (i *TokenData) IsToken() {}
@@ -1280,26 +1236,13 @@ type TokenGroup interface {
 }
 
 func NewTokenGroup() TokenGroup {
-	return &TokenGroupImpl{
-		AstNodeBase:           core.NewAstNode(),
-		AbstractTokenRuleData: NewAbstractTokenRuleData(),
-		AbstractRuleData:      NewAbstractRuleData(),
-		TokenGroupData:        NewTokenGroupData(),
-	}
+	return &TokenGroupImpl{}
 }
 
 type TokenGroupData struct {
 	tokenRefs []*core.Reference[AbstractTokenRule]
 	regexps   []*core.Token
 	keywords  []Keyword
-}
-
-func NewTokenGroupData() TokenGroupData {
-	return TokenGroupData{
-		tokenRefs: []*core.Reference[AbstractTokenRule]{},
-		regexps:   []*core.Token{},
-		keywords:  []Keyword{},
-	}
 }
 
 func (i *TokenGroupData) IsTokenGroup() {}
@@ -1398,18 +1341,11 @@ type Element interface {
 }
 
 func NewElement() Element {
-	return &ElementImpl{
-		AstNodeBase: core.NewAstNode(),
-		ElementData: NewElementData(),
-	}
+	return &ElementImpl{}
 }
 
 type ElementData struct {
 	cardinality *core.Token
-}
-
-func NewElementData() ElementData {
-	return ElementData{}
 }
 
 func (i *ElementData) IsElement() {}
@@ -1473,22 +1409,11 @@ type Alternatives interface {
 }
 
 func NewAlternatives() Alternatives {
-	return &AlternativesImpl{
-		AstNodeBase:      core.NewAstNode(),
-		AssignableData:   NewAssignableData(),
-		ElementData:      NewElementData(),
-		AlternativesData: NewAlternativesData(),
-	}
+	return &AlternativesImpl{}
 }
 
 type AlternativesData struct {
 	alts []Element
-}
-
-func NewAlternativesData() AlternativesData {
-	return AlternativesData{
-		alts: []Element{},
-	}
 }
 
 func (i *AlternativesData) IsAlternatives() {}
@@ -1564,21 +1489,11 @@ type Group interface {
 }
 
 func NewGroup() Group {
-	return &GroupImpl{
-		AstNodeBase: core.NewAstNode(),
-		ElementData: NewElementData(),
-		GroupData:   NewGroupData(),
-	}
+	return &GroupImpl{}
 }
 
 type GroupData struct {
 	elements []Element
-}
-
-func NewGroupData() GroupData {
-	return GroupData{
-		elements: []Element{},
-	}
 }
 
 func (i *GroupData) IsGroup() {}
@@ -1652,20 +1567,11 @@ type Keyword interface {
 }
 
 func NewKeyword() Keyword {
-	return &KeywordImpl{
-		AstNodeBase:    core.NewAstNode(),
-		AssignableData: NewAssignableData(),
-		ElementData:    NewElementData(),
-		KeywordData:    NewKeywordData(),
-	}
+	return &KeywordImpl{}
 }
 
 type KeywordData struct {
 	value *core.Token
-}
-
-func NewKeywordData() KeywordData {
-	return KeywordData{}
 }
 
 func (i *KeywordData) IsKeyword() {}
@@ -1742,21 +1648,13 @@ type Assignment interface {
 }
 
 func NewAssignment() Assignment {
-	return &AssignmentImpl{
-		AstNodeBase:    core.NewAstNode(),
-		ElementData:    NewElementData(),
-		AssignmentData: NewAssignmentData(),
-	}
+	return &AssignmentImpl{}
 }
 
 type AssignmentData struct {
 	property *core.Reference[Field]
 	operator *core.Token
 	value    Assignable
-}
-
-func NewAssignmentData() AssignmentData {
-	return AssignmentData{}
 }
 
 func (i *AssignmentData) IsAssignment() {}
@@ -1862,18 +1760,10 @@ type Assignable interface {
 }
 
 func NewAssignable() Assignable {
-	return &AssignableImpl{
-		AstNodeBase:    core.NewAstNode(),
-		ElementData:    NewElementData(),
-		AssignableData: NewAssignableData(),
-	}
+	return &AssignableImpl{}
 }
 
 type AssignableData struct {
-}
-
-func NewAssignableData() AssignableData {
-	return AssignableData{}
 }
 
 func (i *AssignableData) IsAssignable() {}
@@ -1926,21 +1816,12 @@ type CrossRef interface {
 }
 
 func NewCrossRef() CrossRef {
-	return &CrossRefImpl{
-		AstNodeBase:    core.NewAstNode(),
-		AssignableData: NewAssignableData(),
-		ElementData:    NewElementData(),
-		CrossRefData:   NewCrossRefData(),
-	}
+	return &CrossRefImpl{}
 }
 
 type CrossRefData struct {
 	_Type *core.Reference[Interface]
 	rule  RuleCall
-}
-
-func NewCrossRefData() CrossRefData {
-	return CrossRefData{}
 }
 
 func (i *CrossRefData) IsCrossRef() {}
@@ -2033,20 +1914,11 @@ type RuleCall interface {
 }
 
 func NewRuleCall() RuleCall {
-	return &RuleCallImpl{
-		AstNodeBase:    core.NewAstNode(),
-		AssignableData: NewAssignableData(),
-		ElementData:    NewElementData(),
-		RuleCallData:   NewRuleCallData(),
-	}
+	return &RuleCallImpl{}
 }
 
 type RuleCallData struct {
 	rule *core.Reference[AbstractRule]
-}
-
-func NewRuleCallData() RuleCallData {
-	return RuleCallData{}
 }
 
 func (i *RuleCallData) IsRuleCall() {}
@@ -2122,21 +1994,13 @@ type Action interface {
 }
 
 func NewAction() Action {
-	return &ActionImpl{
-		AstNodeBase: core.NewAstNode(),
-		ElementData: NewElementData(),
-		ActionData:  NewActionData(),
-	}
+	return &ActionImpl{}
 }
 
 type ActionData struct {
 	_Type    *core.Reference[Interface]
 	operator *core.Token
 	property *core.Reference[Field]
-}
-
-func NewActionData() ActionData {
-	return ActionData{}
 }
 
 func (i *ActionData) IsAction() {}
@@ -2237,19 +2101,10 @@ type CompositeRule interface {
 }
 
 func NewCompositeRule() CompositeRule {
-	return &CompositeRuleImpl{
-		AstNodeBase:              core.NewAstNode(),
-		AbstractRuleWithBodyData: NewAbstractRuleWithBodyData(),
-		AbstractRuleData:         NewAbstractRuleData(),
-		CompositeRuleData:        NewCompositeRuleData(),
-	}
+	return &CompositeRuleImpl{}
 }
 
 type CompositeRuleData struct {
-}
-
-func NewCompositeRuleData() CompositeRuleData {
-	return CompositeRuleData{}
 }
 
 func (i *CompositeRuleData) IsCompositeRule() {}
@@ -2302,36 +2157,22 @@ func (i *CompositeRuleImpl) Resolve(path core.FragmentPath) (core.AstNode, error
 
 type InfixRule interface {
 	core.AstNode
-	AbstractRuleWithBody
+	AbstractRuleWithReturnType
 
 	IsInfixRule()
 	Call() RuleCall
 	SetCall(value RuleCall)
-	ReturnType() *core.Reference[Interface]
-	SetReturnType(value *core.Reference[Interface])
 	Groups() []PrecedenceGroup
 	SetGroupsItem(item PrecedenceGroup)
 }
 
 func NewInfixRule() InfixRule {
-	return &InfixRuleImpl{
-		AstNodeBase:              core.NewAstNode(),
-		AbstractRuleWithBodyData: NewAbstractRuleWithBodyData(),
-		AbstractRuleData:         NewAbstractRuleData(),
-		InfixRuleData:            NewInfixRuleData(),
-	}
+	return &InfixRuleImpl{}
 }
 
 type InfixRuleData struct {
-	call       RuleCall
-	returnType *core.Reference[Interface]
-	groups     []PrecedenceGroup
-}
-
-func NewInfixRuleData() InfixRuleData {
-	return InfixRuleData{
-		groups: []PrecedenceGroup{},
-	}
+	call   RuleCall
+	groups []PrecedenceGroup
 }
 
 func (i *InfixRuleData) IsInfixRule() {}
@@ -2346,9 +2187,6 @@ func (i *InfixRuleData) ForEachNode(fn func(core.AstNode, unique.Handle[string],
 }
 
 func (i *InfixRuleData) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
-	if i.returnType != nil {
-		fn(i.returnType, fieldNameReturnType, -1)
-	}
 }
 
 func (i *InfixRuleData) Call() RuleCall {
@@ -2363,18 +2201,6 @@ func (i *InfixRuleData) SetCall(value RuleCall) {
 	i.call = value
 }
 
-func (i *InfixRuleData) ReturnType() *core.Reference[Interface] {
-	if i != nil && i.returnType != nil {
-		return i.returnType
-	} else {
-		return nil
-	}
-}
-
-func (i *InfixRuleData) SetReturnType(value *core.Reference[Interface]) {
-	i.returnType = value
-}
-
 func (i *InfixRuleData) Groups() []PrecedenceGroup {
 	return i.groups
 }
@@ -2385,18 +2211,21 @@ func (i *InfixRuleData) SetGroupsItem(item PrecedenceGroup) {
 
 type InfixRuleImpl struct {
 	core.AstNodeBase
+	AbstractRuleWithReturnTypeData
 	AbstractRuleWithBodyData
 	AbstractRuleData
 	InfixRuleData
 }
 
 func (i *InfixRuleImpl) ForEachNode(fn func(core.AstNode, unique.Handle[string], int)) {
+	i.AbstractRuleWithReturnTypeData.ForEachNode(fn)
 	i.AbstractRuleWithBodyData.ForEachNode(fn)
 	i.AbstractRuleData.ForEachNode(fn)
 	i.InfixRuleData.ForEachNode(fn)
 }
 
 func (i *InfixRuleImpl) ForEachReference(fn func(core.UntypedReference, unique.Handle[string], int)) {
+	i.AbstractRuleWithReturnTypeData.ForEachReference(fn)
 	i.AbstractRuleWithBodyData.ForEachReference(fn)
 	i.AbstractRuleData.ForEachReference(fn)
 	i.InfixRuleData.ForEachReference(fn)
@@ -2455,21 +2284,12 @@ type PrecedenceGroup interface {
 }
 
 func NewPrecedenceGroup() PrecedenceGroup {
-	return &PrecedenceGroupImpl{
-		AstNodeBase:         core.NewAstNode(),
-		PrecedenceGroupData: NewPrecedenceGroupData(),
-	}
+	return &PrecedenceGroupImpl{}
 }
 
 type PrecedenceGroupData struct {
 	associativity *core.Token
 	operators     []Assignable
-}
-
-func NewPrecedenceGroupData() PrecedenceGroupData {
-	return PrecedenceGroupData{
-		operators: []Assignable{},
-	}
 }
 
 func (i *PrecedenceGroupData) IsPrecedenceGroup() {}
@@ -2578,30 +2398,31 @@ var (
 )
 
 var FastbeltSyntheticFactories = map[string]func() core.AstNode{
-	"AbstractRule":         func() core.AstNode { return NewAbstractRule() },
-	"AbstractRuleWithBody": func() core.AstNode { return NewAbstractRuleWithBody() },
-	"AbstractTokenRule":    func() core.AstNode { return NewAbstractTokenRule() },
-	"Action":               func() core.AstNode { return NewAction() },
-	"Alternatives":         func() core.AstNode { return NewAlternatives() },
-	"ArrayType":            func() core.AstNode { return NewArrayType() },
-	"Assignable":           func() core.AstNode { return NewAssignable() },
-	"Assignment":           func() core.AstNode { return NewAssignment() },
-	"CompositeRule":        func() core.AstNode { return NewCompositeRule() },
-	"CrossRef":             func() core.AstNode { return NewCrossRef() },
-	"Element":              func() core.AstNode { return NewElement() },
-	"Field":                func() core.AstNode { return NewField() },
-	"FieldType":            func() core.AstNode { return NewFieldType() },
-	"Grammar":              func() core.AstNode { return NewGrammar() },
-	"Group":                func() core.AstNode { return NewGroup() },
-	"InfixRule":            func() core.AstNode { return NewInfixRule() },
-	"Interface":            func() core.AstNode { return NewInterface() },
-	"Keyword":              func() core.AstNode { return NewKeyword() },
-	"ParserRule":           func() core.AstNode { return NewParserRule() },
-	"PrecedenceGroup":      func() core.AstNode { return NewPrecedenceGroup() },
-	"PrimitiveType":        func() core.AstNode { return NewPrimitiveType() },
-	"ReferenceType":        func() core.AstNode { return NewReferenceType() },
-	"RuleCall":             func() core.AstNode { return NewRuleCall() },
-	"SimpleType":           func() core.AstNode { return NewSimpleType() },
-	"Token":                func() core.AstNode { return NewToken() },
-	"TokenGroup":           func() core.AstNode { return NewTokenGroup() },
+	"AbstractRule":               func() core.AstNode { return NewAbstractRule() },
+	"AbstractRuleWithBody":       func() core.AstNode { return NewAbstractRuleWithBody() },
+	"AbstractRuleWithReturnType": func() core.AstNode { return NewAbstractRuleWithReturnType() },
+	"AbstractTokenRule":          func() core.AstNode { return NewAbstractTokenRule() },
+	"Action":                     func() core.AstNode { return NewAction() },
+	"Alternatives":               func() core.AstNode { return NewAlternatives() },
+	"ArrayType":                  func() core.AstNode { return NewArrayType() },
+	"Assignable":                 func() core.AstNode { return NewAssignable() },
+	"Assignment":                 func() core.AstNode { return NewAssignment() },
+	"CompositeRule":              func() core.AstNode { return NewCompositeRule() },
+	"CrossRef":                   func() core.AstNode { return NewCrossRef() },
+	"Element":                    func() core.AstNode { return NewElement() },
+	"Field":                      func() core.AstNode { return NewField() },
+	"FieldType":                  func() core.AstNode { return NewFieldType() },
+	"Grammar":                    func() core.AstNode { return NewGrammar() },
+	"Group":                      func() core.AstNode { return NewGroup() },
+	"InfixRule":                  func() core.AstNode { return NewInfixRule() },
+	"Interface":                  func() core.AstNode { return NewInterface() },
+	"Keyword":                    func() core.AstNode { return NewKeyword() },
+	"ParserRule":                 func() core.AstNode { return NewParserRule() },
+	"PrecedenceGroup":            func() core.AstNode { return NewPrecedenceGroup() },
+	"PrimitiveType":              func() core.AstNode { return NewPrimitiveType() },
+	"ReferenceType":              func() core.AstNode { return NewReferenceType() },
+	"RuleCall":                   func() core.AstNode { return NewRuleCall() },
+	"SimpleType":                 func() core.AstNode { return NewSimpleType() },
+	"Token":                      func() core.AstNode { return NewToken() },
+	"TokenGroup":                 func() core.AstNode { return NewTokenGroup() },
 }

--- a/internal/grammar/utils.go
+++ b/internal/grammar/utils.go
@@ -28,13 +28,21 @@ func convertString(keyword Keyword) (string, error) {
 	return value, nil
 }
 
-func FindReturnType(rule ParserRule, ctx context.Context) Interface {
+func FindReturnType(rule AbstractRuleWithReturnType, ctx context.Context) Interface {
 	if rule == nil {
 		return nil
 	}
 	typeRef := rule.ReturnType()
 	if typeRef != nil {
 		return typeRef.Ref(ctx)
+	}
+	if infixRule, ok := rule.(InfixRule); ok {
+		// The return type of an infix rule is the return type of its operand rule.
+		if operand, ok := infixRule.Call().Rule().Ref(ctx).(ParserRule); ok {
+			return FindReturnType(operand, ctx)
+		}
+		// Indicates malformed input, no return type
+		return nil
 	}
 	grammar, ok := rule.Container().(Grammar)
 	if !ok || grammar == nil {

--- a/internal/grammar/validator.go
+++ b/internal/grammar/validator.go
@@ -37,6 +37,13 @@ const (
 	ValidateFieldNameCapitalLetter  = "fieldNameCapitalLetter"
 	ValidateReservedFieldName       = "reservedFieldName"
 	ValidateNestedArrayType         = "nestedArrayType"
+	ValidateInfixNodeType           = "infixNodeType"
+	ValidateInfixOperandRule        = "infixOperandRule"
+	ValidateInfixReturnType         = "infixReturnType"
+	ValidateInfixProperty           = "infixProperty"
+	ValidateInfixOperator           = "infixOperator"
+	ValidateInfixDuplicateOperator  = "infixDuplicateOperator"
+	ValidateInfixOperatorGroupName  = "infixOperatorGroupName"
 )
 
 // reservedFieldNames lists field names that must not be used because they
@@ -76,6 +83,11 @@ func checkUniqueRuleNames(g Grammar, accept core.ValidationAcceptor) {
 	for _, tokenGroup := range g.TokenGroups() {
 		if tokenGroup.Name() != "" {
 			seen[tokenGroup.Name()] = append(seen[tokenGroup.Name()], tokenGroup)
+		}
+	}
+	for _, infix := range g.InfixRules() {
+		if infix.Name() != "" {
+			seen[infix.Name()] = append(seen[infix.Name()], infix)
 		}
 	}
 	for name, nodes := range seen {
@@ -451,19 +463,23 @@ func checkRuleCallReturnType(call RuleCall, ctx context.Context, accept core.Val
 	if targetRule == nil {
 		return
 	}
-	if parserRule, ok := targetRule.(ParserRule); ok {
-		targetType := FindReturnType(parserRule, ctx)
-		if targetType == nil {
-			return
-		}
-		if !interfaceIsAssignableTo(targetType, ownType) {
-			accept(core.NewDiagnostic(
-				core.SeverityError,
-				fmt.Sprintf("The return type '%s' of the called rule is not assignable to the return type '%s' of the current rule.", targetType.Name(), ownType.Name()),
-				call,
-				core.WithCode(ValidateRuleCallReturnType),
-			))
-		}
+	var targetType Interface
+	switch target := targetRule.(type) {
+	case ParserRule:
+		targetType = FindReturnType(target, ctx)
+	case InfixRule:
+		targetType = FindInfixReturnType(target, ctx)
+	}
+	if targetType == nil {
+		return
+	}
+	if !interfaceIsAssignableTo(targetType, ownType) {
+		accept(core.NewDiagnostic(
+			core.SeverityError,
+			fmt.Sprintf("The return type '%s' of the called rule is not assignable to the return type '%s' of the current rule.", targetType.Name(), ownType.Name()),
+			call,
+			core.WithCode(ValidateRuleCallReturnType),
+		))
 	}
 }
 
@@ -711,6 +727,32 @@ func isAssignableTo(ctx context.Context, source Assignable, fieldType FieldType,
 					core.WithCode(ValidateAssignmentType),
 				))
 			}
+		case InfixRule:
+			if simpleType, ok := fieldType.(SimpleType); ok {
+				ruleType := FindInfixReturnType(rule, ctx)
+				if ruleType == nil {
+					return
+				}
+				targetType := simpleType.Type().Ref(ctx)
+				if targetType == nil {
+					return
+				}
+				if !interfaceIsAssignableTo(ruleType, targetType) {
+					accept(core.NewDiagnostic(
+						core.SeverityError,
+						fmt.Sprintf("The return type '%s' of the called rule is not assignable to the target field type '%s'.", ruleType.Name(), targetType.Name()),
+						v,
+						core.WithCode(ValidateAssignmentType),
+					))
+				}
+			} else {
+				accept(core.NewDiagnostic(
+					core.SeverityError,
+					"Cannot assign a parser rule to a non-interface field.",
+					v,
+					core.WithCode(ValidateAssignmentType),
+				))
+			}
 		case CompositeRule:
 			if primitiveType, ok := fieldType.(PrimitiveType); !ok || primitiveType.Type() != "composite" {
 				if primitiveType, ok := fieldType.(PrimitiveType); ok && primitiveType.Type() == "string" {
@@ -837,6 +879,287 @@ func checkInvalidTokensInGroup(tg TokenGroup, accept core.ValidationAcceptor) {
 			}
 		}
 	}
+}
+
+// InfixRuleImpl.Validate checks infix rule constraints:
+//   - The rule name must resolve to an interface (the binary node type)
+//     declaring Left/Right fields of a compatible interface type and an
+//     Operator field of type string.
+//   - The operand ("on") rule must be a parser rule whose return type is
+//     assignable to the infix rule's effective return type.
+//   - Operators must be keywords, tokens, or token groups (not hidden or
+//     comment tokens), and no operator may appear in two precedence groups.
+//   - The name of the generated operator token group must be available.
+func (rule *InfixRuleImpl) Validate(ctx context.Context, _ string, accept core.ValidationAcceptor) {
+	checkInfixNodeType(rule, ctx, accept)
+	checkInfixOperandRule(rule, ctx, accept)
+	checkInfixOperators(rule, ctx, accept)
+	checkInfixOperatorGroupName(rule, accept)
+}
+
+func checkInfixNodeType(rule InfixRule, ctx context.Context, accept core.ValidationAcceptor) {
+	if rule.Name() == "" {
+		return
+	}
+	nodeType := FindInfixNodeType(rule)
+	if nodeType == nil {
+		accept(core.NewDiagnostic(
+			core.SeverityError,
+			fmt.Sprintf("Unable to find the node type for infix rule '%s'. Define an interface with the same name as the rule.", rule.Name()),
+			rule,
+			core.WithToken(rule.NameToken()),
+			core.WithCode(ValidateInfixNodeType),
+		))
+		return
+	}
+	returnType := FindInfixReturnType(rule, ctx)
+	if returnType == nil {
+		return
+	}
+	if !interfaceIsAssignableTo(nodeType, returnType) {
+		accept(core.NewDiagnostic(
+			core.SeverityError,
+			fmt.Sprintf("The node type '%s' is not assignable to the return type '%s' of the infix rule.", nodeType.Name(), returnType.Name()),
+			rule,
+			core.WithToken(rule.NameToken()),
+			core.WithCode(ValidateInfixReturnType),
+		))
+	}
+	for _, name := range []string{"Left", "Right"} {
+		field := findInterfaceField(nodeType, name, ctx)
+		if field == nil {
+			accept(core.NewDiagnostic(
+				core.SeverityError,
+				fmt.Sprintf("The node type '%s' must declare a field '%s'.", nodeType.Name(), name),
+				rule,
+				core.WithToken(rule.NameToken()),
+				core.WithCode(ValidateInfixProperty),
+			))
+			continue
+		}
+		simpleType, ok := field.Type().(SimpleType)
+		if !ok {
+			accept(core.NewDiagnostic(
+				core.SeverityError,
+				fmt.Sprintf("The field '%s' of node type '%s' must be of an interface type.", name, nodeType.Name()),
+				rule,
+				core.WithToken(rule.NameToken()),
+				core.WithCode(ValidateInfixProperty),
+			))
+			continue
+		}
+		fieldInterface := simpleType.Type().Ref(ctx)
+		if fieldInterface == nil {
+			continue
+		}
+		if !interfaceIsAssignableTo(returnType, fieldInterface) {
+			accept(core.NewDiagnostic(
+				core.SeverityError,
+				fmt.Sprintf("The return type '%s' of the infix rule is not assignable to the type '%s' of the field '%s'.", returnType.Name(), fieldInterface.Name(), name),
+				rule,
+				core.WithToken(rule.NameToken()),
+				core.WithCode(ValidateInfixProperty),
+			))
+		}
+	}
+	if field := findInterfaceField(nodeType, "Operator", ctx); field == nil {
+		accept(core.NewDiagnostic(
+			core.SeverityError,
+			fmt.Sprintf("The node type '%s' must declare a field 'Operator' of type string.", nodeType.Name()),
+			rule,
+			core.WithToken(rule.NameToken()),
+			core.WithCode(ValidateInfixProperty),
+		))
+	} else if primitiveType, ok := field.Type().(PrimitiveType); !ok || primitiveType.Type() != "string" {
+		accept(core.NewDiagnostic(
+			core.SeverityError,
+			fmt.Sprintf("The field 'Operator' of node type '%s' must be of type string.", nodeType.Name()),
+			rule,
+			core.WithToken(rule.NameToken()),
+			core.WithCode(ValidateInfixProperty),
+		))
+	}
+}
+
+func checkInfixOperandRule(rule InfixRule, ctx context.Context, accept core.ValidationAcceptor) {
+	call := rule.Call()
+	if call == nil {
+		return
+	}
+	target := call.Rule().Ref(ctx)
+	if target == nil {
+		return
+	}
+	operand, ok := target.(ParserRule)
+	if !ok {
+		accept(core.NewDiagnostic(
+			core.SeverityError,
+			"An infix rule must operate on a parser rule.",
+			call,
+			core.WithReference(call.Rule()),
+			core.WithCode(ValidateInfixOperandRule),
+		))
+		return
+	}
+	// Without an explicit return type the operand's return type is the
+	// effective return type, so there is nothing further to check.
+	if rule.ReturnType() == nil {
+		return
+	}
+	returnType := rule.ReturnType().Ref(ctx)
+	operandType := FindReturnType(operand, ctx)
+	if returnType == nil || operandType == nil {
+		return
+	}
+	if !interfaceIsAssignableTo(operandType, returnType) {
+		accept(core.NewDiagnostic(
+			core.SeverityError,
+			fmt.Sprintf("The return type '%s' of the operand rule is not assignable to the return type '%s' of the infix rule.", operandType.Name(), returnType.Name()),
+			call,
+			core.WithReference(call.Rule()),
+			core.WithCode(ValidateInfixReturnType),
+		))
+	}
+}
+
+func checkInfixOperators(rule InfixRule, ctx context.Context, accept core.ValidationAcceptor) {
+	seen := collections.NewSet[string]()
+	for _, group := range rule.Groups() {
+		for _, operator := range group.Operators() {
+			if ruleCall, ok := operator.(RuleCall); ok {
+				target := ruleCall.Rule().Ref(ctx)
+				if target == nil {
+					continue
+				}
+				token, isToken := target.(AbstractTokenRule)
+				if !isToken {
+					accept(core.NewDiagnostic(
+						core.SeverityError,
+						"Infix operators must be keywords, tokens, or token groups.",
+						ruleCall,
+						core.WithReference(ruleCall.Rule()),
+						core.WithCode(ValidateInfixOperator),
+					))
+					continue
+				}
+				if plainToken, ok := token.(Token); ok {
+					if description, special := hiddenOrCommentTokenDescription(plainToken); special {
+						accept(core.NewDiagnostic(
+							core.SeverityError,
+							fmt.Sprintf("The token '%s' cannot be used as an infix operator because it is %s.", plainToken.Name(), description),
+							ruleCall,
+							core.WithReference(ruleCall.Rule()),
+							core.WithCode(ValidateInfixOperator),
+						))
+						continue
+					}
+				}
+			}
+			duplicate := false
+			for _, key := range infixOperatorLeafKeys(operator, ctx, collections.NewSet[string]()) {
+				if !seen.Add(key) {
+					duplicate = true
+				}
+			}
+			if duplicate {
+				diagnosticOptions := []core.DiagnosticOption{core.WithCode(ValidateInfixDuplicateOperator)}
+				switch op := operator.(type) {
+				case Keyword:
+					diagnosticOptions = append(diagnosticOptions, core.WithToken(op.ValueToken()))
+				case RuleCall:
+					diagnosticOptions = append(diagnosticOptions, core.WithReference(op.Rule()))
+				}
+				accept(core.NewDiagnostic(
+					core.SeverityError,
+					"Every operator of an infix rule must belong to exactly one precedence group.",
+					operator,
+					diagnosticOptions...,
+				))
+			}
+		}
+	}
+}
+
+// infixOperatorLeafKeys expands an infix operator to comparable leaf keys so
+// duplicate operators are detected across precedence groups, resolving token
+// groups to their members.
+func infixOperatorLeafKeys(operator Assignable, ctx context.Context, visited collections.Set[string]) []string {
+	switch op := operator.(type) {
+	case Keyword:
+		return []string{"kw:" + op.Value()}
+	case RuleCall:
+		switch target := op.Rule().Ref(ctx).(type) {
+		case TokenGroup:
+			return tokenGroupLeafKeys(target, ctx, visited)
+		case Token:
+			return []string{"token:" + target.Name()}
+		}
+	}
+	return nil
+}
+
+func tokenGroupLeafKeys(tg TokenGroup, ctx context.Context, visited collections.Set[string]) []string {
+	if !visited.Add("group:" + tg.Name()) {
+		return nil
+	}
+	var keys []string
+	for _, keyword := range tg.Keywords() {
+		keys = append(keys, "kw:"+keyword.Value())
+	}
+	for _, ref := range tg.TokenRefs() {
+		switch target := ref.Ref(ctx).(type) {
+		case TokenGroup:
+			keys = append(keys, tokenGroupLeafKeys(target, ctx, visited)...)
+		case Token:
+			keys = append(keys, "token:"+target.Name())
+		}
+	}
+	return keys
+}
+
+func checkInfixOperatorGroupName(rule InfixRule, accept core.ValidationAcceptor) {
+	if rule.Name() == "" {
+		return
+	}
+	grammar, ok := rule.Container().(Grammar)
+	if !ok || grammar == nil {
+		return
+	}
+	groupName := InfixOperatorGroupName(rule)
+	if findRuleByName(grammar, groupName) != nil {
+		accept(core.NewDiagnostic(
+			core.SeverityError,
+			fmt.Sprintf("The infix rule '%s' reserves the name '%s' for its generated operator token group, but that name is already taken.", rule.Name(), groupName),
+			rule,
+			core.WithToken(rule.NameToken()),
+			core.WithCode(ValidateInfixOperatorGroupName),
+		))
+	}
+}
+
+// findInterfaceField returns the field with the given name declared on the
+// interface or any of its (transitive) super interfaces.
+func findInterfaceField(iface Interface, name string, ctx context.Context) Field {
+	return doFindInterfaceField(iface, name, ctx, collections.NewSet[string]())
+}
+
+func doFindInterfaceField(iface Interface, name string, ctx context.Context, visited collections.Set[string]) Field {
+	if !visited.Add(iface.Name()) {
+		return nil
+	}
+	for _, field := range iface.Fields() {
+		if field.Name() == name {
+			return field
+		}
+	}
+	for _, ext := range iface.Extends() {
+		if extType := ext.Ref(ctx); extType != nil {
+			if field := doFindInterfaceField(extType, name, ctx, visited); field != nil {
+				return field
+			}
+		}
+	}
+	return nil
 }
 
 func (cr *CrossRefImpl) Validate(ctx context.Context, _ string, accept core.ValidationAcceptor) {

--- a/internal/grammar/validator.go
+++ b/internal/grammar/validator.go
@@ -464,11 +464,8 @@ func checkRuleCallReturnType(call RuleCall, ctx context.Context, accept core.Val
 		return
 	}
 	var targetType Interface
-	switch target := targetRule.(type) {
-	case ParserRule:
-		targetType = FindReturnType(target, ctx)
-	case InfixRule:
-		targetType = FindInfixReturnType(target, ctx)
+	if targetRule, ok := targetRule.(AbstractRuleWithReturnType); ok {
+		targetType = FindReturnType(targetRule, ctx)
 	}
 	if targetType == nil {
 		return
@@ -702,57 +699,9 @@ func isAssignableTo(ctx context.Context, source Assignable, fieldType FieldType,
 				))
 			}
 		case ParserRule:
-			if simpleType, ok := fieldType.(SimpleType); ok {
-				ruleType := FindReturnType(rule, ctx)
-				if ruleType == nil {
-					return
-				}
-				targetType := simpleType.Type().Ref(ctx)
-				if targetType == nil {
-					return
-				}
-				if !interfaceIsAssignableTo(ruleType, targetType) {
-					accept(core.NewDiagnostic(
-						core.SeverityError,
-						fmt.Sprintf("The return type '%s' of the called rule is not assignable to the target field type '%s'.", ruleType.Name(), targetType.Name()),
-						v,
-						core.WithCode(ValidateAssignmentType),
-					))
-				}
-			} else {
-				accept(core.NewDiagnostic(
-					core.SeverityError,
-					"Cannot assign a parser rule to a non-interface field.",
-					v,
-					core.WithCode(ValidateAssignmentType),
-				))
-			}
+			ruleAssignabilityCheck(fieldType, rule, ctx, v, accept)
 		case InfixRule:
-			if simpleType, ok := fieldType.(SimpleType); ok {
-				ruleType := FindInfixReturnType(rule, ctx)
-				if ruleType == nil {
-					return
-				}
-				targetType := simpleType.Type().Ref(ctx)
-				if targetType == nil {
-					return
-				}
-				if !interfaceIsAssignableTo(ruleType, targetType) {
-					accept(core.NewDiagnostic(
-						core.SeverityError,
-						fmt.Sprintf("The return type '%s' of the called rule is not assignable to the target field type '%s'.", ruleType.Name(), targetType.Name()),
-						v,
-						core.WithCode(ValidateAssignmentType),
-					))
-				}
-			} else {
-				accept(core.NewDiagnostic(
-					core.SeverityError,
-					"Cannot assign a parser rule to a non-interface field.",
-					v,
-					core.WithCode(ValidateAssignmentType),
-				))
-			}
+			ruleAssignabilityCheck(fieldType, rule, ctx, v, accept)
 		case CompositeRule:
 			if primitiveType, ok := fieldType.(PrimitiveType); !ok || primitiveType.Type() != "composite" {
 				if primitiveType, ok := fieldType.(PrimitiveType); ok && primitiveType.Type() == "string" {
@@ -787,6 +736,34 @@ func isAssignableTo(ctx context.Context, source Assignable, fieldType FieldType,
 				isAssignableTo(ctx, assignableOption, fieldType, accept)
 			}
 		}
+	}
+}
+
+func ruleAssignabilityCheck(fieldType FieldType, rule AbstractRuleWithReturnType, ctx context.Context, v RuleCall, accept core.ValidationAcceptor) {
+	if simpleType, ok := fieldType.(SimpleType); ok {
+		ruleType := FindReturnType(rule, ctx)
+		if ruleType == nil {
+			return
+		}
+		targetType := simpleType.Type().Ref(ctx)
+		if targetType == nil {
+			return
+		}
+		if !interfaceIsAssignableTo(ruleType, targetType) {
+			accept(core.NewDiagnostic(
+				core.SeverityError,
+				fmt.Sprintf("The return type '%s' of the called rule is not assignable to the target field type '%s'.", ruleType.Name(), targetType.Name()),
+				v,
+				core.WithCode(ValidateAssignmentType),
+			))
+		}
+	} else {
+		accept(core.NewDiagnostic(
+			core.SeverityError,
+			"Cannot assign a parser rule to a non-interface field.",
+			v,
+			core.WithCode(ValidateAssignmentType),
+		))
 	}
 }
 
@@ -912,7 +889,7 @@ func checkInfixNodeType(rule InfixRule, ctx context.Context, accept core.Validat
 		))
 		return
 	}
-	returnType := FindInfixReturnType(rule, ctx)
+	returnType := FindReturnType(rule, ctx)
 	if returnType == nil {
 		return
 	}

--- a/internal/languages/completion/atn_gen.go
+++ b/internal/languages/completion/atn_gen.go
@@ -191,11 +191,11 @@ const (
 	L_end
 	L__Basic_2
 	M_m
-	M__Basic_0
-	M__Basic_1
+	M_SomeTokenGroup
+	M__Basic
 	N_n
-	N__Basic_0
-	N__Basic_1
+	N_Ref_SomeTokenGroup
+	N__Basic
 	O_o
 	O_Ref_ID
 	O__Basic
@@ -402,11 +402,11 @@ func BuildATN() *parser.RuntimeATN {
 	states[L_end] = parser.NewATNState(L_end, parser.ATNBasic, false)
 	states[L__Basic_2] = parser.NewATNState(L__Basic_2, parser.ATNBasic, true)
 	states[M_m] = parser.NewATNState(M_m, parser.ATNBasic, false)
-	states[M__Basic_0] = parser.NewATNState(M__Basic_0, parser.ATNBasic, false)
-	states[M__Basic_1] = parser.NewATNState(M__Basic_1, parser.ATNBasic, true)
+	states[M_SomeTokenGroup] = parser.NewATNState(M_SomeTokenGroup, parser.ATNBasic, false)
+	states[M__Basic] = parser.NewATNState(M__Basic, parser.ATNBasic, true)
 	states[N_n] = parser.NewATNState(N_n, parser.ATNBasic, false)
-	states[N__Basic_0] = parser.NewATNState(N__Basic_0, parser.ATNBasic, false)
-	states[N__Basic_1] = parser.NewATNState(N__Basic_1, parser.ATNBasic, true)
+	states[N_Ref_SomeTokenGroup] = parser.NewATNState(N_Ref_SomeTokenGroup, parser.ATNBasic, false)
+	states[N__Basic] = parser.NewATNState(N__Basic, parser.ATNBasic, true)
 	states[O_o] = parser.NewATNState(O_o, parser.ATNBasic, false)
 	states[O_Ref_ID] = parser.NewATNState(O_Ref_ID, parser.ATNBasic, false)
 	states[O__Basic] = parser.NewATNState(O__Basic, parser.ATNBasic, true)
@@ -922,21 +922,21 @@ func BuildATN() *parser.RuntimeATN {
 		parser.NewEpsilonTransition(states[L__Stop]),
 	)
 	states[M_m].AppendTransitions(
-		parser.NewAtomTransition(states[M__Basic_0], Keyword_m, nil),
+		parser.NewAtomTransition(states[M_SomeTokenGroup], Keyword_m, nil),
 	)
-	states[M__Basic_0].AppendTransitions(
-		parser.NewAtomTransition(states[M__Basic_1], Token_SomeTokenGroup, nil),
+	states[M_SomeTokenGroup].AppendTransitions(
+		parser.NewAtomTransition(states[M__Basic], Token_SomeTokenGroup, nil),
 	)
-	states[M__Basic_1].AppendTransitions(
+	states[M__Basic].AppendTransitions(
 		parser.NewEpsilonTransition(states[M__Stop]),
 	)
 	states[N_n].AppendTransitions(
-		parser.NewAtomTransition(states[N__Basic_0], Keyword_n, nil),
+		parser.NewAtomTransition(states[N_Ref_SomeTokenGroup], Keyword_n, nil),
 	)
-	states[N__Basic_0].AppendTransitions(
-		parser.NewAtomTransition(states[N__Basic_1], Token_SomeTokenGroup, &parser.CompletionHint{Field: "N.Ref"}),
+	states[N_Ref_SomeTokenGroup].AppendTransitions(
+		parser.NewAtomTransition(states[N__Basic], Token_SomeTokenGroup, &parser.CompletionHint{Field: "N.Ref"}),
 	)
-	states[N__Basic_1].AppendTransitions(
+	states[N__Basic].AppendTransitions(
 		parser.NewEpsilonTransition(states[N__Stop]),
 	)
 	states[O_o].AppendTransitions(

--- a/internal/languages/completion/parser_gen.go
+++ b/internal/languages/completion/parser_gen.go
@@ -674,7 +674,7 @@ func (p *Parser) ParseM() Obj {
 		}
 		{
 			token := p.state.Consume(Token_SomeTokenGroup)
-			core.AssignToken(current, token, M__Basic_0)
+			core.AssignToken(current, token, M_SomeTokenGroup)
 		}
 	}
 	current.SetTextRangeEnd(p.state.LA(0).Range.End)
@@ -691,7 +691,7 @@ func (p *Parser) ParseN() N {
 		}
 		{
 			token := p.state.Consume(Token_SomeTokenGroup)
-			core.AssignToken(current, token, N__Basic_0)
+			core.AssignToken(current, token, N_Ref_SomeTokenGroup)
 			if token != nil {
 				current.SetRef(p.referencesConstructor.NRef(current, token))
 			}

--- a/internal/languages/token_groups/atn_gen.go
+++ b/internal/languages/token_groups/atn_gen.go
@@ -45,40 +45,40 @@ const (
 	Model__Basic_16
 	Model__BlockEnd
 	A_a
-	A__Basic_0
-	A__Basic_1
+	A_Value_Identifier
+	A__Basic
 	B_b
+	B_Value_Identifier
 	B__Basic_0
-	B__Basic_1
 	B_Value_b
+	B__Basic_1
 	B__Basic_2
-	B__Basic_3
 	B__BlockEnd
 	C_c
-	C__Basic_0
-	C__Basic_1
+	C_Value_NestedIdentifier
+	C__Basic
 	D_d
+	D_Value_Identifier
 	D__Basic_0
 	D__Basic_1
-	D__Basic_2
 	E_e
-	E__Basic_0
-	E__Basic_1
-	E__Basic_2
+	E_First_Identifier
+	E_Second_NestedIdentifier
+	E__Basic
 	F_f
-	F__Basic_0
-	F__Basic_1
+	F_Value_KeywordGroup
+	F__Basic
 	G_g
-	G__Basic_0
-	G__Basic_1
+	G_Value_RegexGroup
+	G__Basic
 	H_h
-	H__Basic_0
+	H_Identifier_0
 	H_Value_a
+	H__Basic_0
+	H_Identifier_1
+	H_Value_b
 	H__Basic_1
 	H__Basic_2
-	H_Value_b
-	H__Basic_3
-	H__Basic_4
 	H__BlockEnd
 )
 
@@ -130,40 +130,40 @@ func BuildATN() *parser.RuntimeATN {
 	states[Model__Basic_16] = parser.NewATNState(Model__Basic_16, parser.ATNBasic, true).SetDecision(0)
 	states[Model__BlockEnd] = parser.NewATNState(Model__BlockEnd, parser.ATNBlockEnd, true)
 	states[A_a] = parser.NewATNState(A_a, parser.ATNBasic, false)
-	states[A__Basic_0] = parser.NewATNState(A__Basic_0, parser.ATNBasic, false)
-	states[A__Basic_1] = parser.NewATNState(A__Basic_1, parser.ATNBasic, true)
+	states[A_Value_Identifier] = parser.NewATNState(A_Value_Identifier, parser.ATNBasic, false)
+	states[A__Basic] = parser.NewATNState(A__Basic, parser.ATNBasic, true)
 	states[B_b] = parser.NewATNState(B_b, parser.ATNBasic, false)
-	states[B__Basic_0] = parser.NewATNState(B__Basic_0, parser.ATNBasic, false)
-	states[B__Basic_1] = parser.NewATNState(B__Basic_1, parser.ATNBasic, true)
+	states[B_Value_Identifier] = parser.NewATNState(B_Value_Identifier, parser.ATNBasic, false)
+	states[B__Basic_0] = parser.NewATNState(B__Basic_0, parser.ATNBasic, true)
 	states[B_Value_b] = parser.NewATNState(B_Value_b, parser.ATNBasic, false)
-	states[B__Basic_2] = parser.NewATNState(B__Basic_2, parser.ATNBasic, true)
-	states[B__Basic_3] = parser.NewATNState(B__Basic_3, parser.ATNBasic, true).SetDecision(1)
+	states[B__Basic_1] = parser.NewATNState(B__Basic_1, parser.ATNBasic, true)
+	states[B__Basic_2] = parser.NewATNState(B__Basic_2, parser.ATNBasic, true).SetDecision(1)
 	states[B__BlockEnd] = parser.NewATNState(B__BlockEnd, parser.ATNBlockEnd, true)
 	states[C_c] = parser.NewATNState(C_c, parser.ATNBasic, false)
-	states[C__Basic_0] = parser.NewATNState(C__Basic_0, parser.ATNBasic, false)
-	states[C__Basic_1] = parser.NewATNState(C__Basic_1, parser.ATNBasic, true)
+	states[C_Value_NestedIdentifier] = parser.NewATNState(C_Value_NestedIdentifier, parser.ATNBasic, false)
+	states[C__Basic] = parser.NewATNState(C__Basic, parser.ATNBasic, true)
 	states[D_d] = parser.NewATNState(D_d, parser.ATNBasic, false)
-	states[D__Basic_0] = parser.NewATNState(D__Basic_0, parser.ATNBasic, false)
-	states[D__Basic_1] = parser.NewATNState(D__Basic_1, parser.ATNBasic, true)
-	states[D__Basic_2] = parser.NewATNState(D__Basic_2, parser.ATNBasic, true).SetDecision(2)
+	states[D_Value_Identifier] = parser.NewATNState(D_Value_Identifier, parser.ATNBasic, false)
+	states[D__Basic_0] = parser.NewATNState(D__Basic_0, parser.ATNBasic, true)
+	states[D__Basic_1] = parser.NewATNState(D__Basic_1, parser.ATNBasic, true).SetDecision(2)
 	states[E_e] = parser.NewATNState(E_e, parser.ATNBasic, false)
-	states[E__Basic_0] = parser.NewATNState(E__Basic_0, parser.ATNBasic, false)
-	states[E__Basic_1] = parser.NewATNState(E__Basic_1, parser.ATNBasic, false)
-	states[E__Basic_2] = parser.NewATNState(E__Basic_2, parser.ATNBasic, true)
+	states[E_First_Identifier] = parser.NewATNState(E_First_Identifier, parser.ATNBasic, false)
+	states[E_Second_NestedIdentifier] = parser.NewATNState(E_Second_NestedIdentifier, parser.ATNBasic, false)
+	states[E__Basic] = parser.NewATNState(E__Basic, parser.ATNBasic, true)
 	states[F_f] = parser.NewATNState(F_f, parser.ATNBasic, false)
-	states[F__Basic_0] = parser.NewATNState(F__Basic_0, parser.ATNBasic, false)
-	states[F__Basic_1] = parser.NewATNState(F__Basic_1, parser.ATNBasic, true)
+	states[F_Value_KeywordGroup] = parser.NewATNState(F_Value_KeywordGroup, parser.ATNBasic, false)
+	states[F__Basic] = parser.NewATNState(F__Basic, parser.ATNBasic, true)
 	states[G_g] = parser.NewATNState(G_g, parser.ATNBasic, false)
-	states[G__Basic_0] = parser.NewATNState(G__Basic_0, parser.ATNBasic, false)
-	states[G__Basic_1] = parser.NewATNState(G__Basic_1, parser.ATNBasic, true)
+	states[G_Value_RegexGroup] = parser.NewATNState(G_Value_RegexGroup, parser.ATNBasic, false)
+	states[G__Basic] = parser.NewATNState(G__Basic, parser.ATNBasic, true)
 	states[H_h] = parser.NewATNState(H_h, parser.ATNBasic, false)
-	states[H__Basic_0] = parser.NewATNState(H__Basic_0, parser.ATNBasic, false)
+	states[H_Identifier_0] = parser.NewATNState(H_Identifier_0, parser.ATNBasic, false)
 	states[H_Value_a] = parser.NewATNState(H_Value_a, parser.ATNBasic, false)
-	states[H__Basic_1] = parser.NewATNState(H__Basic_1, parser.ATNBasic, true)
-	states[H__Basic_2] = parser.NewATNState(H__Basic_2, parser.ATNBasic, false)
+	states[H__Basic_0] = parser.NewATNState(H__Basic_0, parser.ATNBasic, true)
+	states[H_Identifier_1] = parser.NewATNState(H_Identifier_1, parser.ATNBasic, false)
 	states[H_Value_b] = parser.NewATNState(H_Value_b, parser.ATNBasic, false)
-	states[H__Basic_3] = parser.NewATNState(H__Basic_3, parser.ATNBasic, true)
-	states[H__Basic_4] = parser.NewATNState(H__Basic_4, parser.ATNBasic, true).SetDecision(3)
+	states[H__Basic_1] = parser.NewATNState(H__Basic_1, parser.ATNBasic, true)
+	states[H__Basic_2] = parser.NewATNState(H__Basic_2, parser.ATNBasic, true).SetDecision(3)
 	states[H__BlockEnd] = parser.NewATNState(H__BlockEnd, parser.ATNBlockEnd, true)
 	states[Model__Start].AppendTransitions(
 		parser.NewEpsilonTransition(states[Model__Basic_16]),
@@ -254,125 +254,125 @@ func BuildATN() *parser.RuntimeATN {
 		parser.NewEpsilonTransition(states[Model__Stop]),
 	)
 	states[A_a].AppendTransitions(
-		parser.NewAtomTransition(states[A__Basic_0], Keyword_a, nil),
+		parser.NewAtomTransition(states[A_Value_Identifier], Keyword_a, nil),
 	)
-	states[A__Basic_0].AppendTransitions(
-		parser.NewAtomTransition(states[A__Basic_1], Token_Identifier, nil),
+	states[A_Value_Identifier].AppendTransitions(
+		parser.NewAtomTransition(states[A__Basic], Token_Identifier, nil),
 	)
-	states[A__Basic_1].AppendTransitions(
+	states[A__Basic].AppendTransitions(
 		parser.NewEpsilonTransition(states[A__Stop]),
 	)
 	states[B_b].AppendTransitions(
-		parser.NewAtomTransition(states[B__Basic_3], Keyword_b, nil),
+		parser.NewAtomTransition(states[B__Basic_2], Keyword_b, nil),
+	)
+	states[B_Value_Identifier].AppendTransitions(
+		parser.NewAtomTransition(states[B__Basic_0], Token_Identifier, nil),
 	)
 	states[B__Basic_0].AppendTransitions(
-		parser.NewAtomTransition(states[B__Basic_1], Token_Identifier, nil),
+		parser.NewEpsilonTransition(states[B__BlockEnd]),
+	)
+	states[B_Value_b].AppendTransitions(
+		parser.NewAtomTransition(states[B__Basic_1], Keyword_b, nil),
 	)
 	states[B__Basic_1].AppendTransitions(
 		parser.NewEpsilonTransition(states[B__BlockEnd]),
 	)
-	states[B_Value_b].AppendTransitions(
-		parser.NewAtomTransition(states[B__Basic_2], Keyword_b, nil),
-	)
 	states[B__Basic_2].AppendTransitions(
-		parser.NewEpsilonTransition(states[B__BlockEnd]),
-	)
-	states[B__Basic_3].AppendTransitions(
-		parser.NewEpsilonTransition(states[B__Basic_0]),
+		parser.NewEpsilonTransition(states[B_Value_Identifier]),
 		parser.NewEpsilonTransition(states[B_Value_b]),
 	)
 	states[B__BlockEnd].AppendTransitions(
 		parser.NewEpsilonTransition(states[B__Stop]),
 	)
 	states[C_c].AppendTransitions(
-		parser.NewAtomTransition(states[C__Basic_0], Keyword_c, nil),
+		parser.NewAtomTransition(states[C_Value_NestedIdentifier], Keyword_c, nil),
 	)
-	states[C__Basic_0].AppendTransitions(
-		parser.NewAtomTransition(states[C__Basic_1], Token_NestedIdentifier, nil),
+	states[C_Value_NestedIdentifier].AppendTransitions(
+		parser.NewAtomTransition(states[C__Basic], Token_NestedIdentifier, nil),
 	)
-	states[C__Basic_1].AppendTransitions(
+	states[C__Basic].AppendTransitions(
 		parser.NewEpsilonTransition(states[C__Stop]),
 	)
 	states[D_d].AppendTransitions(
-		parser.NewAtomTransition(states[D__Basic_2], Keyword_d, nil),
+		parser.NewAtomTransition(states[D__Basic_1], Keyword_d, nil),
+	)
+	states[D_Value_Identifier].AppendTransitions(
+		parser.NewAtomTransition(states[D__Basic_0], Token_Identifier, nil),
 	)
 	states[D__Basic_0].AppendTransitions(
-		parser.NewAtomTransition(states[D__Basic_1], Token_Identifier, nil),
-	)
-	states[D__Basic_1].AppendTransitions(
 		parser.NewEpsilonTransition(states[D__Stop]),
 	)
-	states[D__Basic_2].AppendTransitions(
+	states[D__Basic_1].AppendTransitions(
+		parser.NewEpsilonTransition(states[D_Value_Identifier]),
 		parser.NewEpsilonTransition(states[D__Basic_0]),
-		parser.NewEpsilonTransition(states[D__Basic_1]),
 	)
 	states[E_e].AppendTransitions(
-		parser.NewAtomTransition(states[E__Basic_0], Keyword_e, nil),
+		parser.NewAtomTransition(states[E_First_Identifier], Keyword_e, nil),
 	)
-	states[E__Basic_0].AppendTransitions(
-		parser.NewAtomTransition(states[E__Basic_1], Token_Identifier, nil),
+	states[E_First_Identifier].AppendTransitions(
+		parser.NewAtomTransition(states[E_Second_NestedIdentifier], Token_Identifier, nil),
 	)
-	states[E__Basic_1].AppendTransitions(
-		parser.NewAtomTransition(states[E__Basic_2], Token_NestedIdentifier, nil),
+	states[E_Second_NestedIdentifier].AppendTransitions(
+		parser.NewAtomTransition(states[E__Basic], Token_NestedIdentifier, nil),
 	)
-	states[E__Basic_2].AppendTransitions(
+	states[E__Basic].AppendTransitions(
 		parser.NewEpsilonTransition(states[E__Stop]),
 	)
 	states[F_f].AppendTransitions(
-		parser.NewAtomTransition(states[F__Basic_0], Keyword_f, nil),
+		parser.NewAtomTransition(states[F_Value_KeywordGroup], Keyword_f, nil),
 	)
-	states[F__Basic_0].AppendTransitions(
-		parser.NewAtomTransition(states[F__Basic_1], Token_KeywordGroup, nil),
+	states[F_Value_KeywordGroup].AppendTransitions(
+		parser.NewAtomTransition(states[F__Basic], Token_KeywordGroup, nil),
 	)
-	states[F__Basic_1].AppendTransitions(
+	states[F__Basic].AppendTransitions(
 		parser.NewEpsilonTransition(states[F__Stop]),
 	)
 	states[G_g].AppendTransitions(
-		parser.NewAtomTransition(states[G__Basic_0], Keyword_g, nil),
+		parser.NewAtomTransition(states[G_Value_RegexGroup], Keyword_g, nil),
 	)
-	states[G__Basic_0].AppendTransitions(
-		parser.NewAtomTransition(states[G__Basic_1], Token_RegexGroup, nil),
+	states[G_Value_RegexGroup].AppendTransitions(
+		parser.NewAtomTransition(states[G__Basic], Token_RegexGroup, nil),
 	)
-	states[G__Basic_1].AppendTransitions(
+	states[G__Basic].AppendTransitions(
 		parser.NewEpsilonTransition(states[G__Stop]),
 	)
 	states[H_h].AppendTransitions(
-		parser.NewAtomTransition(states[H__Basic_4], Keyword_h, nil),
+		parser.NewAtomTransition(states[H__Basic_2], Keyword_h, nil),
 	)
-	states[H__Basic_0].AppendTransitions(
+	states[H_Identifier_0].AppendTransitions(
 		parser.NewAtomTransition(states[H_Value_a], Token_Identifier, nil),
 	)
 	states[H_Value_a].AppendTransitions(
-		parser.NewAtomTransition(states[H__Basic_1], Keyword_a, nil),
+		parser.NewAtomTransition(states[H__Basic_0], Keyword_a, nil),
+	)
+	states[H__Basic_0].AppendTransitions(
+		parser.NewEpsilonTransition(states[H__BlockEnd]),
+	)
+	states[H_Identifier_1].AppendTransitions(
+		parser.NewAtomTransition(states[H_Value_b], Token_Identifier, nil),
+	)
+	states[H_Value_b].AppendTransitions(
+		parser.NewAtomTransition(states[H__Basic_1], Keyword_b, nil),
 	)
 	states[H__Basic_1].AppendTransitions(
 		parser.NewEpsilonTransition(states[H__BlockEnd]),
 	)
 	states[H__Basic_2].AppendTransitions(
-		parser.NewAtomTransition(states[H_Value_b], Token_Identifier, nil),
-	)
-	states[H_Value_b].AppendTransitions(
-		parser.NewAtomTransition(states[H__Basic_3], Keyword_b, nil),
-	)
-	states[H__Basic_3].AppendTransitions(
-		parser.NewEpsilonTransition(states[H__BlockEnd]),
-	)
-	states[H__Basic_4].AppendTransitions(
-		parser.NewEpsilonTransition(states[H__Basic_0]),
-		parser.NewEpsilonTransition(states[H__Basic_2]),
+		parser.NewEpsilonTransition(states[H_Identifier_0]),
+		parser.NewEpsilonTransition(states[H_Identifier_1]),
 	)
 	states[H__BlockEnd].AppendTransitions(
 		parser.NewEpsilonTransition(states[H__Stop]),
 	)
 	decisionStates := make([]*parser.RuntimeATNState, 4)
 	decisionStates[0] = states[Model__Basic_16]
-	decisionStates[1] = states[B__Basic_3]
-	decisionStates[2] = states[D__Basic_2]
-	decisionStates[3] = states[H__Basic_4]
+	decisionStates[1] = states[B__Basic_2]
+	decisionStates[2] = states[D__Basic_1]
+	decisionStates[3] = states[H__Basic_2]
 	decisionMap := make([]*parser.RuntimeATNState, 4)
 	decisionMap[0] = states[Model__Basic_16]
-	decisionMap[1] = states[B__Basic_3]
-	decisionMap[2] = states[D__Basic_2]
-	decisionMap[3] = states[H__Basic_4]
+	decisionMap[1] = states[B__Basic_2]
+	decisionMap[2] = states[D__Basic_1]
+	decisionMap[3] = states[H__Basic_2]
 	return parser.NewRuntimeATN(states, decisionStates, decisionMap)
 }

--- a/internal/languages/token_groups/completion_parser_gen.go
+++ b/internal/languages/token_groups/completion_parser_gen.go
@@ -133,8 +133,8 @@ func (p *CompletionParser) ParseD() {
 		p.state.Consume(Keyword_d)
 	}
 	{
-		p.cp.RecordSnapshot(D__Basic_2)
-		p.state.Sync(D__Basic_2)
+		p.cp.RecordSnapshot(D__Basic_1)
+		p.state.Sync(D__Basic_1)
 		if p.lookahead.DValueOptional(p.state) {
 			p.cp.MarkAssignment("Value")
 			p.state.Consume(Token_Identifier)

--- a/internal/languages/token_groups/parser_gen.go
+++ b/internal/languages/token_groups/parser_gen.go
@@ -111,7 +111,7 @@ func (p *Parser) ParseA() Item {
 		}
 		{
 			token := p.state.Consume(Token_Identifier)
-			core.AssignToken(current, token, A__Basic_0)
+			core.AssignToken(current, token, A_Value_Identifier)
 			if token != nil {
 				current.SetValue(token)
 			}
@@ -133,7 +133,7 @@ func (p *Parser) ParseB() Item {
 			switch prediction, _ := p.lookahead.BValueAlternatives(p.state); prediction {
 			case 0:
 				token := p.state.Consume(Token_Identifier)
-				core.AssignToken(current, token, B__Basic_0)
+				core.AssignToken(current, token, B_Value_Identifier)
 				if token != nil {
 					current.SetValue(token)
 				}
@@ -160,7 +160,7 @@ func (p *Parser) ParseC() Item {
 		}
 		{
 			token := p.state.Consume(Token_NestedIdentifier)
-			core.AssignToken(current, token, C__Basic_0)
+			core.AssignToken(current, token, C_Value_NestedIdentifier)
 			if token != nil {
 				current.SetValue(token)
 			}
@@ -179,10 +179,10 @@ func (p *Parser) ParseD() Item {
 			core.AssignToken(current, token, D_d)
 		}
 		{
-			p.state.Sync(D__Basic_2)
+			p.state.Sync(D__Basic_1)
 			if p.lookahead.DValueOptional(p.state) {
 				token := p.state.Consume(Token_Identifier)
-				core.AssignToken(current, token, D__Basic_0)
+				core.AssignToken(current, token, D_Value_Identifier)
 				if token != nil {
 					current.SetValue(token)
 				}
@@ -203,14 +203,14 @@ func (p *Parser) ParseE() Recovery {
 		}
 		{
 			token := p.state.Consume(Token_Identifier)
-			core.AssignToken(current, token, E__Basic_0)
+			core.AssignToken(current, token, E_First_Identifier)
 			if token != nil {
 				current.SetFirst(token)
 			}
 		}
 		{
 			token := p.state.Consume(Token_NestedIdentifier)
-			core.AssignToken(current, token, E__Basic_1)
+			core.AssignToken(current, token, E_Second_NestedIdentifier)
 			if token != nil {
 				current.SetSecond(token)
 			}
@@ -230,7 +230,7 @@ func (p *Parser) ParseF() Item {
 		}
 		{
 			token := p.state.Consume(Token_KeywordGroup)
-			core.AssignToken(current, token, F__Basic_0)
+			core.AssignToken(current, token, F_Value_KeywordGroup)
 			if token != nil {
 				current.SetValue(token)
 			}
@@ -250,7 +250,7 @@ func (p *Parser) ParseG() Item {
 		}
 		{
 			token := p.state.Consume(Token_RegexGroup)
-			core.AssignToken(current, token, G__Basic_0)
+			core.AssignToken(current, token, G_Value_RegexGroup)
 			if token != nil {
 				current.SetValue(token)
 			}
@@ -272,7 +272,7 @@ func (p *Parser) ParseH() Item {
 		case 0:
 			{
 				token := p.state.Consume(Token_Identifier)
-				core.AssignToken(current, token, H__Basic_0)
+				core.AssignToken(current, token, H_Identifier_0)
 			}
 			{
 				token := p.state.Consume(Keyword_a)
@@ -284,7 +284,7 @@ func (p *Parser) ParseH() Item {
 		case 1:
 			{
 				token := p.state.Consume(Token_Identifier)
-				core.AssignToken(current, token, H__Basic_2)
+				core.AssignToken(current, token, H_Identifier_1)
 			}
 			{
 				token := p.state.Consume(Keyword_b)

--- a/internal/vscode-extensions/fastbelt/data/fastbelt.tmLanguage.json
+++ b/internal/vscode-extensions/fastbelt/data/fastbelt.tmLanguage.json
@@ -13,7 +13,7 @@
         },
         {
             "name": "keyword.control.fastbelt",
-            "match": "\\b(bool|comment|composite|current|entry|extends|fragment|grammar|group|hidden|import|interface|keywords|returns|string|token|type)\\b"
+            "match": "\\b(assoc|bool|comment|composite|current|entry|extends|fragment|grammar|group|hidden|import|infix|interface|keywords|left|on|returns|right|string|token|type)\\b"
         },
         {
             "name": "constant.language.fastbelt",

--- a/internal/vscode-extensions/fastbelt/data/fastbelt.tmLanguage.json
+++ b/internal/vscode-extensions/fastbelt/data/fastbelt.tmLanguage.json
@@ -13,7 +13,7 @@
         },
         {
             "name": "keyword.control.fastbelt",
-            "match": "\\b(assoc|bool|comment|composite|current|entry|extends|fragment|grammar|group|hidden|import|infix|interface|keywords|left|on|returns|right|string|token|type)\\b"
+            "match": "\\b(bool|comment|composite|current|entry|extends|fragment|grammar|group|hidden|import|infix|interface|keywords|left|on|returns|right|string|token|type)\\b"
         },
         {
             "name": "constant.language.fastbelt",

--- a/parser/infix.go
+++ b/parser/infix.go
@@ -2,9 +2,13 @@
 // This program and the accompanying materials are made available under the
 // terms of the MIT License, which is available in the project root.
 
-package fastbelt
+package parser
 
-import "math"
+import (
+	"math"
+
+	core "typefox.dev/fastbelt"
+)
 
 // InfixPrecedence describes one operator token type of an infix rule.
 type InfixPrecedence struct {
@@ -23,13 +27,13 @@ type InfixPrecedence struct {
 // rightmost one becomes the split point for left-associative groups (yielding
 // a left-leaning tree) and the leftmost one for right-associative groups.
 //
-// precedence is keyed by the leaf token type id ([Token.TypeId]); an operator
+// precedence is keyed by the leaf token type id; an operator
 // token missing from the map is treated as binding loosest. build constructs a
 // single node; right is the zero value of T when a trailing operator has no
 // operand (parse error tolerance). A single part is returned unchanged.
-func BuildInfixTree[T AstNode](parts []T, operators []*Token,
+func BuildInfixTree[T core.AstNode](parts []T, operators []*core.Token,
 	precedence map[int]InfixPrecedence,
-	build func(left T, operator *Token, right T) T) T {
+	build func(left T, operator *core.Token, right T) T) T {
 	var zero T
 	if len(parts) == 0 {
 		return zero
@@ -47,7 +51,7 @@ func BuildInfixTree[T AstNode](parts []T, operators []*Token,
 		bestLevel := -1
 		for i := lo; i < hi; i++ {
 			level, right := math.MaxInt, false
-			if p, ok := precedence[operators[i].TypeId]; ok {
+			if p, ok := precedence[operators[i].Type.Id]; ok {
 				level, right = p.Level, p.Right
 			}
 			if level > bestLevel {

--- a/parser/infix.go
+++ b/parser/infix.go
@@ -22,10 +22,11 @@ type InfixPrecedence struct {
 // BuildInfixTree folds the flat parts/operators lists collected by a generated
 // infix rule parser into a binary expression tree.
 //
-// The tree is built by recursively splitting at the loosest-binding operator
-// (the one with the largest level). Between operators of the same level, the
-// rightmost one becomes the split point for left-associative groups (yielding
-// a left-leaning tree) and the leftmost one for right-associative groups.
+// The fold is the standard operator-precedence stack reduction: tighter-binding
+// operators (smaller level) reduce before a looser incoming operator is pushed,
+// so the loosest operator ends up at the root. Operators of the same level
+// reduce eagerly when left-associative (yielding a left-leaning tree) and lazily
+// when right-associative. Runs in O(len(operators)).
 //
 // precedence is keyed by the leaf token type id; an operator
 // token missing from the map is treated as binding loosest. build constructs a
@@ -38,32 +39,40 @@ func BuildInfixTree[T core.AstNode](parts []T, operators []*core.Token,
 	if len(parts) == 0 {
 		return zero
 	}
-	// rec builds the tree for operators[lo:hi] and their surrounding parts.
-	var rec func(lo, hi int) T
-	rec = func(lo, hi int) T {
-		if lo == hi {
-			if lo < len(parts) {
-				return parts[lo]
-			}
-			return zero
+	operand := func(i int) T {
+		if i < len(parts) {
+			return parts[i]
 		}
-		pivot := lo
-		bestLevel := -1
-		for i := lo; i < hi; i++ {
-			level, right := math.MaxInt, false
-			if p, ok := precedence[operators[i].Type.Id]; ok {
-				level, right = p.Level, p.Right
-			}
-			if level > bestLevel {
-				bestLevel = level
-				pivot = i
-			} else if level == bestLevel && !right {
-				// Left-associative: the rightmost operator of the loosest
-				// level becomes the root. Right-associative: keep the leftmost.
-				pivot = i
-			}
-		}
-		return build(rec(lo, pivot), operators[pivot], rec(pivot+1, hi))
+		return zero
 	}
-	return rec(0, len(operators))
+	type stackedOp struct {
+		token *core.Token
+		level int
+	}
+	operands := make([]T, 1, len(operators)+1)
+	operands[0] = operand(0)
+	ops := make([]stackedOp, 0, len(operators))
+	reduce := func() {
+		op := ops[len(ops)-1]
+		ops = ops[:len(ops)-1]
+		right := operands[len(operands)-1]
+		operands = operands[:len(operands)-1]
+		operands[len(operands)-1] = build(operands[len(operands)-1], op.token, right)
+	}
+	for i, token := range operators {
+		level, rightAssoc := math.MaxInt, false
+		if p, ok := precedence[token.Type.Id]; ok {
+			level, rightAssoc = p.Level, p.Right
+		}
+		for len(ops) > 0 && (ops[len(ops)-1].level < level ||
+			(ops[len(ops)-1].level == level && !rightAssoc)) {
+			reduce()
+		}
+		ops = append(ops, stackedOp{token, level})
+		operands = append(operands, operand(i+1))
+	}
+	for len(ops) > 0 {
+		reduce()
+	}
+	return operands[0]
 }

--- a/parser/infix_test.go
+++ b/parser/infix_test.go
@@ -2,17 +2,18 @@
 // This program and the accompanying materials are made available under the
 // terms of the MIT License, which is available in the project root.
 
-package fastbelt
+package parser
 
 import (
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	core "typefox.dev/fastbelt"
 )
 
 type infixTestNode struct {
-	AstNodeBase
+	core.AstNodeBase
 	name        string
 	left, right *infixTestNode
 	op          string
@@ -30,18 +31,18 @@ func (n *infixTestNode) String() string {
 
 // parseInfixInput splits "1 + 2 * 3" into leaf nodes and operator tokens,
 // assigning each distinct operator symbol a stable token type id.
-func parseInfixInput(input string, typeIds map[string]int) (parts []*infixTestNode, operators []*Token) {
+func parseInfixInput(input string, typeIds map[string]int) (parts []*infixTestNode, operators []*core.Token) {
 	for i, field := range strings.Fields(input) {
 		if i%2 == 0 {
 			parts = append(parts, &infixTestNode{name: field})
 		} else {
-			operators = append(operators, &Token{Image: field, TypeId: typeIds[field]})
+			operators = append(operators, &core.Token{Image: field, Type: &core.TokenType{Id: typeIds[field], Name: field}})
 		}
 	}
 	return parts, operators
 }
 
-func buildInfixTestNode(left *infixTestNode, operator *Token, right *infixTestNode) *infixTestNode {
+func buildInfixTestNode(left *infixTestNode, operator *core.Token, right *infixTestNode) *infixTestNode {
 	op := "?"
 	if operator != nil {
 		op = operator.Image
@@ -98,9 +99,9 @@ func TestBuildInfixTreeDanglingOperator(t *testing.T) {
 
 	// "1 + 2 -" — the trailing operator has no right operand.
 	parts := []*infixTestNode{{name: "1"}, {name: "2"}}
-	operators := []*Token{
-		{Image: "+", TypeId: 1},
-		{Image: "-", TypeId: 2},
+	operators := []*core.Token{
+		{Image: "+", Type: &core.TokenType{Id: 1, Name: "+"}},
+		{Image: "-", Type: &core.TokenType{Id: 2, Name: "-"}},
 	}
 	tree := BuildInfixTree(parts, operators, precedence, buildInfixTestNode)
 	assert.Equal(t, "((1 + 2) - <nil>)", tree.String())
@@ -109,9 +110,9 @@ func TestBuildInfixTreeDanglingOperator(t *testing.T) {
 func TestBuildInfixTreeUnknownOperatorBindsLoosest(t *testing.T) {
 	precedence := map[int]InfixPrecedence{1: {Level: 0}}
 	parts := []*infixTestNode{{name: "1"}, {name: "2"}, {name: "3"}}
-	operators := []*Token{
-		{Image: "?", TypeId: 99},
-		{Image: "*", TypeId: 1},
+	operators := []*core.Token{
+		{Image: "?", Type: &core.TokenType{Id: 99, Name: "?"}},
+		{Image: "*", Type: &core.TokenType{Id: 1, Name: "*"}},
 	}
 	tree := BuildInfixTree(parts, operators, precedence, buildInfixTestNode)
 	assert.Equal(t, "(1 ? (2 * 3))", tree.String())


### PR DESCRIPTION
Closes https://github.com/TypeFox/fastbelt/issues/115 (as a side effect).

Adds infix rule support, similar to how Langium did it (but a bit simpler, since we don't need CST support). 

Implements the support by rewriting infix rules into parser rules of the shape `Expr (op Expr)*`.