### PR TITLE
Implement linking optimizations

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -248,10 +248,14 @@ func (node *AstNodeBase) Resolve(path FragmentPath) (AstNode, error) {
 //
 // Note that this function will traverse the entire subtree, without short-circuiting.
 func traverseContent(node AstNode, fn func(AstNode)) {
-	node.ForEachNode(func(child AstNode, containerField unique.Handle[string], index int) {
+	// The visitor closure is created once and recurses via itself; recursing
+	// through traverseContent would heap allocate a closure per visited node.
+	var visit func(child AstNode, containerField unique.Handle[string], index int)
+	visit = func(child AstNode, containerField unique.Handle[string], index int) {
 		fn(child)
-		traverseContent(child, fn)
-	})
+		child.ForEachNode(visit)
+	}
+	node.ForEachNode(visit)
 }
 
 // AllNodes creates an iterator over the given node and all its descendant nodes.
@@ -386,20 +390,32 @@ func AssignContainers(doc *Document) {
 }
 
 func doAssignContainers(doc *Document, root AstNode, references *[]UntypedReference) {
-	root.SetDocument(doc)
-	root.ForEachNode(func(child AstNode, containerField unique.Handle[string], index int) {
+	// Both closures are created once per document and track the current parent
+	// node mutably; capturing the parent per recursion level instead would heap
+	// allocate two closures per AST node.
+	current := root
+	var visitNode func(child AstNode, containerField unique.Handle[string], index int)
+	var visitReference func(ur UntypedReference, containerField unique.Handle[string], index int)
+	visitNode = func(child AstNode, containerField unique.Handle[string], index int) {
 		child.SetDocument(doc)
-		child.SetContainer(root, containerField, index)
-		doAssignContainers(doc, child, references)
-	})
-	root.ForEachReference(func(ur UntypedReference, containerField unique.Handle[string], index int) {
+		child.SetContainer(current, containerField, index)
+		prev := current
+		current = child
+		child.ForEachNode(visitNode)
+		child.ForEachReference(visitReference)
+		current = prev
+	}
+	visitReference = func(ur UntypedReference, containerField unique.Handle[string], index int) {
 		*references = append(*references, ur)
 		unit := ur.Unit()
 		if stringNode, ok := unit.(CompositeNode); ok {
 			stringNode.SetDocument(doc)
-			stringNode.SetContainer(root, containerField, index)
+			stringNode.SetContainer(current, containerField, index)
 		}
-	})
+	}
+	root.SetDocument(doc)
+	root.ForEachNode(visitNode)
+	root.ForEachReference(visitReference)
 }
 
 // NamedNode represents an [AstNode] whose name is accessible as a string in the Name field.

--- a/examples/arithmetics/linker_gen.go
+++ b/examples/arithmetics/linker_gen.go
@@ -58,22 +58,26 @@ type ArithmeticsReferencesConstructor interface {
 }
 
 type DefaultArithmeticsReferencesConstructor struct {
-	sc              *service.Container
-	referenceLinker func() ArithmeticsReferenceLinker
+	sc                       *service.Container
+	referenceLinker          func() ArithmeticsReferenceLinker
+	linkFunctionCallCallable func() core.ReferenceGetter[AbstractDefinition]
 }
 
 func NewDefaultArithmeticsReferencesConstructor(sc *service.Container) ArithmeticsReferencesConstructor {
+	referenceLinker := sync.OnceValue(func() ArithmeticsReferenceLinker {
+		return service.MustGet[ArithmeticsReferenceLinker](sc)
+	})
 	return &DefaultArithmeticsReferencesConstructor{
-		sc: sc,
-		referenceLinker: sync.OnceValue(func() ArithmeticsReferenceLinker {
-			return service.MustGet[ArithmeticsReferenceLinker](sc)
+		sc:              sc,
+		referenceLinker: referenceLinker,
+		linkFunctionCallCallable: sync.OnceValue(func() core.ReferenceGetter[AbstractDefinition] {
+			return referenceLinker().LinkFunctionCallCallable
 		}),
 	}
 }
 
 func (s *DefaultArithmeticsReferencesConstructor) FunctionCallCallable(owner core.AstNode, unit core.StringUnit) *core.Reference[AbstractDefinition] {
-	fn := s.referenceLinker().LinkFunctionCallCallable
-	return core.NewReference(owner, unit, fn)
+	return core.NewReference(owner, unit, s.linkFunctionCallCallable())
 }
 
 type ArithmeticsSymbolContainers struct{}

--- a/examples/arithmetics/linker_gen.go
+++ b/examples/arithmetics/linker_gen.go
@@ -114,3 +114,11 @@ func (sc *ArithmeticsSymbolContainer) ForType(t reflect.Type) core.SymbolSeq {
 	}
 	return core.EmptySymbolDescriptions
 }
+
+func (sc *ArithmeticsSymbolContainer) ForTypeSlice(t reflect.Type) ([]*core.SymbolDescription, bool) {
+	switch t {
+	case TypeFor_AbstractDefinition:
+		return sc.AbstractDefinitions, true
+	}
+	return nil, true
+}

--- a/examples/arithmetics/linker_gen.go
+++ b/examples/arithmetics/linker_gen.go
@@ -58,8 +58,6 @@ type ArithmeticsReferencesConstructor interface {
 }
 
 type DefaultArithmeticsReferencesConstructor struct {
-	sc                       *service.Container
-	referenceLinker          func() ArithmeticsReferenceLinker
 	linkFunctionCallCallable func() core.ReferenceGetter[AbstractDefinition]
 }
 
@@ -68,8 +66,6 @@ func NewDefaultArithmeticsReferencesConstructor(sc *service.Container) Arithmeti
 		return service.MustGet[ArithmeticsReferenceLinker](sc)
 	})
 	return &DefaultArithmeticsReferencesConstructor{
-		sc:              sc,
-		referenceLinker: referenceLinker,
 		linkFunctionCallCallable: sync.OnceValue(func() core.ReferenceGetter[AbstractDefinition] {
 			return referenceLinker().LinkFunctionCallCallable
 		}),

--- a/examples/statemachine/linker_gen.go
+++ b/examples/statemachine/linker_gen.go
@@ -181,3 +181,15 @@ func (sc *StatemachineModelSymbolContainer) ForType(t reflect.Type) core.SymbolS
 	}
 	return core.EmptySymbolDescriptions
 }
+
+func (sc *StatemachineModelSymbolContainer) ForTypeSlice(t reflect.Type) ([]*core.SymbolDescription, bool) {
+	switch t {
+	case TypeFor_State:
+		return sc.States, true
+	case TypeFor_Event:
+		return sc.Events, true
+	case TypeFor_Command:
+		return sc.Commands, true
+	}
+	return nil, true
+}

