### PR TITLE
Update to go-lsp v0.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/exp/jsonrpc2 v0.0.0-20260312153236-7ab1446f8b90
-	typefox.dev/lsp v0.0.4
+	typefox.dev/lsp v0.1.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -26,5 +26,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-typefox.dev/lsp v0.0.4 h1:QCnsa4Y8E2kPBhDlVuqJba82gXACgOGjTLEXb7mFISI=
-typefox.dev/lsp v0.0.4/go.mod h1:MQ6ZIFd9xDC+jrSzj5XYTfAvFrAM5l/3BossgTTpwPg=
+typefox.dev/lsp v0.1.0 h1:gQHtK2LKpYw2ohL8jUZhJ0lc3Gx4OLTFA7poT95j6FA=
+typefox.dev/lsp v0.1.0/go.mod h1:MQ6ZIFd9xDC+jrSzj5XYTfAvFrAM5l/3BossgTTpwPg=

--- a/internal/languages/completion/completion_engine_test.go
+++ b/internal/languages/completion/completion_engine_test.go
@@ -292,7 +292,7 @@ e foo.<|cursor>`)
 		return
 	}
 	edit := item.TextEdit
-	textEdit := edit.Value.(lsp.TextEdit)
+	textEdit := *edit.TextEdit
 	// The edit should replace the full "foo." segment
 	if textEdit.NewText != "foo.bar" {
 		t.Errorf("expected replacement text 'foo.bar'; got %q", textEdit.NewText)
@@ -648,7 +648,8 @@ func TestCompletion_ContributorTokenDocs(t *testing.T) {
 			}
 			item := lsp.CompletionItem{}
 			if tt.Name == "declare" {
-				item.Documentation = &lsp.Or_CompletionItem_documentation{Value: "Declares a named symbol."}
+				docs := "Declares a named symbol."
+				item.Documentation = &lsp.CompletionItemDocumentation{String: &docs}
 			}
 			accept(item)
 		},

--- a/server/completion_provider.go
+++ b/server/completion_provider.go
@@ -683,8 +683,8 @@ func fillInsertion(item *lsp.CompletionItem, replace *lsp.Range) {
 // every client that supports completion.
 func applyInsertion(item *lsp.CompletionItem, text string, replace *lsp.Range, insertFormat *lsp.InsertTextFormat) {
 	if replace != nil {
-		item.TextEdit = &lsp.Or_CompletionItem_textEdit{
-			Value: lsp.TextEdit{Range: *replace, NewText: text},
+		item.TextEdit = &lsp.CompletionItemTextEdit{
+			TextEdit: &lsp.TextEdit{Range: *replace, NewText: text},
 		}
 		// InsertText is ignored by the client when TextEdit is present,
 		// but we set it anyway for clients that fall back to it.

--- a/server/diagnostics_publisher.go
+++ b/server/diagnostics_publisher.go
@@ -83,13 +83,13 @@ func toLspDiagnostic(textDoc textdoc.Handle, d core.Diagnostic) lsp.Diagnostic {
 	result := lsp.Diagnostic{
 		Range:    d.Range.LspRange(textDoc),
 		Severity: lsp.DiagnosticSeverity(d.Severity),
-		Message:  d.Message,
+		Message:  lsp.DiagnosticMessage{String: &d.Message},
 	}
 	if d.Source != "" {
 		result.Source = d.Source
 	}
 	if d.Code != "" {
-		result.Code = d.Code
+		result.Code = lsp.DiagnosticCode{String: &d.Code}
 	}
 	if d.CodeDescription != nil {
 		result.CodeDescription = &lsp.CodeDescription{

--- a/server/server.go
+++ b/server/server.go
@@ -24,6 +24,15 @@ type InitializeParticipant interface {
 	OnServerInitialize(params *lsp.ParamInitialize)
 }
 
+// optionsIf returns a fresh *O if a service of type S is registered, nil otherwise.
+// Used to advertise a server capability only when a provider service exists.
+func optionsIf[S, O any](sc *service.Container) *O {
+	if service.Has[S](sc) {
+		return new(O)
+	}
+	return nil
+}
+
 // DefaultLanguageServer implements the [lsp.Server] interface
 type DefaultLanguageServer struct {
 	sc *service.Container
@@ -48,37 +57,33 @@ func (s *DefaultLanguageServer) Initialize(ctx context.Context, params *lsp.Para
 	if triggers, err := service.Get[CompletionTriggers](s.sc); err == nil && triggers != nil {
 		triggerChars = triggers.TriggerCharacters()
 	}
+	var renameProvider *lsp.RenameOptions
+	if service.Has[RenameProvider](s.sc) {
+		renameProvider = &lsp.RenameOptions{PrepareProvider: true}
+	}
 	positionEncoding := lsp.UTF16
 	return &lsp.InitializeResult{
 		Capabilities: lsp.ServerCapabilities{
 			PositionEncoding: &positionEncoding,
-			TextDocumentSync: lsp.Incremental,
+			TextDocumentSync: &lsp.TextDocumentSyncOptions{
+				OpenClose:         true,
+				WillSave:          true,
+				WillSaveWaitUntil: true,
+				Save:              &lsp.SaveOptions{IncludeText: true},
+				Change:            lsp.Incremental,
+			},
 			CompletionProvider: &lsp.CompletionOptions{
 				ResolveProvider:   false,
 				TriggerCharacters: triggerChars,
 			},
-			DefinitionProvider: &lsp.Or_ServerCapabilities_definitionProvider{
-				Value: service.Has[DefinitionProvider](s.sc),
-			},
-			DocumentSymbolProvider: &lsp.Or_ServerCapabilities_documentSymbolProvider{
-				Value: service.Has[DocumentSymbolProvider](s.sc),
-			},
-			FoldingRangeProvider: &lsp.Or_ServerCapabilities_foldingRangeProvider{
-				Value: service.Has[FoldingRangeProvider](s.sc),
-			},
-			DocumentHighlightProvider: &lsp.Or_ServerCapabilities_documentHighlightProvider{
-				Value: service.Has[DocumentHighlightProvider](s.sc),
-			},
-			WorkspaceSymbolProvider: &lsp.Or_ServerCapabilities_workspaceSymbolProvider{
-				Value: service.Has[WorkspaceSymbolProvider](s.sc),
-			},
-			HoverProvider: &lsp.Or_ServerCapabilities_hoverProvider{
-				Value: service.Has[HoverProvider](s.sc),
-			},
-			ReferencesProvider: &lsp.Or_ServerCapabilities_referencesProvider{
-				Value: service.Has[ReferencesProvider](s.sc),
-			},
-			RenameProvider: service.Has[RenameProvider](s.sc),
+			DefinitionProvider:        optionsIf[DefinitionProvider, lsp.DefinitionOptions](s.sc),
+			DocumentSymbolProvider:    optionsIf[DocumentSymbolProvider, lsp.DocumentSymbolOptions](s.sc),
+			FoldingRangeProvider:      optionsIf[FoldingRangeProvider, lsp.FoldingRangeRegistrationOptions](s.sc),
+			DocumentHighlightProvider: optionsIf[DocumentHighlightProvider, lsp.DocumentHighlightOptions](s.sc),
+			WorkspaceSymbolProvider:   optionsIf[WorkspaceSymbolProvider, lsp.WorkspaceSymbolOptions](s.sc),
+			HoverProvider:             optionsIf[HoverProvider, lsp.HoverOptions](s.sc),
+			ReferencesProvider:        optionsIf[ReferencesProvider, lsp.ReferenceOptions](s.sc),
+			RenameProvider:            renameProvider,
 		},
 	}, nil
 }
@@ -347,7 +352,7 @@ func (s *DefaultLanguageServer) Implementation(ctx context.Context, params *lsp.
 func (s *DefaultLanguageServer) InlayHint(ctx context.Context, params *lsp.InlayHintParams) ([]lsp.InlayHint, error) {
 	return nil, nil
 }
-func (s *DefaultLanguageServer) InlineCompletion(ctx context.Context, params *lsp.InlineCompletionParams) (*lsp.Or_Result_textDocument_inlineCompletion, error) {
+func (s *DefaultLanguageServer) InlineCompletion(ctx context.Context, params *lsp.InlineCompletionParams) (*lsp.ResultTextDocumentInlineCompletion, error) {
 	return nil, nil
 }
 func (s *DefaultLanguageServer) InlineValue(ctx context.Context, params *lsp.InlineValueParams) ([]lsp.InlineValue, error) {

--- a/server/workspace_symbol_provider.go
+++ b/server/workspace_symbol_provider.go
@@ -117,8 +117,10 @@ func (p *DefaultWorkspaceSymbolProvider) collectSymbolsFromDocument(doc *core.Do
 		textRange := nameUnit.TextRange()
 
 		symbol := lsp.SymbolInformation{
-			Name: name,
-			Kind: SymbolKind(node),
+			BaseSymbolInformation: lsp.BaseSymbolInformation{
+				Name: name,
+				Kind: SymbolKind(node),
+			},
 			Location: lsp.Location{
 				URI:   lsp.DocumentURI(doc.URI.DocumentURI()),
 				Range: textRange.LspRange(doc.TextDoc),


### PR DESCRIPTION
As the title says. This adds support for the latest LSP 3.18 protocol in Fastbelt and updates our code to reflect the API changes in the library.