### PR TITLE
Disable benchmark comment alert

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -53,11 +53,10 @@ jobs:
         external-data-json-path: ${{ env.CACHE_DIR }}/benchmark-data.json
         # GitHub API token to make a PR/commit comment
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        # Enable alert commit comment
-        comment-on-alert: true
+        # Disable comment on alert, PR summary covers it
+        # Unfortunately, too inconsistent
+        comment-on-alert: false
         # Enable Job Summary for PRs
         summary-always: true
-        # Alert if any benchmark regression is more than 1.5x
-        alert-threshold: "150%"
         # Only save if we are on main branch
         save-data-file: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
As the title says. Unfortunately there are two issues with the alert comments:
1. Sometimes, the benchmark seems to run on a more capable machine. In this case, the benchmarks are much faster.
2. Higher MB/s is counted as a performance regression, even though that's not correct. We cannot configure the benchmark action not do this.

This PR keeps the PR summary, which is still useful to get a feel on the performance numbers.