--- a/examples/statemachine/linker_gen.go
+++ b/examples/statemachine/linker_gen.go
@@ -94,37 +94,50 @@ type StatemachineModelReferencesConstructor interface {
 }
 
 type DefaultStatemachineModelReferencesConstructor struct {
-	sc              *service.Container
-	referenceLinker func() StatemachineModelReferenceLinker
+	sc                   *service.Container
+	referenceLinker      func() StatemachineModelReferenceLinker
+	linkStatemachineInit func() core.ReferenceGetter[State]
+	linkStateActions     func() core.ReferenceGetter[Command]
+	linkTransitionEvent  func() core.ReferenceGetter[Event]
+	linkTransitionState  func() core.ReferenceGetter[State]
 }
 
 func NewDefaultStatemachineModelReferencesConstructor(sc *service.Container) StatemachineModelReferencesConstructor {
+	referenceLinker := sync.OnceValue(func() StatemachineModelReferenceLinker {
+		return service.MustGet[StatemachineModelReferenceLinker](sc)
+	})
 	return &DefaultStatemachineModelReferencesConstructor{
-		sc: sc,
-		referenceLinker: sync.OnceValue(func() StatemachineModelReferenceLinker {
-			return service.MustGet[StatemachineModelReferenceLinker](sc)
+		sc:              sc,
+		referenceLinker: referenceLinker,
+		linkStatemachineInit: sync.OnceValue(func() core.ReferenceGetter[State] {
+			return referenceLinker().LinkStatemachineInit
+		}),
+		linkStateActions: sync.OnceValue(func() core.ReferenceGetter[Command] {
+			return referenceLinker().LinkStateActions
+		}),
+		linkTransitionEvent: sync.OnceValue(func() core.ReferenceGetter[Event] {
+			return referenceLinker().LinkTransitionEvent
+		}),
+		linkTransitionState: sync.OnceValue(func() core.ReferenceGetter[State] {
+			return referenceLinker().LinkTransitionState
 		}),
 	}
 }
 
 func (s *DefaultStatemachineModelReferencesConstructor) StatemachineInit(owner core.AstNode, unit core.StringUnit) *core.Reference[State] {
-	fn := s.referenceLinker().LinkStatemachineInit
-	return core.NewReference(owner, unit, fn)
+	return core.NewReference(owner, unit, s.linkStatemachineInit())
 }
 
 func (s *DefaultStatemachineModelReferencesConstructor) StateActions(owner core.AstNode, unit core.StringUnit) *core.Reference[Command] {
-	fn := s.referenceLinker().LinkStateActions
-	return core.NewReference(owner, unit, fn)
+	return core.NewReference(owner, unit, s.linkStateActions())
 }
 
 func (s *DefaultStatemachineModelReferencesConstructor) TransitionEvent(owner core.AstNode, unit core.StringUnit) *core.Reference[Event] {
-	fn := s.referenceLinker().LinkTransitionEvent
-	return core.NewReference(owner, unit, fn)
+	return core.NewReference(owner, unit, s.linkTransitionEvent())
 }
 
 func (s *DefaultStatemachineModelReferencesConstructor) TransitionState(owner core.AstNode, unit core.StringUnit) *core.Reference[State] {
-	fn := s.referenceLinker().LinkTransitionState
-	return core.NewReference(owner, unit, fn)
+	return core.NewReference(owner, unit, s.linkTransitionState())
 }
 
 type StatemachineModelSymbolContainers struct{}

--- a/examples/statemachine/linker_gen.go
+++ b/examples/statemachine/linker_gen.go
@@ -94,8 +94,6 @@ type StatemachineModelReferencesConstructor interface {
 }
 
 type DefaultStatemachineModelReferencesConstructor struct {
-	sc                   *service.Container
-	referenceLinker      func() StatemachineModelReferenceLinker
 	linkStatemachineInit func() core.ReferenceGetter[State]
 	linkStateActions     func() core.ReferenceGetter[Command]
 	linkTransitionEvent  func() core.ReferenceGetter[Event]
@@ -107,8 +105,6 @@ func NewDefaultStatemachineModelReferencesConstructor(sc *service.Container) Sta
 		return service.MustGet[StatemachineModelReferenceLinker](sc)
 	})
 	return &DefaultStatemachineModelReferencesConstructor{
-		sc:              sc,
-		referenceLinker: referenceLinker,
 		linkStatemachineInit: sync.OnceValue(func() core.ReferenceGetter[State] {
 			return referenceLinker().LinkStatemachineInit
 		}),

--- a/examples/statemachine/linking_benchmark_test.go
+++ b/examples/statemachine/linking_benchmark_test.go
@@ -1,0 +1,188 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+package statemachine
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"typefox.dev/fastbelt"
+	"typefox.dev/fastbelt/linking"
+	"typefox.dev/fastbelt/util/extiter"
+	"typefox.dev/fastbelt/util/service"
+	"typefox.dev/fastbelt/workspace"
+)
+
+// Microbenchmarks for the linking primitives. Each benchmark isolates one layer
+// of the reference resolution stack so regressions are attributable:
+//
+//	Reference.Resolve  = resolve machinery + scope construction + scope lookup
+//	scope construction = LocalScopeOfType chain + GlobalScopeOfType
+//	scope lookup       = SeqScope.ElementByName over the scope chain
+
+// setupLinkedStatemachine parses and fully builds a single generated document
+// and returns it together with a typed reference from a transition (a node
+// nested two levels below the root, so its scope chain has realistic depth).
+func setupLinkedStatemachine(b *testing.B) (*fastbelt.Document, *fastbelt.Reference[State]) {
+	b.Helper()
+	content, _ := generateStatemachineContent(0)
+	srv := CreateServices()
+	doc, err := fastbelt.NewDocumentFromString("file:///workspace/statemachine_0.statemachine", "statemachine", content)
+	if err != nil {
+		b.Fatal(err)
+	}
+	builder := service.MustGet[workspace.Builder](srv)
+	if err := builder.Build(b.Context(), []*fastbelt.Document{doc}, nil); err != nil {
+		b.Fatalf("build failed: %v", err)
+	}
+	for _, ref := range doc.References {
+		if typed, ok := ref.(*fastbelt.Reference[State]); ok && typed.Owner().Container() != nil {
+			return doc, typed
+		}
+	}
+	b.Fatal("no transition state reference found")
+	return nil, nil
+}
+
+// BenchmarkRefResolveMachinery measures the Reference[T] resolution machinery
+// alone: atomic fast path check, mutex, context.WithValue cycle guard, and the
+// desc.Node type assertion. The getter is a constant, so scope construction and
+// lookup are excluded.
+func BenchmarkRefResolveMachinery(b *testing.B) {
+	_, real := setupLinkedStatemachine(b)
+	desc := real.Description()
+	if desc == nil {
+		b.Fatal("reference did not resolve")
+	}
+	getter := func(ctx context.Context, r *fastbelt.Reference[State]) (*fastbelt.SymbolDescription, *fastbelt.ReferenceError) {
+		return desc, nil
+	}
+	ref := fastbelt.NewReference(real.Owner(), real.Unit(), getter)
+	ctx := b.Context()
+	b.ResetTimer()
+	for b.Loop() {
+		ref.Reset()
+		ref.Resolve(ctx)
+	}
+}
+
+// BenchmarkRefResolveFull measures one complete resolution of a real reference:
+// machinery + scope construction + lookup. The difference to
+// BenchmarkRefResolveMachinery is the cost of the scoping/linking layers.
+func BenchmarkRefResolveFull(b *testing.B) {
+	_, ref := setupLinkedStatemachine(b)
+	ctx := b.Context()
+	b.ResetTimer()
+	for b.Loop() {
+		ref.Reset()
+		ref.Resolve(ctx)
+	}
+}
+
+// BenchmarkRefResolvedFastPath measures repeated access to an already resolved
+// reference (the atomic.Bool fast path).
+func BenchmarkRefResolvedFastPath(b *testing.B) {
+	_, ref := setupLinkedStatemachine(b)
+	ctx := b.Context()
+	ref.Resolve(ctx)
+	b.ResetTimer()
+	for b.Loop() {
+		_ = ref.Ref(ctx)
+	}
+}
+
+// BenchmarkScopeConstruction measures building the scope chain for a reference
+// owner (LocalScopeOfType per ancestor + GlobalScopeOfType), without any lookup.
+func BenchmarkScopeConstruction(b *testing.B) {
+	_, ref := setupLinkedStatemachine(b)
+	owner := ref.Owner()
+	b.ResetTimer()
+	for b.Loop() {
+		_ = linking.DefaultScopeOfType[State](owner)
+	}
+}
+
+// BenchmarkScopeLookup measures ElementByName on a prebuilt scope chain,
+// i.e. the linear SeqScope scan without scope construction.
+func BenchmarkScopeLookup(b *testing.B) {
+	_, ref := setupLinkedStatemachine(b)
+	scope := linking.DefaultScopeOfType[State](ref.Owner())
+	name := ref.Text()
+	b.ResetTimer()
+	for b.Loop() {
+		if scope.ElementByName(name) == nil {
+			b.Fatal("lookup failed")
+		}
+	}
+}
+
+// BenchmarkScopeLookupMiss measures ElementByName for a name that does not
+// exist, forcing a full scan of the entire scope chain including the global
+// scope. This is the worst case hit by every unresolvable reference.
+func BenchmarkScopeLookupMiss(b *testing.B) {
+	_, ref := setupLinkedStatemachine(b)
+	scope := linking.DefaultScopeOfType[State](ref.Owner())
+	b.ResetTimer()
+	for b.Loop() {
+		if scope.ElementByName("does_not_exist") != nil {
+			b.Fatal("unexpected hit")
+		}
+	}
+}
+
+// BenchmarkSymbolContainerForType measures the generated SymbolContainer.ForType
+// dispatch plus draining the resulting sequence.
+func BenchmarkSymbolContainerForType(b *testing.B) {
+	doc, ref := setupLinkedStatemachine(b)
+	root := ref.Owner()
+	for root.Container() != nil {
+		root = root.Container()
+	}
+	container := doc.LocalSymbols.For(root)
+	stateType := reflect.TypeFor[State]()
+	b.ResetTimer()
+	for b.Loop() {
+		count := 0
+		for range container.ForType(stateType) {
+			count++
+		}
+		if count == 0 {
+			b.Fatal("no symbols")
+		}
+	}
+}
+
+// BenchmarkIsEmptyOverContainer measures extiter.IsEmpty on a container-backed
+// sequence — the check LocalScopeOfType performs at every ancestor level.
+func BenchmarkIsEmptyOverContainer(b *testing.B) {
+	doc, ref := setupLinkedStatemachine(b)
+	root := ref.Owner()
+	for root.Container() != nil {
+		root = root.Container()
+	}
+	container := doc.LocalSymbols.For(root)
+	stateType := reflect.TypeFor[State]()
+	b.ResetTimer()
+	for b.Loop() {
+		if extiter.IsEmpty(container.ForType(stateType)) {
+			b.Fatal("unexpectedly empty")
+		}
+	}
+}
+
+// BenchmarkSymbolDescriptionName measures SymbolDescription.Name.String(),
+// which SeqScope.ElementByName calls once per candidate symbol.
+func BenchmarkSymbolDescriptionName(b *testing.B) {
+	_, ref := setupLinkedStatemachine(b)
+	desc := ref.Description()
+	if desc == nil {
+		b.Fatal("reference did not resolve")
+	}
+	b.ResetTimer()
+	for b.Loop() {
+		_ = desc.Name.String()
+	}
+}

--- a/examples/statemachine/linking_benchmark_test.go
+++ b/examples/statemachine/linking_benchmark_test.go
@@ -183,6 +183,6 @@ func BenchmarkSymbolDescriptionName(b *testing.B) {
 	}
 	b.ResetTimer()
 	for b.Loop() {
-		_ = desc.Name.String()
+		_ = desc.Unit.String()
 	}
 }

--- a/examples/statemachine/linking_benchmark_test.go
+++ b/examples/statemachine/linking_benchmark_test.go
@@ -48,7 +48,7 @@ func setupLinkedStatemachine(b *testing.B) (*fastbelt.Document, *fastbelt.Refere
 }
 
 // BenchmarkRefResolveMachinery measures the Reference[T] resolution machinery
