### PR TITLE
Remove TypeId from token

### DIFF
--- a/parser/atn_simulator_test.go
+++ b/parser/atn_simulator_test.go
@@ -12,7 +12,7 @@ import (
 
 // tok constructs a token of the given type for tests.
 func tok(tt *core.TokenType) core.Token {
-	return core.Token{Type: tt, TypeId: tt.Id, Image: tt.Name}
+	return core.Token{Type: tt, Image: tt.Name}
 }
 
 // linearATN builds an ATN with two basic states connected by a single atom

--- a/parser/error_recovery.go
+++ b/parser/error_recovery.go
@@ -77,7 +77,7 @@ func (DefaultErrorRecovery) Recover(parserState *ParserState) {
 				// EOF reached, give up and let the parser unwind.
 				return
 			}
-			if followSet.At(la.TypeId) {
+			if followSet.At(la.Type.Id) {
 				break
 			}
 			parserState.Index++
@@ -103,17 +103,17 @@ func (DefaultErrorRecovery) Sync(parserState *ParserState, decisionStateIdx int)
 	// This is the expected case: LA(1) is in the set of valid tokens.
 	// We can immediately return, the parser is valid and ready to continue.
 	// This is the hot path for error-free parsing, so it's important that this check is fast.
-	if tok.Type == core.EOF || validTokens.At(tok.TypeId) {
+	if tok.Type == core.EOF || validTokens.At(tok.Type.Id) {
 		return
 	}
 	followTokens := parserState.FollowSet()
-	if followTokens.At(tok.TypeId) {
+	if followTokens.At(tok.Type.Id) {
 		return
 	}
 	// Single-token deletion: if the *next* token is in the valid set, treat
 	// the current token as extraneous and skip it.
 	la2 := parserState.LA(2)
-	if la2 != nil && validTokens.At(la2.TypeId) {
+	if la2 != nil && validTokens.At(la2.Type.Id) {
 		parserState.ReportError(parserState.messages.ExtraneousInput(tok), tok)
 		parserState.Index++
 		return
@@ -126,7 +126,7 @@ func (DefaultErrorRecovery) Sync(parserState *ParserState, decisionStateIdx int)
 	for {
 		parserState.Index++
 		la := parserState.LA(1)
-		if la.Type == core.EOF || validTokens.At(la.TypeId) || followTokens.At(la.TypeId) {
+		if la.Type == core.EOF || validTokens.At(la.Type.Id) || followTokens.At(la.Type.Id) {
 			return
 		}
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -152,7 +152,9 @@ func (p *ParserState) Consume(tokenType *core.TokenType) *core.Token {
 		return nil
 	}
 	current := p.LA(1)
-	if !tokenType.Matches(current.Type) {
+	// Fast path for the common exact-type match; Matches is a closure call and
+	// only needed for token groups (real tokens never carry a group TypeId).
+	if current.Type.Id != tokenType.Id && !tokenType.Matches(current.Type) {
 		if current.Type == core.EOF {
 			p.AppendError(p.messages.UnexpectedEndOfInput(tokenType), current)
 			return nil
@@ -225,7 +227,7 @@ func (p *ParserState) Lookahead(value LL1Lookahead) (int, *PredictionFailure) {
 		return -1, &PredictionFailure{Token: p.LA(1)}
 	}
 	la := p.LA(1)
-	id := la.TypeId
+	id := la.Type.Id
 	if id < len(value.Lookup) {
 		// Note: generated lookup tables are 1-based to simplify code generation.
 		// That way, 0 (default value) can simply mean "no match"

--- a/token.go
+++ b/token.go
@@ -175,8 +175,6 @@ type Token struct {
 	Type *TokenType
 	// Image is the exact text matched for this token.
 	Image string
-	// TypeId caches Type.Id for parser hot paths.
-	TypeId int
 	// Range is the byte-offset range of the token in the input string.
 	Range TextRange
 	// Element points to the AST node this token was assigned to during parsing.
@@ -188,11 +186,10 @@ type Token struct {
 // NewToken creates a token with image text and half-open source coordinates.
 func NewToken(tokenType *TokenType, image string, startOffset, endOffset int) Token {
 	return Token{
-		Type:   tokenType,
-		Image:  image,
-		Range:  NewTextRange(startOffset, endOffset),
-		TypeId: tokenType.Id,
-		Kind:   0,
+		Type:  tokenType,
+		Image: image,
+		Range: NewTextRange(startOffset, endOffset),
+		Kind:  0,
 	}
 }
 


### PR DESCRIPTION
The `Token.TypeId` field is an 8-byte field that just allows us to skip a memory lookup. This change removes the field in favor of `Token.Type.Id`, which drops `Token` memory allocation from 64-bytes to 56-bytes (1/8th). Does not reduce parsing performance in any measurable way.