### PR TITLE
Reduce parser memory allocations

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -82,7 +82,12 @@ type AstNodeBase struct {
 	containerField unique.Handle[string]
 	containerIndex int
 	tokens         []*Token
-	rng            TextRange
+	// tokenBuf is a small preallocated buffer to avoid heap allocations for nodes with few tokens.
+	// It is used as the backing array for the tokens slice when the node has 4 or fewer tokens.
+	// Massively reduces the amount of allocations required for most languages, which increases
+	// the parsing speed by roughly 25% in benchmarks.
+	tokenBuf [4]*Token
+	rng      TextRange
 }
 
 // Document returns the owning document of the node.
@@ -182,13 +187,9 @@ func (node *AstNodeBase) TextRange() TextRange {
 func (node *AstNodeBase) AppendToken(token *Token) {
 	if node != nil && token != nil {
 		if node.tokens == nil {
-			// Most nodes end up with a handful of tokens; start with capacity 4
-			// to avoid the cap 1->2->4 growth reallocations of a bare append.
-			node.tokens = make([]*Token, 1, 4)
-			node.tokens[0] = token
-		} else {
-			node.tokens = append(node.tokens, token)
+			node.tokens = node.tokenBuf[:0]
 		}
+		node.tokens = append(node.tokens, token)
 	}
 }
 

--- a/examples/arithmetics/parser_gen.go
+++ b/examples/arithmetics/parser_gen.go
@@ -65,8 +65,8 @@ func (p *Parser) ParseModule() Module {
 }
 
 func (p *Parser) ParseStatement() Statement {
-	current := NewStatement()
-	current.SetTextRangeStart(p.state.LA(1).Range.Start)
+	startPos := p.state.LA(1).Range.Start
+	var current Statement
 	{
 		switch prediction, failure := p.lookahead.StatementAlternatives(p.state); prediction {
 		case 0:
@@ -74,7 +74,6 @@ func (p *Parser) ParseStatement() Statement {
 				p.state.EnterRule(Statement__Basic_1)
 				result := p.ParseDefinition()
 				p.state.ExitRule()
-				core.MergeTokens(result, current.Tokens())
 				current = result
 			}
 		case 1:
@@ -82,11 +81,14 @@ func (p *Parser) ParseStatement() Statement {
 				p.state.EnterRule(Statement__Basic_3)
 				result := p.ParseEvaluation()
 				p.state.ExitRule()
-				core.MergeTokens(result, current.Tokens())
 				current = result
 			}
 		default:
 			p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
+		}
+		if current == nil {
+			current = NewStatement()
+			current.SetTextRangeStart(startPos)
 		}
 	}
 	current.SetTextRangeEnd(p.state.LA(0).Range.End)
@@ -202,14 +204,12 @@ func (p *Parser) ParseEvaluation() Evaluation {
 }
 
 func (p *Parser) ParseExpression() Expression {
-	current := NewExpression()
-	current.SetTextRangeStart(p.state.LA(1).Range.Start)
+	var current Expression
 	{
 		{
 			p.state.EnterRule(Expression__Basic_1)
 			result := p.ParseAddition()
 			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
 			current = result
 		}
 	}
@@ -218,14 +218,12 @@ func (p *Parser) ParseExpression() Expression {
 }
 
 func (p *Parser) ParseAddition() Expression {
-	current := NewExpression()
-	current.SetTextRangeStart(p.state.LA(1).Range.Start)
+	var current Expression
 	{
 		{
 			p.state.EnterRule(Addition__LoopEntry)
 			result := p.ParseMultiplication()
 			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
 			current = result
 		}
 		p.state.Sync(Addition__LoopEntry)
@@ -270,14 +268,12 @@ func (p *Parser) ParseAddition() Expression {
 }
 
 func (p *Parser) ParseMultiplication() Expression {
-	current := NewExpression()
-	current.SetTextRangeStart(p.state.LA(1).Range.Start)
+	var current Expression
 	{
 		{
 			p.state.EnterRule(Multiplication__LoopEntry)
 			result := p.ParseExponentiation()
 			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
 			current = result
 		}
 		p.state.Sync(Multiplication__LoopEntry)
@@ -322,14 +318,12 @@ func (p *Parser) ParseMultiplication() Expression {
 }
 
 func (p *Parser) ParseExponentiation() Expression {
-	current := NewExpression()
-	current.SetTextRangeStart(p.state.LA(1).Range.Start)
+	var current Expression
 	{
 		{
 			p.state.EnterRule(Exponentiation__LoopEntry)
 			result := p.ParseModulo()
 			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
 			current = result
 		}
 		p.state.Sync(Exponentiation__LoopEntry)
@@ -365,14 +359,12 @@ func (p *Parser) ParseExponentiation() Expression {
 }
 
 func (p *Parser) ParseModulo() Expression {
-	current := NewExpression()
-	current.SetTextRangeStart(p.state.LA(1).Range.Start)
+	var current Expression
 	{
 		{
 			p.state.EnterRule(Modulo__LoopEntry)
 			result := p.ParsePrimaryExpression()
 			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
 			current = result
 		}
 		p.state.Sync(Modulo__LoopEntry)
@@ -408,12 +400,14 @@ func (p *Parser) ParseModulo() Expression {
 }
 
 func (p *Parser) ParsePrimaryExpression() Expression {
-	current := NewExpression()
-	current.SetTextRangeStart(p.state.LA(1).Range.Start)
+	startPos := p.state.LA(1).Range.Start
+	var current Expression
 	{
 		switch prediction, failure := p.lookahead.PrimaryExpressionAlternatives(p.state); prediction {
 		case 0:
 			{
+				current = NewExpression()
+				current.SetTextRangeStart(startPos)
 				token := p.state.Consume(Keyword_LeftParen)
 				core.AssignToken(current, token, PrimaryExpression_LeftParen_0)
 			}
@@ -431,8 +425,7 @@ func (p *Parser) ParsePrimaryExpression() Expression {
 		case 1:
 			{
 				result := NewNumberLiteral()
-				result.SetTextRange(current.TextRange())
-				core.AssignTokens(result, current.Tokens())
+				result.SetTextRangeStart(startPos)
 				current = result
 			}
 			current := current.(NumberLiteral)
@@ -446,8 +439,7 @@ func (p *Parser) ParsePrimaryExpression() Expression {
 		case 2:
 			{
 				result := NewFunctionCall()
-				result.SetTextRange(current.TextRange())
-				core.AssignTokens(result, current.Tokens())
+				result.SetTextRangeStart(startPos)
 				current = result
 			}
 			current := current.(FunctionCall)
@@ -495,6 +487,10 @@ func (p *Parser) ParsePrimaryExpression() Expression {
 			}
 		default:
 			p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
+		}
+		if current == nil {
+			current = NewExpression()
+			current.SetTextRangeStart(startPos)
 		}
 	}
 	current.SetTextRangeEnd(p.state.LA(0).Range.End)

--- a/internal/generator/parser_generator.go
+++ b/internal/generator/parser_generator.go
@@ -107,6 +107,132 @@ type ParserGeneratorContext struct {
 	// counter for unique Go loop labels (loop0, loop1, ...)
 	// Only used when the generator can combine an Alternatives node with its loop
 	loopLabelSeq int
+	// lazyCurrent is active while generating a rule that allocates its `current`
+	// node on demand: at least one path replaces `current` before touching it,
+	// so the eager placeholder allocation would be pure garbage on that path.
+	// Rules without such a path keep the eager allocation and identical output.
+	lazyCurrent bool
+	// currentNil is true while `current` is statically known to be nil on the
+	// emission path of a lazyCurrent rule.
+	currentNil bool
+	// currentType is the rule return type used to materialize a lazy `current`.
+	currentType string
+}
+
+// ensureCurrent materializes a deferred `current` node right before emitted
+// code that reads or mutates it. No-op unless `current` is known to be nil.
+func (c *ParserGeneratorContext) ensureCurrent(node codegen.Node) {
+	if !c.lazyCurrent || !c.currentNil || c.completion {
+		return
+	}
+	node.AppendLine("current = New", c.currentType, "()")
+	node.AppendLine("current.SetTextRangeStart(startPos)")
+	c.currentNil = false
+}
+
+// materializeCurrentGuard emits a nil-guarded materialization for join points
+// where only some incoming paths allocated `current` (e.g. after a lazy
+// alternatives switch, whose no-viable-alternative arm allocates nothing).
+func (c *ParserGeneratorContext) materializeCurrentGuard(node codegen.Node) {
+	if !c.lazyCurrent || !c.currentNil || c.completion {
+		return
+	}
+	node.AppendLine("if current == nil {")
+	node.Indent(func(n codegen.Node) {
+		n.AppendLine("current = New", c.currentType, "()")
+		n.AppendLine("current.SetTextRangeStart(startPos)")
+	})
+	node.AppendLine("}")
+	c.currentNil = false
+}
+
+// currentTouch classifies how a grammar element first interacts with the
+// enclosing rule's `current` node in emission order.
+type currentTouch int
+
+const (
+	// touchNone: the element never touches current.
+	touchNone currentTouch = iota
+	// touchUse: the first touch reads or mutates current in place.
+	touchUse
+	// touchReplace: on at least one path the first touch replaces current
+	// wholesale (unassigned rule call or property-less action).
+	touchReplace
+)
+
+// ruleCallReplacesCurrent reports whether an unassigned call to the target rule
+// replaces `current` wholesale; token rule calls append to current instead.
+func ruleCallReplacesCurrent(ruleCall grammar.RuleCall) bool {
+	switch ruleCall.Rule().Ref(ctx.Background()).(type) {
+	case grammar.ParserRule, grammar.CompositeRule:
+		return true
+	}
+	return false
+}
+
+// firstCurrentTouch computes the currentTouch classification of element. A rule
+// qualifies for lazy `current` allocation iff its body classifies as
+// touchReplace. Optional/repeated elements always classify as touchUse: their
+// content may run zero or several times, so `current` must exist beforehand.
+func firstCurrentTouch(element grammar.Element) currentTouch {
+	if element.Cardinality() != CardinalityOne {
+		return touchUse
+	}
+	switch e := element.(type) {
+	case grammar.Action:
+		if e.Property() != nil {
+			return touchUse
+		}
+		return touchReplace
+	case grammar.RuleCall:
+		if ruleCallReplacesCurrent(e) {
+			return touchReplace
+		}
+		return touchUse
+	case grammar.Group:
+		for _, el := range e.Elements() {
+			if touch := firstCurrentTouch(el); touch != touchNone {
+				return touch
+			}
+		}
+		return touchNone
+	case grammar.Alternatives:
+		result := touchNone
+		for _, alt := range e.Alts() {
+			switch firstCurrentTouch(alt) {
+			case touchReplace:
+				return touchReplace
+			case touchUse:
+				result = touchUse
+			}
+		}
+		return result
+	default:
+		return touchUse
+	}
+}
+
+// delegatesWithoutStart reports whether the lazy emission of element replaces
+// `current` via a plain unassigned rule-call delegation on every path, in which
+// case the rule-entry start position is never needed (the callee records the
+// same start itself) and no `startPos` variable should be declared.
+func delegatesWithoutStart(element grammar.Element) bool {
+	if element.Cardinality() != CardinalityOne {
+		return false
+	}
+	switch e := element.(type) {
+	case grammar.RuleCall:
+		return ruleCallReplacesCurrent(e)
+	case grammar.Group:
+		for _, el := range e.Elements() {
+			if firstCurrentTouch(el) == touchNone {
+				continue
+			}
+			return delegatesWithoutStart(el)
+		}
+		return false
+	}
+	return false
 }
 
 type LookaheadValue struct {
@@ -865,12 +991,27 @@ func generateParseFunction(node codegen.Node, context *ParserGeneratorContext, r
 	} else {
 		node.AppendLine("func (p *", receiverType, ") Parse", rule.Name(), "() ", returnType.Name(), " {")
 		node.Indent(func(n codegen.Node) {
-			n.AppendLine("current := New", returnType.Name(), "()")
-			n.AppendLine("current.SetTextRangeStart(p.state.LA(1).Range.Start)")
+			lazy := firstCurrentTouch(rule.Body()) == touchReplace
+			context.lazyCurrent = lazy
+			context.currentNil = lazy
+			context.currentType = returnType.Name()
+			if lazy {
+				// At least one path replaces `current` before touching it, so
+				// the placeholder node is only allocated where actually needed.
+				if !delegatesWithoutStart(rule.Body()) {
+					n.AppendLine("startPos := p.state.LA(1).Range.Start")
+				}
+				n.AppendLine("var current ", returnType.Name())
+			} else {
+				n.AppendLine("current := New", returnType.Name(), "()")
+				n.AppendLine("current.SetTextRangeStart(p.state.LA(1).Range.Start)")
+			}
 			// Generate new lexical scope for actions that immediately trigger on rule start
 			n.AppendLine("{")
 			generateAbstractElementParser(n, context, rule.Body())
 			n.AppendLine("}")
+			context.materializeCurrentGuard(n)
+			context.lazyCurrent = false
 			n.AppendLine("current.SetTextRangeEnd(p.state.LA(0).Range.End)")
 			n.AppendLine("return current")
 		})
@@ -910,6 +1051,11 @@ func (c *ParserGeneratorContext) receiverType() string {
 }
 
 func generateAbstractElementParser(node codegen.Node, context *ParserGeneratorContext, element grammar.Element) {
+	if context.currentNil && element.Cardinality() != CardinalityOne {
+		// Optional/repeated content may run zero or several times, so a lazy
+		// `current` must be materialized before entering it.
+		context.ensureCurrent(node)
+	}
 	switch e := element.(type) {
 	case grammar.Alternatives:
 		generateAlternativesParser(node, context, e)
@@ -922,6 +1068,21 @@ func generateAbstractElementParser(node codegen.Node, context *ParserGeneratorCo
 			// emits nothing for them.
 			return
 		}
+		if context.currentNil && e.Property() == nil {
+			// `current` is still unallocated: the action node takes its place
+			// directly, with no tokens or range to inherit.
+			node.AppendLine("{")
+			node.Indent(func(n codegen.Node) {
+				n.AppendLine("result := New", e.Type().Text(), "()")
+				n.AppendLine("result.SetTextRangeStart(startPos)")
+				n.AppendLine("current = result")
+			})
+			node.AppendLine("}")
+			node.AppendLine("current := current.(", e.Type().Text(), ")")
+			context.currentNil = false
+			return
+		}
+		context.ensureCurrent(node)
 		node.AppendLine("{")
 		node.Indent(func(n codegen.Node) {
 			n.AppendLine("result := New", e.Type().Text(), "()")
@@ -947,26 +1108,38 @@ func generateAbstractElementParser(node codegen.Node, context *ParserGeneratorCo
 	case grammar.Keyword:
 		node.AppendLine("{")
 		node.Indent(func(indent codegen.Node) {
+			context.ensureCurrent(indent)
 			generateKeywordParser(indent, context, e)
 		})
 		node.AppendLine("}")
 	case grammar.RuleCall:
 		node.AppendLine("{")
 		node.Indent(func(indent codegen.Node) {
+			if !ruleCallReplacesCurrent(e) {
+				// Token rule calls append to current instead of replacing it.
+				context.ensureCurrent(indent)
+			}
 			resultName := generateRuleCallParser(indent, context, e)
 			if context.completion {
 				return
 			}
 			if resultName == "result" && !context.inCompositeRule {
-				// Unassigned rule call result — merge into current node
-				indent.AppendLine("core.MergeTokens(result, current.Tokens())")
-				indent.AppendLine("current = result")
+				if context.currentNil {
+					// `current` is still unallocated and carries no tokens.
+					indent.AppendLine("current = result")
+					context.currentNil = false
+				} else {
+					// Unassigned rule call result — merge into current node
+					indent.AppendLine("core.MergeTokens(result, current.Tokens())")
+					indent.AppendLine("current = result")
+				}
 			}
 		})
 		node.AppendLine("}")
 	case grammar.Assignment:
 		node.AppendLine("{")
 		node.Indent(func(indent codegen.Node) {
+			context.ensureCurrent(indent)
 			// Decision states in the ATN are keyed by the assignable value
 			// (RuleCall, Keyword, etc.), not by the Assignment wrapper itself.
 			syncCall := buildSyncCall(context, e.Value())
@@ -1130,11 +1303,18 @@ func generateAlternativesParser(node codegen.Node, context *ParserGeneratorConte
 		generateCombinedAlternativesParser(node, context, alts, syncCall)
 		return
 	}
+	// When `current` is still unallocated, each alternative starts from the
+	// unallocated state independently; the guard after the switch covers the
+	// branches (including the no-viable default) that did not allocate.
+	lazyBranches := context.currentNil
 	generateCardinality(node, func(n codegen.Node) {
 		n.AppendLine(orSwitchHead(context, alts))
 		for i, alt := range alts.Alts() {
 			n.AppendLine("case ", strconv.Itoa(i), ":")
 			n.Indent(func(in codegen.Node) {
+				if lazyBranches {
+					context.currentNil = true
+				}
 				generateAbstractElementParser(in, context, alt)
 			})
 		}
@@ -1143,6 +1323,10 @@ func generateAlternativesParser(node codegen.Node, context *ParserGeneratorConte
 			in.AppendLine("p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)")
 		})
 		n.AppendLine("}")
+		if lazyBranches {
+			context.currentNil = true
+			context.materializeCurrentGuard(n)
+		}
 	}, func(n codegen.Node) {
 		n.Append(guardCall(context, alts))
 	}, syncCall, alts.Cardinality())

--- a/internal/generator/parser_generator.go
+++ b/internal/generator/parser_generator.go
@@ -122,27 +122,33 @@ type ParserGeneratorContext struct {
 // ensureCurrent materializes a deferred `current` node right before emitted
 // code that reads or mutates it. No-op unless `current` is known to be nil.
 func (c *ParserGeneratorContext) ensureCurrent(node codegen.Node) {
-	if !c.lazyCurrent || !c.currentNil || c.completion {
-		return
-	}
-	node.AppendLine("current = New", c.currentType, "()")
-	node.AppendLine("current.SetTextRangeStart(startPos)")
-	c.currentNil = false
+	c.ensureCurrentGuard(node, false)
 }
 
 // materializeCurrentGuard emits a nil-guarded materialization for join points
 // where only some incoming paths allocated `current` (e.g. after a lazy
 // alternatives switch, whose no-viable-alternative arm allocates nothing).
 func (c *ParserGeneratorContext) materializeCurrentGuard(node codegen.Node) {
+	c.ensureCurrentGuard(node, true)
+}
+
+func (c *ParserGeneratorContext) ensureCurrentGuard(node codegen.Node, guard bool) {
 	if !c.lazyCurrent || !c.currentNil || c.completion {
 		return
 	}
-	node.AppendLine("if current == nil {")
-	node.Indent(func(n codegen.Node) {
+	write := func(n codegen.Node) {
 		n.AppendLine("current = New", c.currentType, "()")
 		n.AppendLine("current.SetTextRangeStart(startPos)")
-	})
-	node.AppendLine("}")
+	}
+	if guard {
+		node.AppendLine("if current == nil {")
+		node.Indent(func(n codegen.Node) {
+			write(n)
+		})
+		node.AppendLine("}")
+	} else {
+		write(node)
+	}
 	c.currentNil = false
 }
 

--- a/internal/grammar/parser_gen.go
+++ b/internal/grammar/parser_gen.go
@@ -205,8 +205,8 @@ func (p *Parser) ParseField() Field {
 }
 
 func (p *Parser) ParseFieldType() FieldType {
-	current := NewFieldType()
-	current.SetTextRangeStart(p.state.LA(1).Range.Start)
+	startPos := p.state.LA(1).Range.Start
+	var current FieldType
 	{
 		switch prediction, failure := p.lookahead.FieldTypeAlternatives(p.state); prediction {
 		case 0:
@@ -214,7 +214,6 @@ func (p *Parser) ParseFieldType() FieldType {
 				p.state.EnterRule(FieldType__Basic_1)
 				result := p.ParseSimpleType()
 				p.state.ExitRule()
-				core.MergeTokens(result, current.Tokens())
 				current = result
 			}
 		case 1:
@@ -222,7 +221,6 @@ func (p *Parser) ParseFieldType() FieldType {
 				p.state.EnterRule(FieldType__Basic_3)
 				result := p.ParseReferenceType()
 				p.state.ExitRule()
-				core.MergeTokens(result, current.Tokens())
 				current = result
 			}
 		case 2:
@@ -230,7 +228,6 @@ func (p *Parser) ParseFieldType() FieldType {
 				p.state.EnterRule(FieldType__Basic_5)
 				result := p.ParseArrayType()
 				p.state.ExitRule()
-				core.MergeTokens(result, current.Tokens())
 				current = result
 			}
 		case 3:
@@ -238,11 +235,14 @@ func (p *Parser) ParseFieldType() FieldType {
 				p.state.EnterRule(FieldType__Basic_7)
 				result := p.ParsePrimitiveType()
 				p.state.ExitRule()
-				core.MergeTokens(result, current.Tokens())
 				current = result
 			}
 		default:
 			p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
+		}
+		if current == nil {
+			current = NewFieldType()
+			current.SetTextRangeStart(startPos)
 		}
 	}
 	current.SetTextRangeEnd(p.state.LA(0).Range.End)
@@ -526,14 +526,12 @@ func (p *Parser) ParseTokenGroup() TokenGroup {
 }
 
 func (p *Parser) ParseAlternatives() Element {
-	current := NewElement()
-	current.SetTextRangeStart(p.state.LA(1).Range.Start)
+	var current Element
 	{
 		{
 			p.state.EnterRule(Alternatives__Basic_3)
 			result := p.ParseGroup()
 			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
 			current = result
 		}
 		p.state.Sync(Alternatives__Basic_3)
@@ -568,14 +566,12 @@ func (p *Parser) ParseAlternatives() Element {
 }
 
 func (p *Parser) ParseGroup() Element {
-	current := NewElement()
-	current.SetTextRangeStart(p.state.LA(1).Range.Start)
+	var current Element
 	{
 		{
 			p.state.EnterRule(Group__Basic_3)
 			result := p.ParseElement()
 			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
 			current = result
 		}
 		p.state.Sync(Group__Basic_3)
@@ -606,8 +602,8 @@ func (p *Parser) ParseGroup() Element {
 }
 
 func (p *Parser) ParseElement() Element {
-	current := NewElement()
-	current.SetTextRangeStart(p.state.LA(1).Range.Start)
+	startPos := p.state.LA(1).Range.Start
+	var current Element
 	{
 		switch prediction, failure := p.lookahead.ElementAlternatives(p.state); prediction {
 		case 0:
@@ -615,7 +611,6 @@ func (p *Parser) ParseElement() Element {
 				p.state.EnterRule(Element__Basic_1)
 				result := p.ParseKeyword()
 				p.state.ExitRule()
-				core.MergeTokens(result, current.Tokens())
 				current = result
 			}
 		case 1:
@@ -623,7 +618,6 @@ func (p *Parser) ParseElement() Element {
 				p.state.EnterRule(Element__Basic_3)
 				result := p.ParseAssignment()
 				p.state.ExitRule()
-				core.MergeTokens(result, current.Tokens())
 				current = result
 			}
 		case 2:
@@ -631,7 +625,6 @@ func (p *Parser) ParseElement() Element {
 				p.state.EnterRule(Element__Basic_5)
 				result := p.ParseRuleCall()
 				p.state.ExitRule()
-				core.MergeTokens(result, current.Tokens())
 				current = result
 			}
 		case 3:
@@ -639,11 +632,12 @@ func (p *Parser) ParseElement() Element {
 				p.state.EnterRule(Element__Basic_7)
 				result := p.ParseAction()
 				p.state.ExitRule()
-				core.MergeTokens(result, current.Tokens())
 				current = result
 			}
 		case 4:
 			{
+				current = NewElement()
+				current.SetTextRangeStart(startPos)
 				token := p.state.Consume(Keyword_LeftParen)
 				core.AssignToken(current, token, Element_LeftParen)
 			}
@@ -660,6 +654,10 @@ func (p *Parser) ParseElement() Element {
 			}
 		default:
 			p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
+		}
+		if current == nil {
+			current = NewElement()
+			current.SetTextRangeStart(startPos)
 		}
 		{
 			p.state.Sync(Element__Basic_15)
@@ -752,8 +750,8 @@ func (p *Parser) ParseAssignment() Assignment {
 }
 
 func (p *Parser) ParseAssignable() Assignable {
-	current := NewAssignable()
-	current.SetTextRangeStart(p.state.LA(1).Range.Start)
+	startPos := p.state.LA(1).Range.Start
+	var current Assignable
 	{
 		switch prediction, failure := p.lookahead.AssignableAlternatives(p.state); prediction {
 		case 0:
@@ -761,7 +759,6 @@ func (p *Parser) ParseAssignable() Assignable {
 				p.state.EnterRule(Assignable__Basic_1)
 				result := p.ParseKeyword()
 				p.state.ExitRule()
-				core.MergeTokens(result, current.Tokens())
 				current = result
 			}
 		case 1:
@@ -769,7 +766,6 @@ func (p *Parser) ParseAssignable() Assignable {
 				p.state.EnterRule(Assignable__Basic_3)
 				result := p.ParseRuleCall()
 				p.state.ExitRule()
-				core.MergeTokens(result, current.Tokens())
 				current = result
 			}
 		case 2:
@@ -777,11 +773,12 @@ func (p *Parser) ParseAssignable() Assignable {
 				p.state.EnterRule(Assignable__Basic_5)
 				result := p.ParseCrossRef()
 				p.state.ExitRule()
-				core.MergeTokens(result, current.Tokens())
 				current = result
 			}
 		case 3:
 			{
+				current = NewAssignable()
+				current.SetTextRangeStart(startPos)
 				token := p.state.Consume(Keyword_LeftParen)
 				core.AssignToken(current, token, Assignable_LeftParen)
 			}
@@ -799,14 +796,18 @@ func (p *Parser) ParseAssignable() Assignable {
 		default:
 			p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
 		}
+		if current == nil {
+			current = NewAssignable()
+			current.SetTextRangeStart(startPos)
+		}
 	}
 	current.SetTextRangeEnd(p.state.LA(0).Range.End)
 	return current
 }
 
 func (p *Parser) ParseAssignableWithoutAlts() Assignable {
-	current := NewAssignable()
-	current.SetTextRangeStart(p.state.LA(1).Range.Start)
+	startPos := p.state.LA(1).Range.Start
+	var current Assignable
 	{
 		switch prediction, failure := p.lookahead.AssignableWithoutAltsAlternatives(p.state); prediction {
 		case 0:
@@ -814,7 +815,6 @@ func (p *Parser) ParseAssignableWithoutAlts() Assignable {
 				p.state.EnterRule(AssignableWithoutAlts__Basic_1)
 				result := p.ParseKeyword()
 				p.state.ExitRule()
-				core.MergeTokens(result, current.Tokens())
 				current = result
 			}
 		case 1:
@@ -822,7 +822,6 @@ func (p *Parser) ParseAssignableWithoutAlts() Assignable {
 				p.state.EnterRule(AssignableWithoutAlts__Basic_3)
 				result := p.ParseRuleCall()
 				p.state.ExitRule()
-				core.MergeTokens(result, current.Tokens())
 				current = result
 			}
 		case 2:
@@ -830,11 +829,14 @@ func (p *Parser) ParseAssignableWithoutAlts() Assignable {
 				p.state.EnterRule(AssignableWithoutAlts__Basic_5)
 				result := p.ParseCrossRef()
 				p.state.ExitRule()
-				core.MergeTokens(result, current.Tokens())
 				current = result
 			}
 		default:
 			p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
+		}
+		if current == nil {
+			current = NewAssignable()
+			current.SetTextRangeStart(startPos)
 		}
 	}
 	current.SetTextRangeEnd(p.state.LA(0).Range.End)
@@ -842,14 +844,12 @@ func (p *Parser) ParseAssignableWithoutAlts() Assignable {
 }
 
 func (p *Parser) ParseAssignableAlternatives() Assignable {
-	current := NewAssignable()
-	current.SetTextRangeStart(p.state.LA(1).Range.Start)
+	var current Assignable
 	{
 		{
 			p.state.EnterRule(AssignableAlternatives__Basic_3)
 			result := p.ParseAssignableWithoutAlts()
 			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
 			current = result
 		}
 		p.state.Sync(AssignableAlternatives__Basic_3)
@@ -1035,14 +1035,12 @@ func (p *Parser) ParseCompositeRule() CompositeRule {
 }
 
 func (p *Parser) ParseCompositeAlternatives() Element {
-	current := NewElement()
-	current.SetTextRangeStart(p.state.LA(1).Range.Start)
+	var current Element
 	{
 		{
 			p.state.EnterRule(CompositeAlternatives__Basic_3)
 			result := p.ParseCompositeGroup()
 			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
 			current = result
 		}
 		p.state.Sync(CompositeAlternatives__Basic_3)
@@ -1077,14 +1075,12 @@ func (p *Parser) ParseCompositeAlternatives() Element {
 }
 
 func (p *Parser) ParseCompositeGroup() Element {
-	current := NewElement()
-	current.SetTextRangeStart(p.state.LA(1).Range.Start)
+	var current Element
 	{
 		{
 			p.state.EnterRule(CompositeGroup__Basic_3)
 			result := p.ParseCompositeElement()
 			p.state.ExitRule()
-			core.MergeTokens(result, current.Tokens())
 			current = result
 		}
 		p.state.Sync(CompositeGroup__Basic_3)
@@ -1115,8 +1111,8 @@ func (p *Parser) ParseCompositeGroup() Element {
 }
 
 func (p *Parser) ParseCompositeElement() Element {
-	current := NewElement()
-	current.SetTextRangeStart(p.state.LA(1).Range.Start)
+	startPos := p.state.LA(1).Range.Start
+	var current Element
 	{
 		switch prediction, failure := p.lookahead.CompositeElementAlternatives(p.state); prediction {
 		case 0:
@@ -1124,7 +1120,6 @@ func (p *Parser) ParseCompositeElement() Element {
 				p.state.EnterRule(CompositeElement__Basic_1)
 				result := p.ParseKeyword()
 				p.state.ExitRule()
-				core.MergeTokens(result, current.Tokens())
 				current = result
 			}
 		case 1:
@@ -1132,11 +1127,12 @@ func (p *Parser) ParseCompositeElement() Element {
 				p.state.EnterRule(CompositeElement__Basic_3)
 				result := p.ParseRuleCall()
 				p.state.ExitRule()
-				core.MergeTokens(result, current.Tokens())
 				current = result
 			}
 		case 2:
 			{
+				current = NewElement()
+				current.SetTextRangeStart(startPos)
 				token := p.state.Consume(Keyword_LeftParen)
 				core.AssignToken(current, token, CompositeElement_LeftParen)
 			}
@@ -1153,6 +1149,10 @@ func (p *Parser) ParseCompositeElement() Element {
 			}
 		default:
 			p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
+		}
+		if current == nil {
+			current = NewElement()
+			current.SetTextRangeStart(startPos)
 		}
 		{
 			p.state.Sync(CompositeElement__Basic_11)

--- a/internal/languages/completion/parser_gen.go
+++ b/internal/languages/completion/parser_gen.go
@@ -702,13 +702,12 @@ func (p *Parser) ParseN() N {
 }
 
 func (p *Parser) ParseO() Obj {
-	current := NewObj()
-	current.SetTextRangeStart(p.state.LA(1).Range.Start)
+	startPos := p.state.LA(1).Range.Start
+	var current Obj
 	{
 		{
 			result := NewO()
-			result.SetTextRange(current.TextRange())
-			core.AssignTokens(result, current.Tokens())
+			result.SetTextRangeStart(startPos)
 			current = result
 		}
 		current := current.(O)

--- a/internal/languages/lookahead/parser_gen.go
+++ b/internal/languages/lookahead/parser_gen.go
@@ -50,8 +50,8 @@ func (p *Parser) ParseRoot() Root {
 }
 
 func (p *Parser) ParseObj() Obj {
-	current := NewObj()
-	current.SetTextRangeStart(p.state.LA(1).Range.Start)
+	startPos := p.state.LA(1).Range.Start
+	var current Obj
 	{
 		switch prediction, failure := p.lookahead.ObjAlternatives(p.state); prediction {
 		case 0:
@@ -59,7 +59,6 @@ func (p *Parser) ParseObj() Obj {
 				p.state.EnterRule(Obj__Basic_1)
 				result := p.ParseA()
 				p.state.ExitRule()
-				core.MergeTokens(result, current.Tokens())
 				current = result
 			}
 		case 1:
@@ -67,7 +66,6 @@ func (p *Parser) ParseObj() Obj {
 				p.state.EnterRule(Obj__Basic_3)
 				result := p.ParseB()
 				p.state.ExitRule()
-				core.MergeTokens(result, current.Tokens())
 				current = result
 			}
 		case 2:
@@ -75,7 +73,6 @@ func (p *Parser) ParseObj() Obj {
 				p.state.EnterRule(Obj__Basic_5)
 				result := p.ParseC()
 				p.state.ExitRule()
-				core.MergeTokens(result, current.Tokens())
 				current = result
 			}
 		case 3:
@@ -83,7 +80,6 @@ func (p *Parser) ParseObj() Obj {
 				p.state.EnterRule(Obj__Basic_7)
 				result := p.ParseD()
 				p.state.ExitRule()
-				core.MergeTokens(result, current.Tokens())
 				current = result
 			}
 		case 4:
@@ -91,7 +87,6 @@ func (p *Parser) ParseObj() Obj {
 				p.state.EnterRule(Obj__Basic_9)
 				result := p.ParseE()
 				p.state.ExitRule()
-				core.MergeTokens(result, current.Tokens())
 				current = result
 			}
 		case 5:
@@ -99,7 +94,6 @@ func (p *Parser) ParseObj() Obj {
 				p.state.EnterRule(Obj__Basic_11)
 				result := p.ParseF()
 				p.state.ExitRule()
-				core.MergeTokens(result, current.Tokens())
 				current = result
 			}
 		case 6:
@@ -107,7 +101,6 @@ func (p *Parser) ParseObj() Obj {
 				p.state.EnterRule(Obj__Basic_13)
 				result := p.ParseG()
 				p.state.ExitRule()
-				core.MergeTokens(result, current.Tokens())
 				current = result
 			}
 		case 7:
@@ -115,7 +108,6 @@ func (p *Parser) ParseObj() Obj {
 				p.state.EnterRule(Obj__Basic_15)
 				result := p.ParseH()
 				p.state.ExitRule()
-				core.MergeTokens(result, current.Tokens())
 				current = result
 			}
 		case 8:
@@ -123,11 +115,14 @@ func (p *Parser) ParseObj() Obj {
 				p.state.EnterRule(Obj__Basic_17)
 				result := p.ParseI()
 				p.state.ExitRule()
-				core.MergeTokens(result, current.Tokens())
 				current = result
 			}
 		default:
 			p.state.AppendError(p.state.Messages().NoViableAlternative(failure), failure.Token)
+		}
+		if current == nil {
+			current = NewObj()
+			current.SetTextRangeStart(startPos)
 		}
 	}
 	current.SetTextRangeEnd(p.state.LA(0).Range.End)

--- a/parser/error_recovery.go
+++ b/parser/error_recovery.go
@@ -67,17 +67,15 @@ func (DefaultErrorRecovery) Recover(parserState *ParserState) {
 	if parserState.ErrorMode != ErrorModeRecover {
 		return
 	}
-	// Compute the set of tokens that could legally come next at this point in the parse.
-	// Discards tokens until we find one that matches, or until we hit EOF.
-	followSet := parserState.FollowSet()
-	if !followSet.Empty() {
+	// Discards tokens until we find one that the current follow set, or until we hit EOF.
+	if !parserState.FollowSetEmpty() {
 		for {
 			la := parserState.LA(1)
 			if la.Type == core.EOF {
 				// EOF reached, give up and let the parser unwind.
 				return
 			}
-			if followSet.At(la.Type.Id) {
+			if parserState.FollowSetContains(la.Type.Id) {
 				break
 			}
 			parserState.Index++
@@ -106,8 +104,9 @@ func (DefaultErrorRecovery) Sync(parserState *ParserState, decisionStateIdx int)
 	if tok.Type == core.EOF || validTokens.At(tok.Type.Id) {
 		return
 	}
-	followTokens := parserState.FollowSet()
-	if followTokens.At(tok.Type.Id) {
+	// Next, if the current token is in the follow set of the parser stack,
+	// we can directly return and let the parser continue.
+	if parserState.FollowSetContains(tok.Type.Id) {
 		return
 	}
 	// Single-token deletion: if the *next* token is in the valid set, treat
@@ -126,7 +125,7 @@ func (DefaultErrorRecovery) Sync(parserState *ParserState, decisionStateIdx int)
 	for {
 		parserState.Index++
 		la := parserState.LA(1)
-		if la.Type == core.EOF || validTokens.At(la.Type.Id) || followTokens.At(la.Type.Id) {
+		if la.Type == core.EOF || validTokens.At(la.Type.Id) || parserState.FollowSetContains(la.Type.Id) {
 			return
 		}
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -6,7 +6,6 @@ package parser
 
 import (
 	core "typefox.dev/fastbelt"
-	"typefox.dev/fastbelt/util/collections"
 )
 
 // Parser defines the interface for parsing tokens (lexer output) into AST nodes.
@@ -261,13 +260,24 @@ func (p *ParserState) Sync(decisionStateIdx int) {
 	p.recovery.Sync(p, decisionStateIdx)
 }
 
-// FollowSet returns the union of NextTokensAt for every frame on the follow-state stack.
-func (p *ParserState) FollowSet() *collections.BitSet {
-	sets := make([]*collections.BitSet, len(p.followStates))
-	for i, idx := range p.followStates {
-		sets[i] = p.atn.NextTokensAt(idx)
+// FollowSetContains reports whether the token type id is in the follow set.
+func (p *ParserState) FollowSetContains(id int) bool {
+	for _, idx := range p.followStates {
+		if p.atn.NextTokensAt(idx).At(id) {
+			return true
+		}
 	}
-	return collections.MergeBitSets(sets)
+	return false
+}
+
+// FollowSetEmpty reports whether the follow set is empty.
+func (p *ParserState) FollowSetEmpty() bool {
+	for _, idx := range p.followStates {
+		if !p.atn.NextTokensAt(idx).Empty() {
+			return false
+		}
+	}
+	return true
 }
 
 // Base interface for all generated parser lookahead services.


### PR DESCRIPTION
Implements three parser optimizations that massively reduce the amount of memory allocations required for parsing:
1. Instead of constructing the `FollowSet`, we simply iterate over the parser stack via `FollowSetContains`. The additional loop is much cheaper than the allocations of the new `BitSet`.
2. Within each `AstNodeBase`, allocate 4 tokens worth of token buffer together with the AST node. This ensures that a small token buffer is always available. Allocation only needs to happen when there are more tokens, which is rare for most AST nodes.
3. Instead of allocating AST nodes always when the parser rule is called, this change adjusts the parser generator to only instantiate the AST node, if actually required. This is the largest change, but massively reduces the amount of allocations required for any kind of expression language.

In total, these three optimizations quadruple the parsing performance for the arithmetics language. With it, we go from ~7.3MB/s of parsing speed to ~32MB/s on my machine. Also has benefits on the statemachine language benchmark.