-// alone: atomic fast path check, mutex, context.WithValue cycle guard, and the
+// alone: atomic fast path check, mutex, resolution chain cycle guard, and the
 // desc.Node type assertion. The getter is a constant, so scope construction and
 // lookup are excluded.
 func BenchmarkRefResolveMachinery(b *testing.B) {

--- a/internal/generator/linker_generator.go
+++ b/internal/generator/linker_generator.go
@@ -330,22 +330,32 @@ func generateReferenceConstructor(context *LinkerGeneratorContext) codegen.Node 
 	node.AppendLine("type Default", context.grammar.Name(), "ReferencesConstructor struct {")
 	node.AppendLine("	sc              *service.Container")
 	node.AppendLine("	referenceLinker func() ", context.grammar.Name(), "ReferenceLinker")
+	for _, field := range context.fields {
+		node.AppendLine("	link", field.typeName, field.name, " func() core.ReferenceGetter[", field.target, "]")
+	}
 	node.AppendLine("}")
 	node.AppendLine()
 
 	node.AppendLine("func NewDefault", context.grammar.Name(), "ReferencesConstructor(sc *service.Container) ", context.grammar.Name(), "ReferencesConstructor {")
+	node.AppendLine("	referenceLinker := sync.OnceValue(func() ", context.grammar.Name(), "ReferenceLinker {")
+	node.AppendLine("		return service.MustGet[", context.grammar.Name(), "ReferenceLinker](sc)")
+	node.AppendLine("	})")
 	node.AppendLine("	return &Default", context.grammar.Name(), "ReferencesConstructor{")
-	node.AppendLine("		sc: sc,")
-	node.AppendLine("		referenceLinker: sync.OnceValue(func() ", context.grammar.Name(), "ReferenceLinker {")
-	node.AppendLine("			return service.MustGet[", context.grammar.Name(), "ReferenceLinker](sc)")
-	node.AppendLine("		}),")
+	node.AppendLine("		sc:              sc,")
+	node.AppendLine("		referenceLinker: referenceLinker,")
+	// Generate a dedicated link function for each reference
+	// This reduces the amount of closure allocations
+	for _, field := range context.fields {
+		node.AppendLine("		link", field.typeName, field.name, ": sync.OnceValue(func() core.ReferenceGetter[", field.target, "] {")
+		node.AppendLine("			return referenceLinker().Link", field.typeName, field.name)
+		node.AppendLine("		}),")
+	}
 	node.AppendLine("	}")
 	node.AppendLine("}")
 	node.AppendLine()
 	for _, field := range context.fields {
 		node.AppendLine("func (s *Default", context.grammar.Name(), "ReferencesConstructor) ", field.typeName, field.name, "(owner core.AstNode, unit core.StringUnit) *core.Reference[", field.target, "] {")
-		node.AppendLine("    fn := s.referenceLinker().Link", field.typeName, field.name)
-		node.AppendLine("    return core.NewReference(owner, unit, fn)")
+		node.AppendLine("    return core.NewReference(owner, unit, s.link", field.typeName, field.name, "())")
 		node.AppendLine("}").AppendLine()
 	}
 	return node

--- a/internal/generator/linker_generator.go
+++ b/internal/generator/linker_generator.go
@@ -291,6 +291,28 @@ func generateSymbolContainers(context *LinkerGeneratorContext) codegen.Node {
 	node.AppendLine("}")
 	node.AppendLine()
 
+	node.AppendLine("func (sc *", name, "SymbolContainer) ForTypeSlice(t reflect.Type) ([]*core.SymbolDescription, bool) {")
+	node.Indent(func(n codegen.Node) {
+		if len(sortedTargets) > 0 {
+			n.AppendLine("switch t {")
+			for _, target := range sortedTargets {
+				subtypes := subtypesInTargets(target, sortedTargets, context.ifaceParents)
+				n.AppendLine("case TypeFor_", target, ":")
+				if len(subtypes) == 1 {
+					// No descendants in target set, the type maps to exactly one slice.
+					n.AppendLine("    return sc.", target, "s, true")
+				} else {
+					// Symbols span multiple slices, callers must fall back to ForType.
+					n.AppendLine("    return nil, false")
+				}
+			}
+			n.AppendLine("}")
+		}
+		n.AppendLine("return nil, true")
+	})
+	node.AppendLine("}")
+	node.AppendLine()
+
 	return node
 }
 

--- a/internal/generator/linker_generator.go
+++ b/internal/generator/linker_generator.go
@@ -328,8 +328,6 @@ func generateReferenceConstructor(context *LinkerGeneratorContext) codegen.Node 
 	node.AppendLine()
 
 	node.AppendLine("type Default", context.grammar.Name(), "ReferencesConstructor struct {")
-	node.AppendLine("	sc              *service.Container")
-	node.AppendLine("	referenceLinker func() ", context.grammar.Name(), "ReferenceLinker")
 	for _, field := range context.fields {
 		node.AppendLine("	link", field.typeName, field.name, " func() core.ReferenceGetter[", field.target, "]")
 	}
@@ -337,12 +335,12 @@ func generateReferenceConstructor(context *LinkerGeneratorContext) codegen.Node 
 	node.AppendLine()
 
 	node.AppendLine("func NewDefault", context.grammar.Name(), "ReferencesConstructor(sc *service.Container) ", context.grammar.Name(), "ReferencesConstructor {")
-	node.AppendLine("	referenceLinker := sync.OnceValue(func() ", context.grammar.Name(), "ReferenceLinker {")
-	node.AppendLine("		return service.MustGet[", context.grammar.Name(), "ReferenceLinker](sc)")
-	node.AppendLine("	})")
+	if len(context.fields) > 0 {
+		node.AppendLine("	referenceLinker := sync.OnceValue(func() ", context.grammar.Name(), "ReferenceLinker {")
+		node.AppendLine("		return service.MustGet[", context.grammar.Name(), "ReferenceLinker](sc)")
+		node.AppendLine("	})")
+	}
 	node.AppendLine("	return &Default", context.grammar.Name(), "ReferencesConstructor{")
-	node.AppendLine("		sc:              sc,")
-	node.AppendLine("		referenceLinker: referenceLinker,")
 	// Generate a dedicated link function for each reference
 	// This reduces the amount of closure allocations
 	for _, field := range context.fields {

--- a/internal/grammar/infix.go
+++ b/internal/grammar/infix.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	core "typefox.dev/fastbelt"
+	"typefox.dev/fastbelt/linking"
 )
 
 // InfixOperatorGroupName returns the name of the token group synthesized by
@@ -189,7 +190,7 @@ func synthesizeInfixBody(rule InfixRule, operand ParserRule, operatorGroup Token
 func resolvedReference[T core.AstNode](owner core.AstNode, unit core.StringUnit, target T) *core.Reference[T] {
 	description := &core.SymbolDescription{
 		Node: target,
-		Name: any(target).(core.NamedTokenNode).NameToken(),
+		Unit: linking.Name(target),
 	}
 	if doc := target.Document(); doc != nil {
 		description.URI = doc.URI

--- a/internal/grammar/infix.go
+++ b/internal/grammar/infix.go
@@ -190,7 +190,10 @@ func synthesizeInfixBody(rule InfixRule, operand ParserRule, operatorGroup Token
 func resolvedReference[T core.AstNode](owner core.AstNode, unit core.StringUnit, target T) *core.Reference[T] {
 	description := &core.SymbolDescription{
 		Node: target,
-		Unit: linking.Name(target),
+	}
+	if nameUnit := linking.Name(target); nameUnit != nil {
+		description.Unit = nameUnit
+		description.Name = nameUnit.String()
 	}
 	if doc := target.Document(); doc != nil {
 		description.URI = doc.URI

--- a/internal/grammar/linker_gen.go
+++ b/internal/grammar/linker_gen.go
@@ -294,3 +294,17 @@ func (sc *FastbeltSymbolContainer) ForType(t reflect.Type) core.SymbolSeq {
 	}
 	return core.EmptySymbolDescriptions
 }
+
+func (sc *FastbeltSymbolContainer) ForTypeSlice(t reflect.Type) ([]*core.SymbolDescription, bool) {
+	switch t {
+	case TypeFor_Interface:
+		return sc.Interfaces, true
+	case TypeFor_Field:
+		return sc.Fields, true
+	case TypeFor_AbstractTokenRule:
+		return sc.AbstractTokenRules, true
+	case TypeFor_AbstractRule:
+		return nil, false
+	}
+	return nil, true
+}

--- a/internal/grammar/linker_gen.go
+++ b/internal/grammar/linker_gen.go
@@ -166,67 +166,98 @@ type FastbeltReferencesConstructor interface {
 }
 
 type DefaultFastbeltReferencesConstructor struct {
-	sc              *service.Container
-	referenceLinker func() FastbeltReferenceLinker
+	sc                                       *service.Container
+	referenceLinker                          func() FastbeltReferenceLinker
+	linkInterfaceExtends                     func() core.ReferenceGetter[Interface]
+	linkReferenceTypeType                    func() core.ReferenceGetter[Interface]
+	linkSimpleTypeType                       func() core.ReferenceGetter[Interface]
+	linkAbstractRuleWithReturnTypeReturnType func() core.ReferenceGetter[Interface]
+	linkTokenGroupTokenRefs                  func() core.ReferenceGetter[AbstractTokenRule]
+	linkAssignmentProperty                   func() core.ReferenceGetter[Field]
+	linkCrossRefType                         func() core.ReferenceGetter[Interface]
+	linkRuleCallRule                         func() core.ReferenceGetter[AbstractRule]
+	linkActionType                           func() core.ReferenceGetter[Interface]
+	linkActionProperty                       func() core.ReferenceGetter[Field]
 }
 
 func NewDefaultFastbeltReferencesConstructor(sc *service.Container) FastbeltReferencesConstructor {
+	referenceLinker := sync.OnceValue(func() FastbeltReferenceLinker {
+		return service.MustGet[FastbeltReferenceLinker](sc)
+	})
 	return &DefaultFastbeltReferencesConstructor{
-		sc: sc,
-		referenceLinker: sync.OnceValue(func() FastbeltReferenceLinker {
-			return service.MustGet[FastbeltReferenceLinker](sc)
+		sc:              sc,
+		referenceLinker: referenceLinker,
+		linkInterfaceExtends: sync.OnceValue(func() core.ReferenceGetter[Interface] {
+			return referenceLinker().LinkInterfaceExtends
+		}),
+		linkReferenceTypeType: sync.OnceValue(func() core.ReferenceGetter[Interface] {
+			return referenceLinker().LinkReferenceTypeType
+		}),
+		linkSimpleTypeType: sync.OnceValue(func() core.ReferenceGetter[Interface] {
+			return referenceLinker().LinkSimpleTypeType
+		}),
+		linkAbstractRuleWithReturnTypeReturnType: sync.OnceValue(func() core.ReferenceGetter[Interface] {
+			return referenceLinker().LinkAbstractRuleWithReturnTypeReturnType
+		}),
+		linkTokenGroupTokenRefs: sync.OnceValue(func() core.ReferenceGetter[AbstractTokenRule] {
+			return referenceLinker().LinkTokenGroupTokenRefs
+		}),
+		linkAssignmentProperty: sync.OnceValue(func() core.ReferenceGetter[Field] {
+			return referenceLinker().LinkAssignmentProperty
+		}),
+		linkCrossRefType: sync.OnceValue(func() core.ReferenceGetter[Interface] {
+			return referenceLinker().LinkCrossRefType
+		}),
+		linkRuleCallRule: sync.OnceValue(func() core.ReferenceGetter[AbstractRule] {
+			return referenceLinker().LinkRuleCallRule
+		}),
+		linkActionType: sync.OnceValue(func() core.ReferenceGetter[Interface] {
+			return referenceLinker().LinkActionType
+		}),
+		linkActionProperty: sync.OnceValue(func() core.ReferenceGetter[Field] {
+			return referenceLinker().LinkActionProperty
 		}),
 	}
 }
 
 func (s *DefaultFastbeltReferencesConstructor) InterfaceExtends(owner core.AstNode, unit core.StringUnit) *core.Reference[Interface] {
-	fn := s.referenceLinker().LinkInterfaceExtends
-	return core.NewReference(owner, unit, fn)
+	return core.NewReference(owner, unit, s.linkInterfaceExtends())
 }
 
 func (s *DefaultFastbeltReferencesConstructor) ReferenceTypeType(owner core.AstNode, unit core.StringUnit) *core.Reference[Interface] {
-	fn := s.referenceLinker().LinkReferenceTypeType
-	return core.NewReference(owner, unit, fn)
+	return core.NewReference(owner, unit, s.linkReferenceTypeType())
 }
 
 func (s *DefaultFastbeltReferencesConstructor) SimpleTypeType(owner core.AstNode, unit core.StringUnit) *core.Reference[Interface] {
-	fn := s.referenceLinker().LinkSimpleTypeType
-	return core.NewReference(owner, unit, fn)
+	return core.NewReference(owner, unit, s.linkSimpleTypeType())
 }
 
 func (s *DefaultFastbeltReferencesConstructor) AbstractRuleWithReturnTypeReturnType(owner core.AstNode, unit core.StringUnit) *core.Reference[Interface] {
-	fn := s.referenceLinker().LinkAbstractRuleWithReturnTypeReturnType
-	return core.NewReference(owner, unit, fn)
+	return core.NewReference(owner, unit, s.linkAbstractRuleWithReturnTypeReturnType())
 }
 
 func (s *DefaultFastbeltReferencesConstructor) TokenGroupTokenRefs(owner core.AstNode, unit core.StringUnit) *core.Reference[AbstractTokenRule] {
-	fn := s.referenceLinker().LinkTokenGroupTokenRefs
-	return core.NewReference(owner, unit, fn)
+	return core.NewReference(owner, unit, s.linkTokenGroupTokenRefs())
 }
 
 func (s *DefaultFastbeltReferencesConstructor) AssignmentProperty(owner core.AstNode, unit core.StringUnit) *core.Reference[Field] {
-	fn := s.referenceLinker().LinkAssignmentProperty
-	return core.NewReference(owner, unit, fn)
+	return core.NewReference(owner, unit, s.linkAssignmentProperty())
 }
 
 func (s *DefaultFastbeltReferencesConstructor) CrossRefType(owner core.AstNode, unit core.StringUnit) *core.Reference[Interface] {
-	fn := s.referenceLinker().LinkCrossRefType
-	return core.NewReference(owner, unit, fn)
+	return core.NewReference(owner, unit, s.linkCrossRefType())
 }
 
 func (s *DefaultFastbeltReferencesConstructor) RuleCallRule(owner core.AstNode, unit core.StringUnit) *core.Reference[AbstractRule] {
-	fn := s.referenceLinker().LinkRuleCallRule
-	return core.NewReference(owner, unit, fn)
+	return core.NewReference(owner, unit, s.linkRuleCallRule())
 }
 
 func (s *DefaultFastbeltReferencesConstructor) ActionType(owner core.AstNode, unit core.StringUnit) *core.Reference[Interface] {
-	fn := s.referenceLinker().LinkActionType
-	return core.NewReference(owner, unit, fn)
+	return core.NewReference(owner, unit, s.linkActionType())
 }
 
 func (s *DefaultFastbeltReferencesConstructor) ActionProperty(owner core.AstNode, unit core.StringUnit) *core.Reference[Field] {
-	fn := s.referenceLinker().LinkActionProperty
-	return core.NewReference(owner, unit, fn)
+	return core.NewReference(owner, unit, s.linkActionProperty())
 }
 
 type FastbeltSymbolContainers struct{}

--- a/internal/grammar/linker_gen.go
+++ b/internal/grammar/linker_gen.go
@@ -166,8 +166,6 @@ type FastbeltReferencesConstructor interface {
 }
 
 type DefaultFastbeltReferencesConstructor struct {
-	sc                                       *service.Container
-	referenceLinker                          func() FastbeltReferenceLinker
 	linkInterfaceExtends                     func() core.ReferenceGetter[Interface]
 	linkReferenceTypeType                    func() core.ReferenceGetter[Interface]
 	linkSimpleTypeType                       func() core.ReferenceGetter[Interface]
@@ -185,8 +183,6 @@ func NewDefaultFastbeltReferencesConstructor(sc *service.Container) FastbeltRefe
 		return service.MustGet[FastbeltReferenceLinker](sc)
 	})
 	return &DefaultFastbeltReferencesConstructor{
-		sc:              sc,
-		referenceLinker: referenceLinker,
 		linkInterfaceExtends: sync.OnceValue(func() core.ReferenceGetter[Interface] {
 			return referenceLinker().LinkInterfaceExtends
 		}),

--- a/internal/languages/completion/completion_engine_test.go
+++ b/internal/languages/completion/completion_engine_test.go
@@ -581,7 +581,7 @@ type hidingCompletionFilter struct {
 func (h *hidingCompletionFilter) FilterERef(ctx context.Context, ref *core.Reference[completion.Declare], in iter.Seq[*core.SymbolDescription]) iter.Seq[*core.SymbolDescription] {
 	return func(yield func(*core.SymbolDescription) bool) {
 		for d := range in {
-			if d.Name.String() == h.hide {
+			if d.Unit.String() == h.hide {
 				continue
 			}
 			if !yield(d) {
@@ -703,7 +703,7 @@ func TestCompletion_ContributorReferenceBranching(t *testing.T) {
 	contrib := &recordingContributor{
 		onReference: func(d *core.SymbolDescription, hint *parser.CompletionHint, atnState int, cc server.ContributorContext, accept server.CompletionAcceptor) {
 			observations = append(observations, seen{
-				name:     d.Name.String(),
+				name:     d.Unit.String(),
 				field:    hint.Field,
 				atnState: atnState,
 				node:     cc.Node,

--- a/internal/languages/completion/linker_gen.go
+++ b/internal/languages/completion/linker_gen.go
@@ -154,62 +154,90 @@ type CompletionReferencesConstructor interface {
 }
 
 type DefaultCompletionReferencesConstructor struct {
-	sc              *service.Container
-	referenceLinker func() CompletionReferenceLinker
+	sc                *service.Container
+	referenceLinker   func() CompletionReferenceLinker
+	linkERef          func() core.ReferenceGetter[Declare]
+	linkFItemRef      func() core.ReferenceGetter[Declare]
+	linkGRef          func() core.ReferenceGetter[Declare]
+	linkMemberCallRef func() core.ReferenceGetter[Declare]
+	linkJRef          func() core.ReferenceGetter[Declare]
+	linkKRef1         func() core.ReferenceGetter[Declare]
+	linkKRef2         func() core.ReferenceGetter[Declare]
+	linkNRef          func() core.ReferenceGetter[Declare]
+	linkORef          func() core.ReferenceGetter[Declare]
 }
 
 func NewDefaultCompletionReferencesConstructor(sc *service.Container) CompletionReferencesConstructor {
+	referenceLinker := sync.OnceValue(func() CompletionReferenceLinker {
+		return service.MustGet[CompletionReferenceLinker](sc)
+	})
 	return &DefaultCompletionReferencesConstructor{
-		sc: sc,
-		referenceLinker: sync.OnceValue(func() CompletionReferenceLinker {
-			return service.MustGet[CompletionReferenceLinker](sc)
+		sc:              sc,
+		referenceLinker: referenceLinker,
+		linkERef: sync.OnceValue(func() core.ReferenceGetter[Declare] {
+			return referenceLinker().LinkERef
+		}),
+		linkFItemRef: sync.OnceValue(func() core.ReferenceGetter[Declare] {
+			return referenceLinker().LinkFItemRef
+		}),
+		linkGRef: sync.OnceValue(func() core.ReferenceGetter[Declare] {
+			return referenceLinker().LinkGRef
+		}),
+		linkMemberCallRef: sync.OnceValue(func() core.ReferenceGetter[Declare] {
+			return referenceLinker().LinkMemberCallRef
+		}),
+		linkJRef: sync.OnceValue(func() core.ReferenceGetter[Declare] {
+			return referenceLinker().LinkJRef
+		}),
+		linkKRef1: sync.OnceValue(func() core.ReferenceGetter[Declare] {
+			return referenceLinker().LinkKRef1
+		}),
+		linkKRef2: sync.OnceValue(func() core.ReferenceGetter[Declare] {
+			return referenceLinker().LinkKRef2
+		}),
+		linkNRef: sync.OnceValue(func() core.ReferenceGetter[Declare] {
+			return referenceLinker().LinkNRef
+		}),
+		linkORef: sync.OnceValue(func() core.ReferenceGetter[Declare] {
+			return referenceLinker().LinkORef
 		}),
 	}
 }
 
 func (s *DefaultCompletionReferencesConstructor) ERef(owner core.AstNode, unit core.StringUnit) *core.Reference[Declare] {
-	fn := s.referenceLinker().LinkERef
-	return core.NewReference(owner, unit, fn)
+	return core.NewReference(owner, unit, s.linkERef())
 }
 
 func (s *DefaultCompletionReferencesConstructor) FItemRef(owner core.AstNode, unit core.StringUnit) *core.Reference[Declare] {
-	fn := s.referenceLinker().LinkFItemRef
-	return core.NewReference(owner, unit, fn)
+	return core.NewReference(owner, unit, s.linkFItemRef())
 }
 
 func (s *DefaultCompletionReferencesConstructor) GRef(owner core.AstNode, unit core.StringUnit) *core.Reference[Declare] {
-	fn := s.referenceLinker().LinkGRef
-	return core.NewReference(owner, unit, fn)
+	return core.NewReference(owner, unit, s.linkGRef())
 }
 
 func (s *DefaultCompletionReferencesConstructor) MemberCallRef(owner core.AstNode, unit core.StringUnit) *core.Reference[Declare] {
-	fn := s.referenceLinker().LinkMemberCallRef
-	return core.NewReference(owner, unit, fn)
+	return core.NewReference(owner, unit, s.linkMemberCallRef())
 }
 
 func (s *DefaultCompletionReferencesConstructor) JRef(owner core.AstNode, unit core.StringUnit) *core.Reference[Declare] {
-	fn := s.referenceLinker().LinkJRef
-	return core.NewReference(owner, unit, fn)
+	return core.NewReference(owner, unit, s.linkJRef())
 }
 
 func (s *DefaultCompletionReferencesConstructor) KRef1(owner core.AstNode, unit core.StringUnit) *core.Reference[Declare] {
-	fn := s.referenceLinker().LinkKRef1
-	return core.NewReference(owner, unit, fn)
+	return core.NewReference(owner, unit, s.linkKRef1())
 }
 
 func (s *DefaultCompletionReferencesConstructor) KRef2(owner core.AstNode, unit core.StringUnit) *core.Reference[Declare] {
-	fn := s.referenceLinker().LinkKRef2
-	return core.NewReference(owner, unit, fn)
+	return core.NewReference(owner, unit, s.linkKRef2())
 }
 
 func (s *DefaultCompletionReferencesConstructor) NRef(owner core.AstNode, unit core.StringUnit) *core.Reference[Declare] {
-	fn := s.referenceLinker().LinkNRef
-	return core.NewReference(owner, unit, fn)
+	return core.NewReference(owner, unit, s.linkNRef())
 }
 
 func (s *DefaultCompletionReferencesConstructor) ORef(owner core.AstNode, unit core.StringUnit) *core.Reference[Declare] {
-	fn := s.referenceLinker().LinkORef
-	return core.NewReference(owner, unit, fn)
+	return core.NewReference(owner, unit, s.linkORef())
 }
 
 type CompletionSymbolContainers struct{}

--- a/internal/languages/completion/linker_gen.go
+++ b/internal/languages/completion/linker_gen.go
@@ -250,3 +250,11 @@ func (sc *CompletionSymbolContainer) ForType(t reflect.Type) core.SymbolSeq {
 	}
 	return core.EmptySymbolDescriptions
 }
+
+func (sc *CompletionSymbolContainer) ForTypeSlice(t reflect.Type) ([]*core.SymbolDescription, bool) {
+	switch t {
+	case TypeFor_Declare:
+		return sc.Declares, true
+	}
+	return nil, true
+}

--- a/internal/languages/completion/linker_gen.go
+++ b/internal/languages/completion/linker_gen.go
@@ -154,8 +154,6 @@ type CompletionReferencesConstructor interface {
 }
 
 type DefaultCompletionReferencesConstructor struct {
-	sc                *service.Container
-	referenceLinker   func() CompletionReferenceLinker
 	linkERef          func() core.ReferenceGetter[Declare]
 	linkFItemRef      func() core.ReferenceGetter[Declare]
 	linkGRef          func() core.ReferenceGetter[Declare]
@@ -172,8 +170,6 @@ func NewDefaultCompletionReferencesConstructor(sc *service.Container) Completion
 		return service.MustGet[CompletionReferenceLinker](sc)
 	})
 	return &DefaultCompletionReferencesConstructor{
-		sc:              sc,
-		referenceLinker: referenceLinker,
 		linkERef: sync.OnceValue(func() core.ReferenceGetter[Declare] {
 			return referenceLinker().LinkERef
 		}),

--- a/internal/languages/lookahead/linker_gen.go
+++ b/internal/languages/lookahead/linker_gen.go
@@ -79,3 +79,7 @@ func (sc *LookaheadSymbolContainer) All() core.SymbolSeq {
 func (sc *LookaheadSymbolContainer) ForType(t reflect.Type) core.SymbolSeq {
 	return core.EmptySymbolDescriptions
 }
+
+func (sc *LookaheadSymbolContainer) ForTypeSlice(t reflect.Type) ([]*core.SymbolDescription, bool) {
+	return nil, true
+}

--- a/internal/languages/lookahead/linker_gen.go
+++ b/internal/languages/lookahead/linker_gen.go
@@ -47,11 +47,12 @@ type DefaultLookaheadReferencesConstructor struct {
 }
 
 func NewDefaultLookaheadReferencesConstructor(sc *service.Container) LookaheadReferencesConstructor {
+	referenceLinker := sync.OnceValue(func() LookaheadReferenceLinker {
+		return service.MustGet[LookaheadReferenceLinker](sc)
+	})
 	return &DefaultLookaheadReferencesConstructor{
-		sc: sc,
-		referenceLinker: sync.OnceValue(func() LookaheadReferenceLinker {
-			return service.MustGet[LookaheadReferenceLinker](sc)
-		}),
+		sc:              sc,
+		referenceLinker: referenceLinker,
 	}
 }
 

--- a/internal/languages/lookahead/linker_gen.go
+++ b/internal/languages/lookahead/linker_gen.go
@@ -42,18 +42,10 @@ type LookaheadReferencesConstructor interface {
 }
 
 type DefaultLookaheadReferencesConstructor struct {
-	sc              *service.Container
-	referenceLinker func() LookaheadReferenceLinker
 }
 
 func NewDefaultLookaheadReferencesConstructor(sc *service.Container) LookaheadReferencesConstructor {
-	referenceLinker := sync.OnceValue(func() LookaheadReferenceLinker {
-		return service.MustGet[LookaheadReferenceLinker](sc)
-	})
-	return &DefaultLookaheadReferencesConstructor{
-		sc:              sc,
-		referenceLinker: referenceLinker,
-	}
+	return &DefaultLookaheadReferencesConstructor{}
 }
 
 type LookaheadSymbolContainers struct{}

--- a/internal/languages/token_groups/linker_gen.go
+++ b/internal/languages/token_groups/linker_gen.go
@@ -79,3 +79,7 @@ func (sc *TokenGroupsSymbolContainer) All() core.SymbolSeq {
 func (sc *TokenGroupsSymbolContainer) ForType(t reflect.Type) core.SymbolSeq {
 	return core.EmptySymbolDescriptions
 }
+
+func (sc *TokenGroupsSymbolContainer) ForTypeSlice(t reflect.Type) ([]*core.SymbolDescription, bool) {
+	return nil, true
+}

--- a/internal/languages/token_groups/linker_gen.go
+++ b/internal/languages/token_groups/linker_gen.go
@@ -47,11 +47,12 @@ type DefaultTokenGroupsReferencesConstructor struct {
 }
 
 func NewDefaultTokenGroupsReferencesConstructor(sc *service.Container) TokenGroupsReferencesConstructor {
+	referenceLinker := sync.OnceValue(func() TokenGroupsReferenceLinker {
+		return service.MustGet[TokenGroupsReferenceLinker](sc)
+	})
 	return &DefaultTokenGroupsReferencesConstructor{
-		sc: sc,
-		referenceLinker: sync.OnceValue(func() TokenGroupsReferenceLinker {
-			return service.MustGet[TokenGroupsReferenceLinker](sc)
-		}),
+		sc:              sc,
+		referenceLinker: referenceLinker,
 	}
 }
 

--- a/internal/languages/token_groups/linker_gen.go
+++ b/internal/languages/token_groups/linker_gen.go
@@ -42,18 +42,10 @@ type TokenGroupsReferencesConstructor interface {
 }
 
 type DefaultTokenGroupsReferencesConstructor struct {
-	sc              *service.Container
-	referenceLinker func() TokenGroupsReferenceLinker
 }
 
 func NewDefaultTokenGroupsReferencesConstructor(sc *service.Container) TokenGroupsReferencesConstructor {
-	referenceLinker := sync.OnceValue(func() TokenGroupsReferenceLinker {
-		return service.MustGet[TokenGroupsReferenceLinker](sc)
-	})
-	return &DefaultTokenGroupsReferencesConstructor{
-		sc:              sc,
-		referenceLinker: referenceLinker,
-	}
+	return &DefaultTokenGroupsReferencesConstructor{}
 }
 
 type TokenGroupsSymbolContainers struct{}

--- a/linking/linker.go
+++ b/linking/linker.go
@@ -33,10 +33,14 @@ func NewDefaultLinker(sc *service.Container) Linker {
 }
 
 func (s *DefaultLinker) Link(ctx context.Context, document *core.Document) {
-	parallel.ForEach(document.References, func(ref core.UntypedReference, _ int) {
-		if ctx.Err() != nil {
-			return
-		}
-		ref.Resolve(ctx)
-	})
+	// Each worker resolves references with its own resolution chain context,
+	// so cycle detection does not need to allocate per resolved reference.
+	parallel.ForEachWithSetup(document.References,
+		func() context.Context { return core.WithResolutionChain(ctx) },
+		func(workerCtx context.Context, ref core.UntypedReference, _ int) {
+			if workerCtx.Err() != nil {
+				return
+			}
+			ref.Resolve(workerCtx)
+		})
 }

--- a/linking/scoping.go
+++ b/linking/scoping.go
@@ -32,7 +32,6 @@ func GlobalScopeOfType[T core.AstNode](node core.AstNode) core.Scope {
 // LocalScopeOfType is the default way of creating a local scope for a reference in the given AST node.
 // It returns the scope of symbols visible from the given AST node or any of its containers.
 func LocalScopeOfType[T core.AstNode](node core.AstNode, globalScope core.Scope) core.Scope {
-	symbols := GetLocalSymbols[T](node)
 	var outer core.Scope
 	if container := node.Container(); container != nil {
 		// The container node (or one of its ancestors) defines the outer scope
@@ -41,6 +40,22 @@ func LocalScopeOfType[T core.AstNode](node core.AstNode, globalScope core.Scope)
 		// We're at the root node, use the given global scope
 		outer = globalScope
 	}
+	targetType := reflect.TypeFor[T]()
+	symbolContainer := node.Document().LocalSymbols.For(node)
+	if sliceContainer, ok := symbolContainer.(core.SymbolSliceContainer); ok {
+		if slice, ok := sliceContainer.ForTypeSlice(targetType); ok {
+			// Fast path: the container exposes its symbols as a plain slice,
+			// so emptiness is free to check and lookups don't allocate iterators.
+			if len(slice) == 0 {
+				if outer != nil {
+					return outer
+				}
+				return core.EmptyScope
+			}
+			return core.NewSliceScope(slice, outer)
+		}
+	}
+	symbols := symbolContainer.ForType(targetType)
 	if extiter.IsEmpty(symbols) {
 		// Shortcut to generate fewer scopes
 		if outer != nil {

--- a/linking/scoping.go
+++ b/linking/scoping.go
@@ -47,24 +47,24 @@ func LocalScopeOfType[T core.AstNode](node core.AstNode, globalScope core.Scope)
 			// Fast path: the container exposes its symbols as a plain slice,
 			// so emptiness is free to check and lookups don't allocate iterators.
 			if len(slice) == 0 {
-				if outer != nil {
-					return outer
-				}
-				return core.EmptyScope
+				return outerOrEmpty(outer)
 			}
 			return core.NewSliceScope(slice, outer)
 		}
 	}
 	symbols := symbolContainer.ForType(targetType)
 	if extiter.IsEmpty(symbols) {
-		// Shortcut to generate fewer scopes
-		if outer != nil {
-			return outer
-		} else {
-			return core.EmptyScope
-		}
+		return outerOrEmpty(outer)
 	}
 	return core.NewSeqScope(symbols, outer)
+}
+
+// outerOrEmpty is the shortcut for nodes without local symbols: no new scope is created.
+func outerOrEmpty(outer core.Scope) core.Scope {
+	if outer != nil {
+		return outer
+	}
+	return core.EmptyScope
 }
 
 // GetLocalSymbols retrieves the local symbols for the given AST node and type.

--- a/reference.go
+++ b/reference.go
@@ -107,6 +107,31 @@ func (r *Reference[T]) TextRange() TextRange {
 	return r.unit.TextRange()
 }
 
+// resolutionChainKey is the context key under which a [resolutionChain] is stored.
+type resolutionChainKey struct{}
+
+// resolutionChain tracks the references currently being resolved, for cycle
+// detection. It is mutated without synchronization and must therefore only be
+// used by a single goroutine at a time.
+type resolutionChain struct {
+	refs []UntypedReference
+}
+
+// WithResolutionChain returns a context that carries a reusable resolution
+// chain for reference cycle detection.
+//
+// The chain is mutated without synchronization: the returned context must not
+// be shared by goroutines that resolve references concurrently. Create one
+// chain context per goroutine instead.
+func WithResolutionChain(ctx context.Context) context.Context {
+	return context.WithValue(ctx, resolutionChainKey{}, &resolutionChain{})
+}
+
+func getResolveChain(ctx context.Context) *resolutionChain {
+	chain, _ := ctx.Value(resolutionChainKey{}).(*resolutionChain)
+	return chain
+}
+
 // Resolve resolves the reference exactly once for this instance.
 // It is safe for concurrent use.
 func (r *Reference[T]) Resolve(ctx context.Context) {
@@ -119,9 +144,13 @@ func (r *Reference[T]) Resolve(ctx context.Context) {
 }
 
 func (r *Reference[T]) resolveSlow(ctx context.Context) {
-	// We can use the context to detect cyclic reference resolution attempts
-	// We are allowed to do this outside of the mutex lock because context is immutable
-	if ctx.Value(r) != nil {
+	// Cyclic resolution attempts are detected via the resolution chain
+	chain := getResolveChain(ctx)
+	cyclic := false
+	if chain != nil {
+		cyclic = slices.Contains(chain.refs, UntypedReference(r))
+	}
+	if cyclic {
 		// Note that we write directly to r.err without locking here
 		// This is safe, because the reference is already locked by the caller
 		// Attempting to lock it again would cause a deadlock anyway
@@ -135,8 +164,18 @@ func (r *Reference[T]) resolveSlow(ctx context.Context) {
 		// Another goroutine might have resolved it while we were waiting for the lock
 		return
 	}
-	newCtx := context.WithValue(ctx, r, true)
-	desc, e := r.getter(newCtx, r)
+	if chain != nil {
+		// Append the current reference to the chain for cycle detection
+		chain.refs = append(chain.refs, r)
+		defer func() {
+			// Pop the reference from the chain after resolution
+			chain.refs = chain.refs[:len(chain.refs)-1]
+		}()
+	} else {
+		// No chain provided, so create a context with a new chain
+		ctx = WithResolutionChain(ctx)
+	}
+	desc, e := r.getter(ctx, r)
 	r.description = desc
 	if r.err == nil {
 		// Do not overwrite existing errors

--- a/reference.go
+++ b/reference.go
@@ -146,11 +146,7 @@ func (r *Reference[T]) Resolve(ctx context.Context) {
 func (r *Reference[T]) resolveSlow(ctx context.Context) {
 	// Cyclic resolution attempts are detected via the resolution chain
 	chain := getResolveChain(ctx)
-	cyclic := false
-	if chain != nil {
-		cyclic = slices.Contains(chain.refs, UntypedReference(r))
-	}
-	if cyclic {
+	if chain != nil && slices.Contains(chain.refs, UntypedReference(r)) {
 		// Note that we write directly to r.err without locking here
 		// This is safe, because the reference is already locked by the caller
 		// Attempting to lock it again would cause a deadlock anyway
@@ -164,17 +160,17 @@ func (r *Reference[T]) resolveSlow(ctx context.Context) {
 		// Another goroutine might have resolved it while we were waiting for the lock
 		return
 	}
-	if chain != nil {
-		// Append the current reference to the chain for cycle detection
-		chain.refs = append(chain.refs, r)
-		defer func() {
-			// Pop the reference from the chain after resolution
-			chain.refs = chain.refs[:len(chain.refs)-1]
-		}()
-	} else {
+	if chain == nil {
 		// No chain provided, so create a context with a new chain
-		ctx = WithResolutionChain(ctx)
+		chain = &resolutionChain{}
+		ctx = context.WithValue(ctx, resolutionChainKey{}, chain)
 	}
+	// Append the current reference to the chain for cycle detection
+	chain.refs = append(chain.refs, r)
+	defer func() {
+		// Pop the reference from the chain after resolution
+		chain.refs = chain.refs[:len(chain.refs)-1]
+	}()
 	desc, e := r.getter(ctx, r)
 	r.description = desc
 	if r.err == nil {

--- a/reference_test.go
+++ b/reference_test.go
@@ -1,0 +1,32 @@
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+
+package fastbelt
+
+import (
+	"context"
+	"testing"
+)
+
+// A self-referencing getter must report a cyclic error instead of deadlocking,
+// even when the caller passes a context without a resolution chain.
+func TestResolveSelfCycleWithoutChain(t *testing.T) {
+	ref := NewReference(nil, nil, func(ctx context.Context, r *Reference[AstNode]) (*SymbolDescription, *ReferenceError) {
+		r.Resolve(ctx)
+		return nil, nil
+	})
+	done := make(chan struct{})
+	go func() {
+		ref.Resolve(context.Background())
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-t.Context().Done():
+		t.Fatal("Resolve deadlocked on self cycle")
+	}
+	if ref.Error() == nil {
+		t.Fatal("expected cyclic reference error")
+	}
+}

--- a/scope.go
+++ b/scope.go
@@ -96,7 +96,7 @@ func NewSeqScope(elements iter.Seq[*SymbolDescription], outer Scope) *SeqScope {
 // ElementByName returns the first local symbol named name, then checks outer.
 func (s *SeqScope) ElementByName(name string) *SymbolDescription {
 	for desc := range s.elements {
-		if desc.Name.String() == name {
+		if desc.NameText() == name {
 			return desc
 		}
 	}
@@ -109,7 +109,7 @@ func (s *SeqScope) ElementByName(name string) *SymbolDescription {
 // ElementsByName returns all local symbols named name followed by outer matches.
 func (s *SeqScope) ElementsByName(name string) iter.Seq[*SymbolDescription] {
 	matching := extiter.Filter(s.elements, func(desc *SymbolDescription) bool {
-		return desc.Name.String() == name
+		return desc.NameText() == name
 	})
 	if s.outer != nil {
 		return extiter.Concat(matching, s.outer.ElementsByName(name))
@@ -149,7 +149,7 @@ func NewSliceScope(elements []*SymbolDescription, outer Scope) *SliceScope {
 // ElementByName returns the first local symbol named name, then checks outer.
 func (s *SliceScope) ElementByName(name string) *SymbolDescription {
 	for _, desc := range s.elements {
-		if desc.Name.String() == name {
+		if desc.NameText() == name {
 			return desc
 		}
 	}
@@ -162,7 +162,7 @@ func (s *SliceScope) ElementByName(name string) *SymbolDescription {
 // ElementsByName returns all local symbols named name followed by outer matches.
 func (s *SliceScope) ElementsByName(name string) iter.Seq[*SymbolDescription] {
 	matching := extiter.Filter(slices.Values(s.elements), func(desc *SymbolDescription) bool {
-		return desc.Name.String() == name
+		return desc.NameText() == name
 	})
 	if s.outer != nil {
 		return extiter.Concat(matching, s.outer.ElementsByName(name))
@@ -208,7 +208,7 @@ func NewMapScopeFromSlice(elements []*SymbolDescription, outer Scope) *MapScope 
 func NewMapScopeFromSeq(elements iter.Seq[*SymbolDescription], outer Scope) *MapScope {
 	elemMap := collections.NewMultiMap[string, *SymbolDescription]()
 	for desc := range elements {
-		elemMap.Put(desc.Name.String(), desc)
+		elemMap.Put(desc.NameText(), desc)
 	}
 	return NewMapScope(elemMap, outer)
 }

--- a/scope.go
+++ b/scope.go
@@ -125,6 +125,59 @@ func (s *SeqScope) AllElements() iter.Seq[*SymbolDescription] {
 	return s.elements
 }
 
+// SliceScope is a scope backed by a plain slice of symbol descriptions.
+//
+// Unlike [SeqScope], lookups scan the slice directly without allocating
+// iterator closures, which makes it the preferred scope type for the
+// performance-sensitive linking phase.
+type SliceScope struct {
+	elements []*SymbolDescription
+	outer    Scope
+}
+
+// NewSliceScope creates a [SliceScope] from local elements and an optional outer scope.
+//
+// Local elements are searched before the outer scope. The slice is not copied;
+// callers must not modify it afterwards.
+func NewSliceScope(elements []*SymbolDescription, outer Scope) *SliceScope {
+	return &SliceScope{
+		elements: elements,
+		outer:    outer,
+	}
+}
+
+// ElementByName returns the first local symbol named name, then checks outer.
+func (s *SliceScope) ElementByName(name string) *SymbolDescription {
+	for _, desc := range s.elements {
+		if desc.Name.String() == name {
+			return desc
+		}
+	}
+	if s.outer != nil {
+		return s.outer.ElementByName(name)
+	}
+	return nil
+}
+
+// ElementsByName returns all local symbols named name followed by outer matches.
+func (s *SliceScope) ElementsByName(name string) iter.Seq[*SymbolDescription] {
+	matching := extiter.Filter(slices.Values(s.elements), func(desc *SymbolDescription) bool {
+		return desc.Name.String() == name
+	})
+	if s.outer != nil {
+		return extiter.Concat(matching, s.outer.ElementsByName(name))
+	}
+	return matching
+}
+
+// AllElements returns local elements followed by all outer elements.
+func (s *SliceScope) AllElements() iter.Seq[*SymbolDescription] {
+	if s.outer != nil {
+		return extiter.Concat(slices.Values(s.elements), s.outer.AllElements())
+	}
+	return slices.Values(s.elements)
+}
+
 // MapScope is a scope backed by a name-indexed multimap.
 //
 // MapScope is optimized for repeated name lookups by grouping local symbols by

--- a/scope.go
+++ b/scope.go
@@ -96,7 +96,7 @@ func NewSeqScope(elements iter.Seq[*SymbolDescription], outer Scope) *SeqScope {
 // ElementByName returns the first local symbol named name, then checks outer.
 func (s *SeqScope) ElementByName(name string) *SymbolDescription {
 	for desc := range s.elements {
-		if desc.NameText() == name {
+		if desc.Name == name {
 			return desc
 		}
 	}
@@ -109,7 +109,7 @@ func (s *SeqScope) ElementByName(name string) *SymbolDescription {
 // ElementsByName returns all local symbols named name followed by outer matches.
 func (s *SeqScope) ElementsByName(name string) iter.Seq[*SymbolDescription] {
 	matching := extiter.Filter(s.elements, func(desc *SymbolDescription) bool {
-		return desc.NameText() == name
+		return desc.Name == name
 	})
 	if s.outer != nil {
 		return extiter.Concat(matching, s.outer.ElementsByName(name))
@@ -149,7 +149,7 @@ func NewSliceScope(elements []*SymbolDescription, outer Scope) *SliceScope {
 // ElementByName returns the first local symbol named name, then checks outer.
 func (s *SliceScope) ElementByName(name string) *SymbolDescription {
 	for _, desc := range s.elements {
-		if desc.NameText() == name {
+		if desc.Name == name {
 			return desc
 		}
 	}
@@ -162,7 +162,7 @@ func (s *SliceScope) ElementByName(name string) *SymbolDescription {
 // ElementsByName returns all local symbols named name followed by outer matches.
 func (s *SliceScope) ElementsByName(name string) iter.Seq[*SymbolDescription] {
 	matching := extiter.Filter(slices.Values(s.elements), func(desc *SymbolDescription) bool {
-		return desc.NameText() == name
+		return desc.Name == name
 	})
 	if s.outer != nil {
 		return extiter.Concat(matching, s.outer.ElementsByName(name))
@@ -208,7 +208,7 @@ func NewMapScopeFromSlice(elements []*SymbolDescription, outer Scope) *MapScope 
 func NewMapScopeFromSeq(elements iter.Seq[*SymbolDescription], outer Scope) *MapScope {
 	elemMap := collections.NewMultiMap[string, *SymbolDescription]()
 	for desc := range elements {
-		elemMap.Put(desc.NameText(), desc)
+		elemMap.Put(desc.Name, desc)
 	}
 	return NewMapScope(elemMap, outer)
 }

--- a/scope.go
+++ b/scope.go
@@ -161,21 +161,12 @@ func (s *SliceScope) ElementByName(name string) *SymbolDescription {
 
 // ElementsByName returns all local symbols named name followed by outer matches.
 func (s *SliceScope) ElementsByName(name string) iter.Seq[*SymbolDescription] {
-	matching := extiter.Filter(slices.Values(s.elements), func(desc *SymbolDescription) bool {
-		return desc.Name == name
-	})
-	if s.outer != nil {
-		return extiter.Concat(matching, s.outer.ElementsByName(name))
-	}
-	return matching
+	return NewSeqScope(slices.Values(s.elements), s.outer).ElementsByName(name)
 }
 
 // AllElements returns local elements followed by all outer elements.
 func (s *SliceScope) AllElements() iter.Seq[*SymbolDescription] {
-	if s.outer != nil {
-		return extiter.Concat(slices.Values(s.elements), s.outer.AllElements())
-	}
-	return slices.Values(s.elements)
+	return NewSeqScope(slices.Values(s.elements), s.outer).AllElements()
 }
 
 // MapScope is a scope backed by a name-indexed multimap.

--- a/server/completion_provider.go
+++ b/server/completion_provider.go
@@ -194,7 +194,7 @@ func (s *DefaultCompletionProvider) completionsForContext(
 		hcCopy := hc
 		for d := range seq {
 			dCopy := d
-			if !matcher.Match(cc.ReplaceText, dCopy.Name.String()) {
+			if !matcher.Match(cc.ReplaceText, dCopy.NameText()) {
 				continue
 			}
 			accept := func(item lsp.CompletionItem) {
@@ -625,7 +625,7 @@ func EnrichReferenceCompletionItem(item lsp.CompletionItem, d *core.SymbolDescri
 	if d == nil {
 		return item
 	}
-	defaultLabel := d.Name.String()
+	defaultLabel := d.NameText()
 	if item.Label == "" {
 		item.Label = defaultLabel
 	}

--- a/server/completion_provider.go
+++ b/server/completion_provider.go
@@ -194,7 +194,7 @@ func (s *DefaultCompletionProvider) completionsForContext(
 		hcCopy := hc
 		for d := range seq {
 			dCopy := d
-			if !matcher.Match(cc.ReplaceText, dCopy.NameText()) {
+			if !matcher.Match(cc.ReplaceText, dCopy.Name) {
 				continue
 			}
 			accept := func(item lsp.CompletionItem) {
@@ -625,7 +625,7 @@ func EnrichReferenceCompletionItem(item lsp.CompletionItem, d *core.SymbolDescri
 	if d == nil {
 		return item
 	}
-	defaultLabel := d.NameText()
+	defaultLabel := d.Name
 	if item.Label == "" {
 		item.Label = defaultLabel
 	}

--- a/server/name_finder.go
+++ b/server/name_finder.go
@@ -75,7 +75,7 @@ func (nf *DefaultNameFinder) forToken(ctx context.Context, token *core.Token) Fo
 			// Reference could not be resolved, but return the source unit
 			return FoundName{Source: unit}
 		}
-		return FoundName{Source: unit, Target: refDescription.Name}
+		return FoundName{Source: unit, Target: refDescription.Unit}
 	} else {
 		// Not a reference, try to find the name range that contains the given token
 		node := token.Owner()

--- a/symbols.go
+++ b/symbols.go
@@ -20,6 +20,20 @@ type SymbolDescription struct {
 	Node AstNode
 	// Name is the source unit that provides the symbol's textual name.
 	Name StringUnit
+	// name caches Name.String() so that scope lookups compare plain strings
+	// instead of dispatching through the StringUnit interface per candidate.
+	name string
+}
+
+// NameText returns the symbol's textual name.
+//
+// It is equivalent to Name.String() but avoids the interface dispatch for
+// descriptions created via [NewSymbolDescription].
+func (d *SymbolDescription) NameText() string {
+	if d.name == "" && d.Name != nil {
+		return d.Name.String()
+	}
+	return d.name
 }
 
 // NewSymbolDescription returns a [SymbolDescription] for node and name.
@@ -31,6 +45,7 @@ func NewSymbolDescription(node AstNode, name StringUnit) *SymbolDescription {
 		URI:  doc.URI,
 		Node: node,
 		Name: name,
+		name: name.String(),
 	}
 }
 

--- a/symbols.go
+++ b/symbols.go
@@ -7,6 +7,7 @@ package fastbelt
 import (
 	"iter"
 	"reflect"
+	"sync"
 
 	"typefox.dev/fastbelt/util/extiter"
 )
@@ -67,6 +68,9 @@ type SymbolSeq = iter.Seq[*SymbolDescription]
 // A SymbolContainer is an efficient data structure for storing and querying symbol descriptions.
 // References usually need to query symbols for specific AST types.
 // Language specific implementations optimize for this by indexing descriptions by the type of their AST node.
+//
+// If the container uses a plain slice to store its symbols, it should implement [SymbolSliceContainer] to
+// allow fast lookups without allocating iterators.
 type SymbolContainer interface {
 	// Put attempts to put the given description into the container.
 	// Returns true if the description was added.
@@ -79,6 +83,20 @@ type SymbolContainer interface {
 	ForType(targetType reflect.Type) SymbolSeq
 }
 
+// SymbolSliceContainer is an optional extension of [SymbolContainer] for containers
+// that store their descriptions in plain slices.
+//
+// It allows scope implementations to look up symbols without allocating iterators.
+// Generated symbol containers implement this interface.
+type SymbolSliceContainer interface {
+	SymbolContainer
+	// ForTypeSlice returns the descriptions of the given type as a plain slice.
+	// The second return value is false when the result cannot be represented as a
+	// single slice (e.g. the type's symbols span multiple internal slices);
+	// callers must then fall back to [SymbolContainer.ForType].
+	ForTypeSlice(targetType reflect.Type) ([]*SymbolDescription, bool)
+}
+
 // EmptySymbolContainer is an immutable [SymbolContainer] with no symbols.
 var EmptySymbolContainer SymbolContainer = &emptySymbolContainer{}
 
@@ -87,6 +105,10 @@ type emptySymbolContainer struct{}
 func (c *emptySymbolContainer) Put(desc *SymbolDescription) bool {
 	// This container is immutable, don't accept any descriptions.
 	return false
+}
+
+func (c *emptySymbolContainer) ForTypeSlice(targetType reflect.Type) ([]*SymbolDescription, bool) {
+	return nil, true
 }
 
 func (c *emptySymbolContainer) All() SymbolSeq {
@@ -110,6 +132,10 @@ func MergeSymbolContainers(containers iter.Seq[SymbolContainer]) SymbolContainer
 
 type mergedSymbolContainer struct {
 	containers iter.Seq[SymbolContainer]
+	// forTypeCache memoizes the sequences returned by ForType, keyed by reflect.Type.
+	// The merged container is immutable, so the lazy sequences can be shared between
+	// callers; this avoids rebuilding the same closures for every reference resolution.
+	forTypeCache sync.Map
 }
 
 func (c *mergedSymbolContainer) Put(desc *SymbolDescription) bool {
@@ -124,9 +150,14 @@ func (c *mergedSymbolContainer) All() SymbolSeq {
 }
 
 func (c *mergedSymbolContainer) ForType(targetType reflect.Type) SymbolSeq {
-	return extiter.FlatMap(c.containers, func(container SymbolContainer) SymbolSeq {
+	if cached, ok := c.forTypeCache.Load(targetType); ok {
+		return cached.(SymbolSeq)
+	}
+	seq := extiter.FlatMap(c.containers, func(container SymbolContainer) SymbolSeq {
 		return container.ForType(targetType)
 	})
+	c.forTypeCache.Store(targetType, seq)
+	return seq
 }
 
 // LocalSymbols are used for lexical scoping within a document.

--- a/symbols.go
+++ b/symbols.go
@@ -26,17 +26,11 @@ type SymbolDescription struct {
 }
 
 // NewSymbolDescription returns a [SymbolDescription] for node and its name unit.
-// The symbol name value is dervived from the specified name unit.
+// The symbol name value is derived from the specified name unit.
 //
 // The description URI is derived from node's document.
 func NewSymbolDescription(node AstNode, nameUnit StringUnit) *SymbolDescription {
-	doc := node.Document()
-	return &SymbolDescription{
-		URI:  doc.URI,
-		Node: node,
-		Unit: nameUnit,
-		Name: nameUnit.String(),
-	}
+	return NewNamedSymbolDescription(node, nameUnit, nameUnit.String())
 }
 
 // NewNamedSymbolDescription returns a [SymbolDescription] for node and its name unit

--- a/symbols.go
+++ b/symbols.go
@@ -18,34 +18,37 @@ type SymbolDescription struct {
 	URI URI
 	// Node is the AST node that declares the symbol.
 	Node AstNode
-	// Name is the source unit that provides the symbol's textual name.
-	Name StringUnit
-	// name caches Name.String() so that scope lookups compare plain strings
-	// instead of dispatching through the StringUnit interface per candidate.
-	name string
+	// Unit is the source unit that provides the symbol's position in the text.
+	Unit StringUnit
+	// Name is the canonical name of this symbol. It is allowed to differ
+	// from the [SymbolDescription.Unit]'s text content.
+	Name string
 }
 
-// NameText returns the symbol's textual name.
-//
-// It is equivalent to Name.String() but avoids the interface dispatch for
-// descriptions created via [NewSymbolDescription].
-func (d *SymbolDescription) NameText() string {
-	if d.name == "" && d.Name != nil {
-		return d.Name.String()
-	}
-	return d.name
-}
-
-// NewSymbolDescription returns a [SymbolDescription] for node and name.
+// NewSymbolDescription returns a [SymbolDescription] for node and its name unit.
+// The symbol name value is dervived from the specified name unit.
 //
 // The description URI is derived from node's document.
-func NewSymbolDescription(node AstNode, name StringUnit) *SymbolDescription {
+func NewSymbolDescription(node AstNode, nameUnit StringUnit) *SymbolDescription {
 	doc := node.Document()
 	return &SymbolDescription{
 		URI:  doc.URI,
 		Node: node,
+		Unit: nameUnit,
+		Name: nameUnit.String(),
+	}
+}
+
+// NewNamedSymbolDescription returns a [SymbolDescription] for node and its name unit
+// using a specific canonical name. Useful to specify a name this symbol can be resolved as
+// which can differ from the name unit's text content.
+func NewNamedSymbolDescription(node AstNode, nameUnit StringUnit, name string) *SymbolDescription {
+	doc := node.Document()
+	return &SymbolDescription{
+		URI:  doc.URI,
+		Node: node,
+		Unit: nameUnit,
 		Name: name,
-		name: name.String(),
 	}
 }
 

--- a/textdoc/file.go
+++ b/textdoc/file.go
@@ -36,7 +36,8 @@ func NewFile(uri lsp.DocumentURI, languageID string, version int32, content stri
 		uri:        uri,
 		languageID: languageID,
 		version:    version,
-		content:    []byte(content),
+		// Convert in-place from string to []byte without copying.
+		content: unsafe.Slice(unsafe.StringData(content), len(content)),
 	}
 	f.lineOffsets = computeLineOffsets(f.content, true, 0)
 	return f, nil

--- a/util/parallel/parallel.go
+++ b/util/parallel/parallel.go
@@ -23,30 +23,46 @@ func ForEachIter[T any](seq iter.Seq[T], action func(T, int)) {
 	ForEach(slices.Collect(seq), action)
 }
 
+// maxWorkers caches runtime.GOMAXPROCS(0), which takes the scheduler lock on
+// every call and shows up as contention when ForEach is called frequently.
+// GOMAXPROCS changes at runtime are rare enough to ignore here.
+var maxWorkers = runtime.GOMAXPROCS(0)
+
 // ForEach calls action once for each element in the given slice,
-// distributing the calls across at most [runtime.GOMAXPROCS](0) goroutines
-// instead of one goroutine per element.
+// distributing the calls across the available CPU cores, while trying to
+// limit the number of goroutines to a minimum to reduce scheduling overhead.
 //
-// The second argument to action is the zero-based index of the element.
-// This function blocks until every action call has returned.
+// The first argument to action is the element, and the second argument is the
+// zero-based index of the element. This function blocks until every action
+// call has returned.
 func ForEach[T any](elements []T, action func(T, int)) {
+	ForEachWithSetup(elements, func() struct{} { return struct{}{} }, func(_ struct{}, element T, i int) {
+		action(element, i)
+	})
+}
+
+// ForEachWithSetup behaves like [ForEach], but additionally calls setup once
+// per worker goroutine and passes its result to every action call performed by
+// that worker. Use it to give each worker goroutine-local state.
+func ForEachWithSetup[T, S any](elements []T, setup func() S, action func(S, T, int)) {
 	total := len(elements)
 	if total == 0 {
 		return
 	}
-	workers := min(runtime.GOMAXPROCS(0), total)
+	workers := min(maxWorkers, total)
 	var next atomic.Int64
 	// Store -1 so that the first Add(1) returns 0, the index of the first element.
 	next.Store(-1)
 	var wg sync.WaitGroup
 	for range workers {
 		wg.Go(func() {
+			state := setup()
 			for {
 				i := int(next.Add(1))
 				if i >= total {
 					return
 				}
-				action(elements[i], i)
+				action(state, elements[i], i)
 			}
 		})
 	}


### PR DESCRIPTION
The linking phase is usually the most performance intensive phase. This is an attempt to improve its performance by reducing the amount of allocations performed during the linking.

The main improvement is concerned with the new `SymbolSliceContainer`. Adopters (or the generated `<Language>SymbolContainer`) can implement this to generate allocation free scopes.

Another major improvement is the reduction of per-reference allocations. Mainly the new context that we generate for linking. It's now a single context with a special `resolutionChain` attached to it that keeps track of cycles. Adds a `ForEachWithSetup` for this, which keeps one setup function per worker.

Then there are a few other improvements:
1. Reduce the amount of allocations in the parser by storing the closures for reference resolving functions
2. Store the `name` of a symbol on the symbol description directly. This reduces the need for interface dispatches (expensive).
3. Reduce the amount of closures required for traversing the AST.
4. Caches the available number of CPU cores. Calling `GOMAXPROCS` on every `ForEach` call had to acquire a lock first internally.

All of these changes together roughly **double** the performance of the workspace build.